### PR TITLE
[NRH-219] Bugfix Preview thumbnail

### DIFF
--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -99,10 +99,9 @@ function PageEditor() {
   useEffect(() => {
     setLoading(true);
 
-    const { revProgramSlug, pageSlug } = parameters;
     const params = {
-      revenue_program: revProgramSlug,
-      page: pageSlug,
+      revenue_program: parameters.revProgramSlug,
+      page: parameters.pageSlug,
       live: 0
     };
     requestGetPage(
@@ -116,7 +115,7 @@ function PageEditor() {
       }
     );
     // Don't include requestGetPage for now.
-  }, [parameters]);
+  }, [parameters.revProgramSlug, parameters.pageSlug]);
 
   useEffect(() => {
     setLoading(true);


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug in which the preview thumbnail in the page list view appeared to be showing the second-to-latest page version.  In fact, what was happening was that when the page preview was being generated (on page save), the page briefly displayed the unedited version (this happened to occur for just a moment, exactly when the code to generate the screenshot runs). So the screenshot saved was the unedited version.

#### How should this be manually tested?
Edit a page with something obvious, like a drastic style change. Observe that the thumbnail in the page list view shows your changed version and not the previous version.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
