### PR TITLE
[NRH-255] stripe fee calculation tweaks

### DIFF
--- a/spa/src/utilities/calculateStripeFee.js
+++ b/spa/src/utilities/calculateStripeFee.js
@@ -22,10 +22,9 @@ function calculateStripeFee(amount, isNonProfit) {
   const RATE = isNonProfit ? STRIPE_NP_RATE : STRIPE_FP_RATE;
   // Get "new amount" after stripe rates are applied
   let newAmount = (amount + STRIPE_FIXED) / (1 - RATE);
-  // Get the fee paid on this "new amount"
-  newAmount = newAmount / 1 - RATE;
   // Calculate fee based on this amount, so that organizations recieve exactly the amount intended without fees
-  const fee = newAmount * RATE + STRIPE_FIXED;
+  const fee = newAmount.toFixed(2) * RATE + STRIPE_FIXED;
+
   return fee.toFixed(2);
 }
 


### PR DESCRIPTION
#### What's this PR do?
Makes a few tweaks the Stripe fee calculation:
- Rounds to 2 decimal places before the final fee is calculated, in addition to at the end
- Removes a mistaken redundant calculation

#### How should this be manually tested?
Maybe just calculate what you think your fee should be and compare it to what it is. (only particularly large numbers are likely to show a difference from the previous iteration).

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
