### PR TITLE
[NRH-70] Stripe Customers **WIP

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 
+import stripe
+
 from apps.common.models import IndexedTimeStampedModel
+from apps.contributions.utils import get_hub_stripe_api_key
 
 
 class Contributor(IndexedTimeStampedModel):
@@ -17,6 +20,31 @@ class Contributor(IndexedTimeStampedModel):
     def __str__(self):
         return self.email
 
+    def get_stripe_customer_for_organization(self, organization):
+        """
+        Stripe Customers are not unique by email. Thus, finding a single Customer instance by email address is not supported. The best we can do here is list all the customers that have that email address.
+        In this case, we ought to treat "has any customers matching this email address" as "has stripe customer". For
+
+        A single Stripe Customer may have unqiue information attached that we need. In particular, a Customer is created with a default payment method.  This payment method is used to capture each payment of a recurring donation.
+        That is why it's important to store the actually unique Customer pk on the Contribution itself, as provider_customer_id.
+        """
+        stripe_customers = stripe.Customer.list(
+            email=self.email, api_key=get_hub_stripe_api_key(), stripe_account=organization.stripe_account_id
+        )
+        # ??
+        return list(stripe_customers)[0]
+
+    def get_or_create_stripe_customer_for_organization(self, organization):
+        """
+        Create a Stripe Customer for this organization, if they have no customers matching self.email. O
+        """
+        stripe_customer = self.get_stripe_customer_for_organization(organization)
+        if not stripe_customer:
+            stripe_customer = stripe.Customer.create(
+                email=self.email, api_key=get_hub_stripe_api_key(), stripe_account=organization.stripe_account_id
+            )
+        return stripe_customer
+
 
 class Contribution(IndexedTimeStampedModel):
     amount = models.IntegerField(help_text="Stored in cents")
@@ -26,6 +54,8 @@ class Contribution(IndexedTimeStampedModel):
     payment_provider_used = models.CharField(max_length=64)
     payment_provider_data = models.JSONField(null=True)
     provider_reference_id = models.CharField(max_length=255)
+
+    provider_customer_id = models.CharField(max_length=255, blank=True)
 
     contributor = models.ForeignKey("contributions.Contributor", on_delete=models.SET_NULL, null=True)
     donation_page = models.ForeignKey("pages.DonationPage", on_delete=models.SET_NULL, null=True)

--- a/apps/contributions/urls.py
+++ b/apps/contributions/urls.py
@@ -6,6 +6,7 @@ from apps.contributions import views
 
 urlpatterns = [
     path("stripe/one-time-donation/", views.stripe_one_time_payment, name="stripe-one-time-payment"),
+    path("stripe/recurring-donation/", views.stripe_recurring_payment, name="stripe-recurring-payment"),
     path("stripe/onboarding/", views.stripe_onboarding, name="stripe-onboarding"),
     path("stripe/confirmation/", views.stripe_confirmation, name="stripe-confirmation"),
     re_path(


### PR DESCRIPTION
WIP

Each Organization will want to have a list of its own Customers.  The big challenge here is that RevEngine only wants one contributor per unique email, whereas Stripe has a Customer per organization.  It would be easy enough if the Customer was essentially metadata, but in fact the Customer stores a default payment method that is required to capture each payment on a recurring donation. 

