### PR TITLE
Styles inline api explorer

### DIFF
--- a/apps/pages/admin.py
+++ b/apps/pages/admin.py
@@ -16,6 +16,7 @@ class DonationPageAdminAbstract(admin.ModelAdmin):
         ),
         ("Header", {"fields": ("header_bg_image", "header_logo", "header_link")}),
         ("Title", {"fields": ("title",)}),
+        (None, {"fields": ("styles",)}),
         (None, {"fields": ("elements",)}),
         (
             "Benefits",

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_celery_beat",
+    "rest_framework",
 ]
 
 


### PR DESCRIPTION
Fixes two issues discovered in demo today:
1. "styles" inline missing from DonationPage and Template admins
2. API explorer not hooked up.