### PR TITLE
refs #NRH-220 Allows fractional other amounts.

### DIFF
--- a/spa/cypress/fixtures/pages/live-page-1.json
+++ b/spa/cypress/fixtures/pages/live-page-1.json
@@ -9,7 +9,8 @@
     {"type": "DAmount", "uuid": "testAmount1", "content": { "allowOther": true, "options": {
         "one_time": [120, 180, 365],
         "month": [10, 15, 25],
-        "year": [120, 180, 365]
+        "year": [120, 180, 365],
+        "other": [22.45, 33]
       }}
     },
     {"type": "DDonorInfo", "uuid": "testDonorInfo1"},

--- a/spa/cypress/integration/donation-page-edit.spec.js
+++ b/spa/cypress/integration/donation-page-edit.spec.js
@@ -95,6 +95,7 @@ describe('Donation page edit', () => {
 
     it('should show existing frequencies and amounts', () => {
       for (const frequency in options) {
+        if (frequency === 'other') continue;
         cy.contains(getFrequencyAdjective(frequency))
           .siblings('ul')
           .within(() =>

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -35,7 +35,7 @@ function DAmount({ element, ...props }) {
   useEffect(() => {
     let amount;
     if (selectedAmount === 'other') {
-      amount = parseInt(otherAmount || 0);
+      amount = parseFloat(otherAmount || 0);
     } else {
       // It's possible options[frequency][selectedAmount] is undefined, in the case that somebody either
       // has stale development data, or somebody has messed around with page.elements JSONField.

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -35,7 +35,7 @@ function DAmount({ element, ...props }) {
   useEffect(() => {
     let amount;
     if (selectedAmount === 'other') {
-      amount = parseFloat(otherAmount || 0);
+      amount = parseFloat(otherAmount || 0).toFixed(2);
     } else {
       // It's possible options[frequency][selectedAmount] is undefined, in the case that somebody either
       // has stale development data, or somebody has messed around with page.elements JSONField.

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -35,7 +35,7 @@ function DAmount({ element, ...props }) {
   useEffect(() => {
     let amount;
     if (selectedAmount === 'other') {
-      amount = parseFloat(otherAmount || 0).toFixed(2);
+      amount = parseFloat(otherAmount || 0);
     } else {
       // It's possible options[frequency][selectedAmount] is undefined, in the case that somebody either
       // has stale development data, or somebody has messed around with page.elements JSONField.


### PR DESCRIPTION
#### What's this PR do?
Modifies a regression where fractional OtherAmounts were disabled.

#### How should this be manually tested?
1. Go to a donation page with other amount enabled
2. Add a fractional donation. (e.g 42.42)
3. Note that the donation button reflects the fractional change

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?

No.
