### PR TITLE
refs #NRH-148 Sends magic_link through Mailgun

### DIFF
--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -304,6 +304,11 @@ EMAIL_SUBJECT_PREFIX = "[RevEngine] "
 
 ADMINS = [("nrh-team", "nrh-team@caktusgroup.com")]
 
+# Revengine template identifiers
+EMAIL_TEMPLATE_IDENTIFIER_MAGIC_LINK_DONOR = os.environ.get(
+    "EMAIL_TEMPLATE_IDENTIFIER_MAGIC_LINK_DONOR", "nrh-manage-donations-magic-link"
+)
+
 # this is only used by HubAdmins, not OrgAdmins, but needs to be named generically as LOGIN_URL
 # so our implementation of password reset flow for HubAdmins works as expected
 LOGIN_URL = "/admin/"


### PR DESCRIPTION
Modifies the magic_link view to send using the mailgun API.

Updates tests

To test locally:

- If you care to click the link when you get the email you will need to have your settings.SITE_URL set to "http://localhost:8001" or your ngrok host if that is what you are using.
- In a terminal run `inv dc.run-celery`
- In another terminal run `make run-dev`

Then you should be able to hit the `contributor/` endpoint and send an email with the magic_link.