### PR TITLE
Nrh 208  payment block causes error

### DIFF
--- a/spa/src/components/pageEditor/editInterface/EditInterface.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.js
@@ -23,7 +23,7 @@ const EditInterfaceContext = createContext();
 /**
  * EditInterface
  * EditInterface renders the Sidebar in the PageEdit view. It maintains state for elements
- * in element tab, as well as the state of the tabs themsevles. It also renders and controls
+ * in element tab, as well as the state of the tabs themselves. It also renders and controls
  * the state of the AddElementModal. It swaps PageElements for ElementProperties when a Page
  * Element is selected.
  *

--- a/spa/src/components/pageEditor/elementEditors/payment/PaymentEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/payment/PaymentEditor.js
@@ -40,7 +40,7 @@ function PaymentEditor() {
             <S.Toggle
               label={`Enable payment via ${paymentMethod.displayName}`}
               toggle
-              checked={isPaymentMethodOn(paymentMethod.value, elementContent.stripe)}
+              checked={isPaymentMethodOn(paymentMethod.value, elementContent?.stripe)}
               onChange={(_e, { checked }) => setToggled(checked, paymentMethod.value, 'stripe')}
             />
           </S.ToggleWrapper>


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug that caused the payment element to explode when selected on the PageEditor.

#### How should this be manually tested?
1. Open the PageEditor
2. Add the Payment Element
3. Select the Payment Element

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?

No.
