### PR TITLE
[NRH-223] Clearable date filters

### DIFF
--- a/spa/cypress/integration/donations.spec.js
+++ b/spa/cypress/integration/donations.spec.js
@@ -100,12 +100,12 @@ describe('Donations list', () => {
 
     it('should display the second page of donations when click on next page', () => {
       cy.wait('@getDonations');
-      cy.getByTestId('next-page').click();
       cy.wait('@getDonations').then((intercept) => {
         cy.getByTestId('donations-table')
           .find('tbody tr[data-testid="donation-row"]')
           .should('have.length', intercept.response.body.results.length);
       });
+      cy.getByTestId('next-page').click();
     });
 
     it('should make donations sortable by payment date', () => {

--- a/spa/src/components/donations/filters/CreatedFilter.js
+++ b/spa/src/components/donations/filters/CreatedFilter.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import * as S from './CreatedFilter.styled';
 
 // Depts
@@ -8,20 +8,25 @@ import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 
 // Children
+import XButton from 'elements/buttons/XButton';
 import { FilterWrapper, FilterLabel } from 'components/donations/filters/Filters';
 import formatDatetimeForAPI from 'utilities/formatDatetimeForAPI';
 
 function CreatedFilter({ handleFilterChange }) {
   const theme = useTheme();
-  const [fromDate, setFromDate] = useState(new Date(2019, 0, 1));
+  const [fromDate, setFromDate] = useState(null);
   const [toDate, setToDate] = useState(new Date());
 
   const updateFilters = () => {
     handleFilterChange('created', {
-      created__gte: formatDatetimeForAPI(fromDate, false),
-      created__lte: formatDatetimeForAPI(toDate, false)
+      created__gte: fromDate ? formatDatetimeForAPI(fromDate, false) : '',
+      created__lte: toDate ? formatDatetimeForAPI(toDate, false) : ''
     });
   };
+
+  useEffect(() => {
+    updateFilters();
+  }, [fromDate, toDate]);
 
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
@@ -31,45 +36,49 @@ function CreatedFilter({ handleFilterChange }) {
           <S.DateFilters>
             <S.DatePickerWrapper>
               <S.DateLabel>From:</S.DateLabel>
-              <S.DatePicker
-                disableToolbar
-                variant="inline"
-                format="MM/dd/yyyy"
-                margin="normal"
-                value={fromDate}
-                onChange={setFromDate}
-                onClose={updateFilters}
-                onBlur={updateFilters}
-                KeyboardButtonProps={{
-                  'aria-label': 'change from date'
-                }}
-                inputProps={{
-                  style: {
-                    fontFamily: theme.font
-                  }
-                }}
-              />
+              <S.DatePickerInner>
+                <S.DatePicker
+                  disableToolbar
+                  variant="inline"
+                  format="MM/dd/yyyy"
+                  placeholder="Select a from date"
+                  margin="normal"
+                  value={fromDate}
+                  onChange={setFromDate}
+                  KeyboardButtonProps={{
+                    'aria-label': 'change from date'
+                  }}
+                  inputProps={{
+                    style: {
+                      fontFamily: theme.font
+                    }
+                  }}
+                />
+                <XButton onClick={() => setFromDate(null)} />
+              </S.DatePickerInner>
             </S.DatePickerWrapper>
             <S.DatePickerWrapper>
               <S.DateLabel>To:</S.DateLabel>
-              <S.DatePicker
-                disableToolbar
-                variant="inline"
-                format="MM/dd/yyyy"
-                margin="normal"
-                value={toDate}
-                onChange={setToDate}
-                onClose={updateFilters}
-                onBlur={updateFilters}
-                KeyboardButtonProps={{
-                  'aria-label': 'change to date'
-                }}
-                inputProps={{
-                  style: {
-                    fontFamily: theme.font
-                  }
-                }}
-              />
+              <S.DatePickerInner>
+                <S.DatePicker
+                  disableToolbar
+                  variant="inline"
+                  format="MM/dd/yyyy"
+                  placeholder="Select a to date"
+                  margin="normal"
+                  value={toDate}
+                  onChange={setToDate}
+                  KeyboardButtonProps={{
+                    'aria-label': 'change to date'
+                  }}
+                  inputProps={{
+                    style: {
+                      fontFamily: theme.font
+                    }
+                  }}
+                />
+                <XButton onClick={() => setToDate(null)} />
+              </S.DatePickerInner>
             </S.DatePickerWrapper>
           </S.DateFilters>
         </S.CreatedFilter>

--- a/spa/src/components/donations/filters/CreatedFilter.styled.js
+++ b/spa/src/components/donations/filters/CreatedFilter.styled.js
@@ -18,4 +18,17 @@ export const DatePickerWrapper = styled.div``;
 
 export const DateLabel = styled.p``;
 
-export const DatePicker = styled(KeyboardDatePicker)``;
+export const DatePickerInner = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const DatePicker = styled(KeyboardDatePicker)`
+  &&.MuiFormControl-marginNormal {
+    margin: 0;
+  }
+  && label + .MuiInput-formControl {
+    margin-top: 16px;
+  }
+`;


### PR DESCRIPTION
#### What's this PR do?
In the Org donations list view, the "Date" filter datepickers were previously not clearable. Now you can clear them.

#### How should this be manually tested?
Go to /dashboard/donations and filter to a date range, then clear out one or the other dates by clicking the red "x". Observe that the filter for that part of the range is removed from the results.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No