### PR TITLE
[NRH-54] Email configured to use vanilla SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ The react app will be available at `https://localhost:8001/`, and the django adm
 The Django admin is at `/admin/`.
 
 
+**11. Test Email Setup**
+To test production email settings `export TEST_EMAIL=True`, otherwise emails will use the console backend.
+
 **11. Run tests**
 
 revengine uses pytest as a test runner.

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -243,8 +243,6 @@ PHONENUMBER_DB_FORMAT = "NATIONAL"
 PHONENUMBER_DEFAULT_FORMAT = "NATIONAL"
 PHONENUMBER_DEFAULT_REGION = "US"
 
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "no-reply@rev-engine.caktus-built.com")
-
 # Stripe configs
 STRIPE_LIVE_SECRET_KEY = os.getenv("LIVE_HUB_STRIPE_API_SECRET_KEY", "")
 STRIPE_TEST_SECRET_KEY = os.getenv("TEST_HUB_STRIPE_API_SECRET_KEY", "")
@@ -264,3 +262,17 @@ STRIPE_WEBHOOK_EVENTS = [
 ]
 
 SITE_URL = os.getenv("SITE_URL", "")
+
+# Transactional Email
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp.mailgun.org"
+EMAIL_PORT = 587
+EMAIL_HOST_USER = "postmaster@fundjournalism.org"
+EMAIL_HOST_PASSWORD = os.getenv("MAILGUN_SMTP_PASSWORD", "")
+EMAIL_USE_TLS = True
+
+ADMINS = [("nrh-team", "nrh-team@caktusgroup.com")]
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "no-reply@rev-engine.caktus-built.com")
+
+SEVER_EMAIL = os.getenv("SERVER_EMAIL", "nrh-errors@rev-engine.caktus-built.com")

--- a/revengine/settings/dev.py
+++ b/revengine/settings/dev.py
@@ -31,3 +31,6 @@ if os.getenv("DEBUG_TOOLBAR", "True") == "True":
         "debug_toolbar",
     ]
     MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
+
+if not os.getenv("TEST_EMAIL", "False") == "True":
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/revengine/settings/dev.py
+++ b/revengine/settings/dev.py
@@ -31,5 +31,3 @@ if os.getenv("DEBUG_TOOLBAR", "True") == "True":
         "debug_toolbar",
     ]
     MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
-
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"


### PR DESCRIPTION
Configured with plain SMTP authentication. Details are in LP.

To test locally: Get PW from LP and add to your environment run `./manage.py sendtestemail nrh-team@caktusgroup.com`