### PR TITLE
[NRH-52] Applies security patches

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -278,7 +278,7 @@ python-versions = "*"
 
 [[package]]
 name = "django"
-version = "3.2"
+version = "3.2.2"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
@@ -1222,7 +1222,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "1e8ba98d7c987e62e2781bf9c57601250f4db4fe013e475fcea0185103de83be"
+content-hash = "07d3a159d954ae9b9aafb6d767a0178220cc62a3c66de9be24d863cdbb75cc6a"
 
 [metadata.files]
 amqp = [
@@ -1367,8 +1367,8 @@ dj-database-url = [
     {file = "dj_database_url-0.5.0-py2.py3-none-any.whl", hash = "sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"},
 ]
 django = [
-    {file = "Django-3.2-py3-none-any.whl", hash = "sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927"},
-    {file = "Django-3.2.tar.gz", hash = "sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d"},
+    {file = "Django-3.2.2-py3-none-any.whl", hash = "sha256:18dd3145ddbd04bf189ff79b9954d08fda5171ea7b57bf705789fea766a07d50"},
+    {file = "Django-3.2.2.tar.gz", hash = "sha256:0a1d195ad65c52bf275b8277b3d49680bd1137a5f55039a806f25f6b9752ce3d"},
 ]
 django-appconf = [
     {file = "django-appconf-1.0.4.tar.gz", hash = "sha256:be58deb54a43d77d2e1621fe59f787681376d3cd0b8bd8e4758ef6c3a6453380"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ djangorestframework = "^3.12.4"
 djangorestframework-simplejwt = "^4.6.0"
 Pillow = "^8.2.0"
 stripe = "^2.56.0"
+Django = "3.2.2"
 
 [tool.poetry.dev-dependencies]
 appnope = "0.1.2"


### PR DESCRIPTION
3.2.1: https://www.djangoproject.com/weblog/2021/may/04/security-releases/
3.2.2: https://www.djangoproject.com/weblog/2021/may/06/security-releases/

Tests pass and smoke test of site functions as expected.