### PR TITLE
[NRH]--bugfix--DAmount Badindex

### DIFF
--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -7,6 +7,10 @@ from apps.contributions.models import Contributor
 from apps.users.serializers import UserSerializer
 
 
+# Configure global error messaging here
+serializers.CharField.default_error_messages["blank"] = "This information is required"
+
+
 class NoSuchContributorError(AuthenticationFailed):
     pass
 

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -8,7 +8,8 @@ from apps.users.serializers import UserSerializer
 
 
 # Configure global error messaging here
-serializers.CharField.default_error_messages["blank"] = "This information is required"
+ERROR_MESSAGE_BLANK = "This information is required"
+serializers.CharField.default_error_messages["blank"] = ERROR_MESSAGE_BLANK
 
 
 class NoSuchContributorError(AuthenticationFailed):

--- a/apps/api/tests/test_views.py
+++ b/apps/api/tests/test_views.py
@@ -11,6 +11,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import AccessToken
 
+from apps.api.serializers import ERROR_MESSAGE_BLANK
 from apps.api.tokens import ContributorRefreshToken
 from apps.api.views import TokenObtainPairCookieView
 from apps.contributions.models import Contributor
@@ -83,7 +84,7 @@ class RequestContributorTokenEmailViewTest(APITestCase):
     def test_validation_when_email_is_blank(self):
         response = self.client.post(self.url, {"email": ""})
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(str(response.data["email"][0]), "This field may not be blank.")
+        self.assertEqual(str(response.data["email"][0]), ERROR_MESSAGE_BLANK)
 
     def test_token_appears_in_outbound_email(self):
         target_email = self.contributor.email

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -38,7 +38,12 @@ function DAmount({ element, ...props }) {
     if (selectedAmount === 'other') {
       amount = parseInt(otherAmount || 0);
     } else {
-      amount = element?.content?.options && element.content?.options[frequency][selectedAmount];
+      // It's possible options[frequency][selectedAmount] is undefined, in the case that somebody either
+      // has stale development data, or somebody has messed around with page.elements JSONField.
+      amount =
+        element?.content?.options &&
+        element.content?.options[frequency] &&
+        element.content?.options[frequency][selectedAmount];
     }
     const fee = calculateStripeFee(amount);
     setAmount(amount);

--- a/spa/src/components/donationPage/pageContent/DPayment.js
+++ b/spa/src/components/donationPage/pageContent/DPayment.js
@@ -17,7 +17,11 @@ function DPayment({ element, live, ...props }) {
   */
   return (
     <DElement>
-      {live ? <S.DPayment>{element.content['stripe'] && <StripePayment />}</S.DPayment> : <NotLivePlaceholder />}
+      {live ? (
+        <S.DPayment>{element?.content && element.content['stripe'] && <StripePayment />}</S.DPayment>
+      ) : (
+        <NotLivePlaceholder />
+      )}
     </DElement>
   );
 }

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PublishWidget.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PublishWidget.js
@@ -30,8 +30,6 @@ function PublishWidget({ publishDate, onChange }) {
     onChange(new Date());
   };
 
-  console.log('publishDate', publishDate);
-
   return (
     <S.PublishWidget data-testid="publish-widget">
       <Label>Publication date</Label>

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -208,7 +208,7 @@ function StripePaymentForm({ loading, setLoading }) {
       >
         Give ${getTotalAmount(amount, fee, payFee)} {getFrequencyAdverb(frequency)}
       </Button>
-      {errors.stripe && (
+      {errors?.stripe && (
         <S.PaymentError role="alert" data-testid="donation-error">
           {errors.stripe}
         </S.PaymentError>


### PR DESCRIPTION
#### What's this PR do?
Fixes hopefully two bugs:

1. A bug where, somehow, a page has gotten in to a state where a given `frequency` in `element.content?.options[frequency]` is not actually in the `options` object. This should only be possible with pretty funky stale data, and we've only seen this particular issue locally. 
2. An error in page edit mode, with sparse reporting, indicating that `<something>.stripe` is undefined. Since that pattern only occurs in a few places, we've just judiciously defaulted those chained references to null. 

We also, incidentally, update the "this field may not be blank" front facing error message to something a little less django-y

#### How should this be manually tested?
For each above:
1. It's unknown how to reproduce this bug. It hasn't occurred on staging, and locally it's only occurred once as far as we know. But you should be able to add a frequency widget and an amount widget in any order, with any degree of data present or missing, and it shouldn't crash.
2. This has only be seen on staging once, when a new page loads. Create a new page-- once in edit mode, it shouldn't crash.

For the error message, try to submit a donation without providing first name last name.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
Nope
