### PR TITLE
[NRH-195] bugfix OtherAmount toggle not saving

### DIFF
--- a/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.js
@@ -52,10 +52,7 @@ function AmountEditor() {
     });
   };
 
-  const toggleAllowOther = (e) => {
-    const allowOther = e.target.checked;
-    setElementContent({ ...elementContent, allowOther });
-  };
+  const toggleAllowOther = (_, { checked }) => setElementContent({ ...elementContent, allowOther: checked });
 
   const handleKeyUp = (e, freq) => {
     if (e.key === 'Enter') {


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug where, in the AmountEditor widget, toggling "Include 'other' option" would not save to the page.

#### How should this be manually tested?
Go in to a page editor, edit an Amount widget, toggle on or off "Include 'other' option", ensure that it is saved to the page.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
Nope
