### PR TITLE
try selecting recurring donation to get test to pass

### DIFF
--- a/spa/cypress/integration/contributor.spec.js
+++ b/spa/cypress/integration/contributor.spec.js
@@ -117,7 +117,7 @@ describe('Contributor portal', () => {
       });
     });
 
-    it.only('should show update payment method modal when payment method clicked for recurring contribution', () => {
+    it('should show update payment method modal when payment method clicked for recurring contribution', () => {
       cy.get('td[data-testcolumnaccessor="interval"]')
         .contains('Monthly')
         .closest('tr')

--- a/spa/cypress/integration/contributor.spec.js
+++ b/spa/cypress/integration/contributor.spec.js
@@ -117,14 +117,16 @@ describe('Contributor portal', () => {
       });
     });
 
-    // this test passes locally, but fails in CI. Temoporarily commenting out
-    // until we can track down root cause.
-
-    // it('should show update payment method modal when payment method clicked', () => {
-    //   cy.getByTestId('payment-method').first().click();
-    //   cy.getByTestId('edit-recurring-payment-modal').should('exist');
-    //   cy.getByTestId('close-modal').click();
-    // });
+    it.only('should show update payment method modal when payment method clicked for recurring contribution', () => {
+      cy.get('td[data-testcolumnaccessor="interval"]')
+        .contains('Monthly')
+        .closest('tr')
+        .find('[data-testid="payment-method"]')
+        .first()
+        .click();
+      cy.getByTestId('edit-recurring-payment-modal').should('exist');
+      cy.getByTestId('close-modal').click();
+    });
 
     it('should do send cancel request if continue is clicked', () => {
       const targetContId = donationsData.find((d) => d.interval !== 'one_time').id;


### PR DESCRIPTION
#### What's this PR do?

Gets `    it('should show update payment method modal when payment method clicked for recurring contribution',)` from contributor.spec.js to pass.

Turns out the reason it was passing locally is that there were upstream changes in develop that I was unaware of that fixed the bug whereby you could get the update payment method modal for one time payments. When the test ran in CI, it was based on merging feature branch into develop, so the two testing environments were not identical. There were no merge conflicts appearing in the PR, so I was not aware this was causing the issue. Add on top of that that there were some flaky tests that were failing in CI while passing locally (the root problem of which was solved), and that led to me not understanding the underlying issue.

#### How should this be manually tested?

Test passes in CI

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?

No