### PR TITLE
NRH-209 bugfix OneTime payments allow paymentmethod updates

### DIFF
--- a/spa/src/components/contributor/contributorDashboard/ContributorDashboard.js
+++ b/spa/src/components/contributor/contributorDashboard/ContributorDashboard.js
@@ -215,10 +215,14 @@ function getStatusCellIcon(status) {
 export function PaymentMethodCell({ contribution, handlePaymentClick }) {
   if (!contribution.card_brand && !contribution.last4) return '?';
 
+  const getCanInteract = () => {
+    return !!handlePaymentClick && contribution.interval !== 'one_time';
+  };
+
   return (
     <S.PaymentMethodCell
-      interactive={!!handlePaymentClick}
-      onClick={() => (!!handlePaymentClick ? handlePaymentClick(contribution) : {})}
+      interactive={getCanInteract()}
+      onClick={() => (getCanInteract() ? handlePaymentClick(contribution) : {})}
       data-testid="payment-method"
     >
       {contribution.card_brand && (


### PR DESCRIPTION
#### What's this PR do?
We failed to disabled Payment method updates in the contributor/contributions table.  This disables that.

#### How should this be manually tested?
"Login" as a contributor. View your donations. Find a one-time donation and verify that clicking on the credit card info does nothing, unlike clicking on the card info for a recurring donation.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
