### PR TITLE
hotfix: use window.location instead of history.push on password reset in SPA

### DIFF
--- a/spa/src/components/authentication/Login.js
+++ b/spa/src/components/authentication/Login.js
@@ -38,7 +38,7 @@ function Login() {
 
   const handleForgotPassword = (e) => {
     e.preventDefault();
-    history.push(PASSWORD_RESET_URL);
+    window.location = PASSWORD_RESET_URL;
   };
 
   const handleLogin = async (e) => {


### PR DESCRIPTION
Fixes a bug with forgot password flow that stemmed from routing the URL through the SPA, rather than to the backend.