### PR TITLE
NRH: Fix flaky cypress tests

### DIFF
--- a/spa/cypress/integration/donations.spec.js
+++ b/spa/cypress/integration/donations.spec.js
@@ -86,7 +86,9 @@ describe('Donations list', () => {
     });
     it('should display the second page of donations when click on next page', () => {
       cy.wait('@getDonations');
-      cy.getByTestId('next-page').click();
+      // force: true needs to be here to prevent intermittent test failure
+      // that seems to stem from this element not yet being visible on page
+      cy.getByTestId('next-page').click({ force: true });
       cy.wait('@getDonations').then((intercept) => {
         cy.getByTestId('donations-table')
           .find('tbody tr[data-testid="donation-row"]')
@@ -246,14 +248,16 @@ describe('Donations list', () => {
       cy.getByTestId('previous-page').should('be.disabled');
       cy.getByTestId('next-page').should('not.be.disabled');
 
-      cy.getByTestId('next-page').click();
+      // force: true needs to be here to prevent intermittent test failure
+      // that seems to stem from this element not yet being visible on page
+      cy.getByTestId('next-page').click({ force: true });
       cy.getByTestId('previous-page').should('not.be.disabled');
       cy.getByTestId('next-page').should('be.disabled');
     });
   });
 
   describe('Filtering', () => {
-    before(() => {
+    beforeEach(() => {
       cy.login('user/stripe-verified.json');
       cy.interceptPaginatedDonations();
       cy.visit('/dashboard/donations/');
@@ -261,15 +265,18 @@ describe('Donations list', () => {
 
     it('should render expected filters', () => {
       const expectedFilterTestIds = ['status-filter', 'amount-filter', 'created-filter'];
+      cy.wait('@getDonations');
       expectedFilterTestIds.forEach((testId) => cy.getByTestId(testId).should('exist'));
     });
 
     it('should display total results', () => {
+      cy.wait('@getDonations');
       cy.getByTestId('filter-results-count').should('exist');
     });
 
     it('should update results to expected amount when filtering status', () => {
-      cy.interceptPaginatedDonations();
+      // cy.interceptPaginatedDonations();
+      cy.wait('@getDonations');
       const expectedPaids = donationsData.filter((d) => d.status === 'paid');
       cy.getByTestId('status-filter-paid').click();
       cy.getByTestId('filter-results-count').contains(expectedPaids.length);

--- a/spa/cypress/integration/donations.spec.js
+++ b/spa/cypress/integration/donations.spec.js
@@ -275,7 +275,6 @@ describe('Donations list', () => {
     });
 
     it('should update results to expected amount when filtering status', () => {
-      // cy.interceptPaginatedDonations();
       cy.wait('@getDonations');
       const expectedPaids = donationsData.filter((d) => d.status === 'paid');
       cy.getByTestId('status-filter-paid').click();


### PR DESCRIPTION
#### What's this PR do?

Updates `donation.spec.js` to fix some flaky Cypress tests that passed sometimes and failed others, seemingly from a race condition between UI completely rendering and Cypress running test commands.

#### How should this be manually tested?

Should no longer see Cypress tests for `donation-spec.js` "randomly" failing in CI.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?

No.