### PR TITLE
[NRH-132] Missing initial frequency bug

### DIFF
--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -1,12 +1,13 @@
 import { useRef, useState, createContext, useContext } from 'react';
 import * as S from './DonationPage.styled';
 import * as getters from 'components/donationPage/pageGetters';
+import { frequencySort } from 'components/donationPage/pageContent/DFrequency';
 
 const DonationPageContext = createContext({});
 
 function DonationPage({ page, live = false }) {
   const formRef = useRef();
-  const [frequency, setFrequency] = useState('one_time');
+  const [frequency, setFrequency] = useState(getInitialFrequency(page));
   const [fee, setFee] = useState();
   const [payFee, setPayFee] = useState(false);
   const [amount, setAmount] = useState();
@@ -55,3 +56,12 @@ function DonationPage({ page, live = false }) {
 export const usePage = () => useContext(DonationPageContext);
 
 export default DonationPage;
+
+function getInitialFrequency(page) {
+  const frequencyElement = page?.elements?.find((el) => el.type === 'DFrequency');
+  if (frequencyElement) {
+    const sortedOptions = frequencyElement.content.sort(frequencySort);
+    return sortedOptions[0].value;
+  }
+  return 'one_time';
+}

--- a/spa/src/components/donationPage/pageContent/DFrequency.js
+++ b/spa/src/components/donationPage/pageContent/DFrequency.js
@@ -48,7 +48,7 @@ DFrequency.unique = true;
 
 export default DFrequency;
 
-function frequencySort(a, b) {
+export function frequencySort(a, b) {
   const sortOrder = ['one_time', 'month', 'year'];
   const aVal = a.value;
   const bVal = b.value;

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -171,6 +171,7 @@ function PageEditor() {
       if (Object.hasOwnProperty.call(patchedPage, datumKey)) {
         let datum = patchedPage[datumKey];
         if (datum instanceof Date) datum = formatDatetimeForAPI(datum);
+        if (datumKey === 'elements') datum = JSON.stringify(datum);
         if (datumKey === 'donor_benefits') {
           datumKey = 'donor_benefits_pk';
         }


### PR DESCRIPTION
If "one_time" was not an available frequency, not initial frequency was set, allowing a case where somebody could submit a donation withoiut selecting a frequency. There should always be a frequency selected.

Also fixed a missing JSON.stringify in elements data parsing.