### PR TITLE
[NRH-120] Page-edit validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,3 +76,4 @@ jobs:
           working-directory: spa
           build: npx cypress info
           start: npm run start
+          wait-on: http://localhost:3000

--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -11442,6 +11442,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",

--- a/spa/package.json
+++ b/spa/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-cypress": "^2.11.3",
     "find-webpack": "^2.2.1",
     "framer-motion": "^4.1.8",
+    "lodash.isempty": "^4.4.0",
     "lodash.merge": "^4.6.2",
     "msw": "^0.28.2",
     "prettier": "^2.2.1",

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -1,6 +1,5 @@
 import { useState, useEffect, createContext, useContext, useCallback } from 'react';
 import * as S from './PageEditor.styled';
-import * as A from 'elements/alert/Alert.styled';
 import { useTheme } from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
 
@@ -163,11 +162,11 @@ function MissingElementErrors({ missing = [] }) {
   return (
     <>
       The following elements are required for your page to function properly:
-      <A.ErrorsList data-testid="missing-elements-alert">
+      <ul data-testid="missing-elements-alert">
         {missing.map((missingEl) => (
           <li key={missingEl}>{dynamicElements[missingEl].displayName}</li>
         ))}
-      </A.ErrorsList>
+      </ul>
     </>
   );
 }

--- a/spa/src/components/pageEditor/editInterface/ElementProperties.js
+++ b/spa/src/components/pageEditor/editInterface/ElementProperties.js
@@ -49,8 +49,18 @@ function ElementProperties() {
       </S.ElementHeading>
       <S.ElementEditor>{getElementEditor(selectedElement.type)}</S.ElementEditor>
       <S.Buttons>
-        <CircleButton icon={faCheck} type="positive" onClick={handleKeepChanges} />
-        <CircleButton icon={faTimes} type="caution" onClick={handleDiscardChanges} />
+        <CircleButton
+          icon={faCheck}
+          type="positive"
+          onClick={handleKeepChanges}
+          data-testid="save-element-changes-button"
+        />
+        <CircleButton
+          icon={faTimes}
+          type="caution"
+          onClick={handleDiscardChanges}
+          data-testid="discard-element-changes-button"
+        />
       </S.Buttons>
     </S.ElementProperties>
   );

--- a/spa/src/components/pageEditor/validatePage.js
+++ b/spa/src/components/pageEditor/validatePage.js
@@ -1,0 +1,24 @@
+import isEmpty from 'lodash.isempty';
+import * as dynamicElements from 'components/donationPage/pageContent/dynamicElements';
+
+function validatePage(page) {
+  const errors = {
+    ...validateRequiredElements(page.elements)
+  };
+  return !isEmpty(errors) && errors;
+}
+
+function validateRequiredElements(elements = []) {
+  const requiredElements = Object.keys(dynamicElements).filter((key) => dynamicElements[key].required);
+  const errors = {};
+  for (let i = 0; i < requiredElements.length; i++) {
+    const requiredElement = requiredElements[i];
+    if (!elements.find((el) => el.type === requiredElement)) {
+      errors.missing = errors.missing || [];
+      errors.missing.push(requiredElement);
+    }
+  }
+  return errors;
+}
+
+export default validatePage;

--- a/spa/src/elements/alert/Alert.js
+++ b/spa/src/elements/alert/Alert.js
@@ -3,7 +3,7 @@ import { transitions, positions } from 'react-alert';
 
 function Alert({ style, options, message, close }) {
   return (
-    <S.Alert style={style} type={options.type}>
+    <S.Alert style={style} type={options.type} data-testid="alert">
       {message}
       <S.Close onClick={close}>x</S.Close>
     </S.Alert>
@@ -18,5 +18,8 @@ export const alertOptions = {
   timeout: 5000,
   offset: '15px',
   // you can also just use 'scale'
-  transition: transitions.SCALE
+  transition: transitions.SCALE,
+  containerStyle: {
+    zIndex: 1020
+  }
 };

--- a/spa/src/elements/alert/Alert.styled.js
+++ b/spa/src/elements/alert/Alert.styled.js
@@ -39,8 +39,3 @@ export const Close = styled.button`
   right: 0;
   top: 0;
 `;
-
-export const ErrorsList = styled.ul`
-  li {
-  }
-`;

--- a/spa/src/elements/alert/Alert.styled.js
+++ b/spa/src/elements/alert/Alert.styled.js
@@ -22,7 +22,7 @@ export const Alert = styled.div`
     }
     if (props.type === 'error') {
       return css`
-        background: ${props.theme.colors.warning};
+        background: ${props.theme.colors.caution};
       `;
     }
   }}
@@ -38,4 +38,9 @@ export const Close = styled.button`
   position: absolute;
   right: 0;
   top: 0;
+`;
+
+export const ErrorsList = styled.ul`
+  li {
+  }
 `;


### PR DESCRIPTION
Enables page validation and enables required-element validation. Any validation beyond that is possible, but it's not clear at the moment what that would need to be.

It's worth noting that I vacillated a bit on whether or not to handle the validation on the backend with a PageElementsSerializer. I think there's lots of value in that (eg I particularly don't like front-end validation), but if we do that, fully controlled page elements start to recommend themselves. Rather than Page.elements being a flexible JSON field, Page.elements would be a one-to-many to an Element model. That's fine and all, but it's probably a bit more control than we need/want for this version. 

The way we have it now, adding more features to the donation page only requires front-end changes, and that's a big plus.