### PR TITLE
[NRH-213] bugfix setup tab images and links broken

### DIFF
--- a/spa/cypress/integration/donation-page-edit.spec.js
+++ b/spa/cypress/integration/donation-page-edit.spec.js
@@ -1,4 +1,4 @@
-import { DELETE_PAGE, FULL_PAGE, DONOR_BENEFITS, LIST_PAGES, CONTRIBUTION_META } from 'ajax/endpoints';
+import { DELETE_PAGE, FULL_PAGE, PATCH_PAGE, DONOR_BENEFITS, LIST_PAGES, CONTRIBUTION_META } from 'ajax/endpoints';
 import { getEndpoint } from '../support/util';
 import { getFrequencyAdjective } from 'utilities/parseFrequency';
 import { format } from 'date-fns';
@@ -12,13 +12,13 @@ describe('Donation page edit', () => {
     cy.intercept(
       { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
       { fixture: 'pages/live-page-1', statusCode: 200 }
-    ).as('getPage');
+    );
     cy.intercept(
       { method: 'GET', pathname: getEndpoint(DONOR_BENEFITS) },
       { fixture: 'org/donor-benefits-1.json', statusCode: 200 }
-    ).as('getDonorBenefits');
+    );
     cy.visit('edit/my/page');
-    cy.wait(['@login', '@getPage', '@getDonorBenefits']);
+    // cy.wait(['@login', '@getPage', '@getDonorBenefits']);
   });
 
   it('should render page edit buttons', () => {
@@ -117,7 +117,6 @@ describe('Donation page edit', () => {
         .within(() => {
           cy.contains(amountToRemove).find("[data-testid='x-button']").click();
           cy.contains(amountToRemove).should('not.exist');
-          // cy.getByTestId('x-button').click()
         });
     });
 
@@ -175,29 +174,73 @@ describe('Donation page edit', () => {
       cy.intercept({ method: 'GET', pathname: getEndpoint(FULL_PAGE) }, { body: page, statusCode: 200 }).as(
         'getPageDetail'
       );
-      cy.intercept(
-        { method: 'GET', pathname: getEndpoint(DONOR_BENEFITS) },
-        { fixture: 'org/donor-benefits-1.json', statusCode: 200 }
-      ).as('getDonorBenefits');
       cy.login('user/stripe-verified.json');
       cy.visit('edit/my/page');
       cy.wait('@getPageDetail');
 
-      // Need to add fake an update to the page to enable
+      // Need to fake an update to the page to enable save
       cy.getByTestId('edit-page-button').click();
       cy.contains('Rich text').click();
+
+      // Accept changes
       cy.getByTestId('keep-element-changes-button').click();
+
+      // Save changes
       cy.getByTestId('save-page-button').click();
+
+      // Expect alert
       cy.getByTestId('missing-elements-alert').should('exist');
       cy.getByTestId('missing-elements-alert').contains('Payment');
+
+      // Cleanup
       cy.getByTestId('edit-page-button').click();
+      cy.wait(300);
       cy.getByTestId('add-element-button').click();
       cy.getByTestId('edit-interface-item').contains('Payment').click({ force: true });
+    });
+
+    it('should open appropriate tab for error and scroll to first error', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/unpublished-page-1.json' }
+      ).as('getPageDetail');
+      cy.login('user/stripe-verified.json');
+      cy.visit('edit/my/page');
+      cy.wait('@getPageDetail');
+      cy.getByTestId('edit-page-button').click();
+      cy.getByTestId('setup-tab').click();
+      cy.getByTestId('logo-link-input').type('not a valid url');
+      cy.getByTestId('keep-element-changes-button').click();
+
+      // Before we save, let's close the tab so we can more meaningfully assert its presence later.
+      cy.getByTestId('preview-page-button').click();
+      cy.getByTestId('edit-interface').should('not.exist');
+
+      const expectedErrorMessage = 'Not a valid url';
+      cy.intercept(
+        { method: 'PATCH', pathname: `${getEndpoint(PATCH_PAGE)}${unpublishedPage.id}/` },
+        { body: { header_link: [expectedErrorMessage] }, statusCode: 400 }
+      ).as('patchPage');
+
+      // Save
+      cy.getByTestId('save-page-button').click();
+      cy.wait('@patchPage');
+
+      // Now we should see the Setup tab and our error message
+      cy.getByTestId('edit-interface').should('exist');
+      cy.getByTestId('errors-Logo link').contains(expectedErrorMessage);
     });
   });
 
   describe('Edit interface: Setup', () => {
     before(() => {
+      cy.login('user/stripe-verified.json');
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/live-page-1', statusCode: 200 }
+      ).as('getPageDetail');
+      cy.visit('edit/my/page');
+      cy.wait('@getPageDetail');
       cy.getByTestId('edit-page-button').click({ force: true });
       cy.getByTestId('setup-tab').click({ force: true });
     });
@@ -247,7 +290,7 @@ describe('Donation page delete', () => {
       { fixture: 'pages/unpublished-page-1', statusCode: 200 }
     ).as('getPage');
     cy.visit('edit/my/page');
-    cy.wait(['@login', '@getPage']);
+    cy.wait(['@getPage']);
     cy.getByTestId('delete-page-button').click();
     cy.wait('@deletePage').then((interception) => {
       const pkPathIndex = interception.request.url.split('/').length - 2;
@@ -261,7 +304,7 @@ describe('Donation page delete', () => {
       { fixture: 'pages/live-page-1', statusCode: 200 }
     ).as('getPage');
     cy.visit('edit/my/page');
-    cy.wait(['@login', '@getPage']);
+    cy.wait(['@getPage']);
     cy.getByTestId('delete-page-button').click();
 
     cy.getByTestId('confirmation-modal').contains(DELETE_CONFIRM_MESSAGE).getByTestId('continue-button').click();

--- a/spa/cypress/integration/donation-page-edit.spec.js
+++ b/spa/cypress/integration/donation-page-edit.spec.js
@@ -18,7 +18,6 @@ describe('Donation page edit', () => {
       { fixture: 'org/donor-benefits-1.json', statusCode: 200 }
     );
     cy.visit('edit/my/page');
-    // cy.wait(['@login', '@getPage', '@getDonorBenefits']);
   });
 
   it('should render page edit buttons', () => {

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -16,6 +16,7 @@ Cypress.Commands.add('login', (userFixture) => {
   cy.getByTestId('login-password').type('testing');
   cy.intercept('POST', getEndpoint(TOKEN), { fixture: userFixture }).as('login');
   cy.getByTestId('login-button').click();
+  return cy.wait('@login');
 });
 
 Cypress.Commands.add('visitDonationPage', () => {

--- a/spa/src/components/donationPage/pageContent/SHeaderBar.js
+++ b/spa/src/components/donationPage/pageContent/SHeaderBar.js
@@ -6,10 +6,16 @@ import { usePage } from 'components/donationPage/DonationPage';
 function SHeaderBar() {
   const { page } = usePage();
 
+  const getImageUrl = (img) => {
+    if (img instanceof File) {
+      return URL.createObjectURL(img);
+    } else return img;
+  };
+
   return (
-    <S.SHeaderBar bgImg={page?.header_bg_image} data-testid="s-header-bar">
+    <S.SHeaderBar bgImg={getImageUrl(page?.header_bg_image)} data-testid="s-header-bar">
       <a href={page?.header_link} target="_blank" rel="noreferrer noopener">
-        <S.SHeaderLogo src={page?.header_logo} />
+        <S.SHeaderLogo src={getImageUrl(page?.header_logo)} />
       </a>
     </S.SHeaderBar>
   );

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -48,8 +48,8 @@ import EditInterface from 'components/pageEditor/editInterface/EditInterface';
 
 const PageEditorContext = createContext();
 
-const EDIT = 'EDIT';
-const PREVIEW = 'PREVIEW';
+export const EDIT = 'EDIT';
+export const PREVIEW = 'PREVIEW';
 const IMAGE_KEYS = ['graphic', 'header_bg_image', 'header_logo'];
 const THUMBNAIL_KEYS = ['graphic_thumbnail', 'header_bg_image_thumbnail', 'header_logo_thumbnail'];
 
@@ -280,13 +280,21 @@ function PageEditor() {
         onSuccess: ({ data }) => {
           const successMessage = getSuccessMessage(page, data);
           alert.success(successMessage);
+          setErrors({});
           setPage(data);
           setSelectedButton(PREVIEW);
           setLoading(false);
         },
         onFailure: (e) => {
-          alert.error(GENERIC_ERROR);
-          setSelectedButton(PREVIEW);
+          if (e?.response?.data) {
+            setErrors({ ...errors, ...e.response.data });
+            setSelectedButton(EDIT);
+            setShowEditInterface(true);
+            setLoading(false);
+          } else {
+            alert.error(GENERIC_ERROR);
+            setSelectedButton(PREVIEW);
+          }
           setLoading(false);
         }
       }
@@ -314,6 +322,7 @@ function PageEditor() {
         setUpdatedPage,
         showEditInterface,
         setShowEditInterface,
+        setSelectedButton,
         errors
       }}
     >

--- a/spa/src/components/pageEditor/editInterface/EditInterface.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.js
@@ -1,15 +1,18 @@
-import { useState, useContext, createContext } from 'react';
+import { useState, useContext, createContext, useEffect, useCallback } from 'react';
 import * as S from './EditInterface.styled';
 
 import { usePageEditorContext } from 'components/pageEditor/PageEditor';
 
+// Util
+import isEmpty from 'lodash.isempty';
+
 // Children
-import EditInterfaceTabs from 'components/pageEditor/editInterface/EditInterfaceTabs';
+import EditInterfaceTabs, { EDIT_INTERFACE_TABS } from 'components/pageEditor/editInterface/EditInterfaceTabs';
 import ElementProperties from 'components/pageEditor/editInterface/pageElements/ElementProperties';
 import AddElementModal from 'components/pageEditor/editInterface/pageElements/addElementModal/AddElementModal';
 
 import PageElements from 'components/pageEditor/editInterface/pageElements/PageElements';
-import PageSetup from 'components/pageEditor/editInterface/pageSetup/PageSetup';
+import PageSetup, { PAGE_SETUP_FIELDS } from 'components/pageEditor/editInterface/pageSetup/PageSetup';
 import PageStyles from 'components/pageEditor/editInterface/pageStyles/PageStyles';
 
 const editInterfaceAnimation = {
@@ -30,14 +33,44 @@ const EditInterfaceContext = createContext();
  * EditInterface is direct child of PageEditor
  */
 function EditInterface() {
-  const { page, setPage, updatedPage, setUpdatedPage } = usePageEditorContext();
-  const [tab, setTab] = useState(0);
+  const {
+    page,
+    setPage,
+    updatedPage,
+    setUpdatedPage,
+    errors,
+    showEditInterface,
+    setSelectedButton
+  } = usePageEditorContext();
   const [addElementModalOpen, setAddElementModalOpen] = useState(false);
   const [selectedElement, setSelectedElement] = useState();
 
+  const [tab, setTab] = useState(0);
   // Since you can only edit one element at a time, it's safe (and much easier)
   // to only store one set of "unconfirmed" changes at a time.
   const [elementContent, setElementContent] = useState();
+
+  /**
+   * This method exists to acknowledge potential additional complexity. Lucky for this developer,
+   * there is not currently a scenario where validation errors will come back for somewhere other
+   * than the Setup tab.
+   */
+  const setTabFromErrors = useCallback((errorsObj) => {
+    const firstError = Object.keys(errorsObj)[0];
+    if (PAGE_SETUP_FIELDS.includes(firstError)) {
+      const setupTab = EDIT_INTERFACE_TABS.indexOf('Setup');
+      setTab(setupTab);
+    }
+  }, []);
+
+  /**
+   * If we have errors, open edit interface and set tab based on value in errors.
+   */
+  useEffect(() => {
+    if (!isEmpty(errors)) {
+      setTabFromErrors(errors);
+    }
+  }, [errors, setTabFromErrors, setSelectedButton, showEditInterface]);
 
   /**
    * setPageContent performs updates necessary to affect a change made in

--- a/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.js
@@ -1,11 +1,11 @@
 import * as S from './EditInterfaceTabs.styled';
 
-const TABS = ['Layout', 'Setup', 'Styles'];
+export const EDIT_INTERFACE_TABS = ['Layout', 'Setup', 'Styles'];
 
 function EditInterfaceTabs({ tab, setTab }) {
   return (
     <S.EditInterfaceTabs>
-      {TABS.map((tabName, i) => (
+      {EDIT_INTERFACE_TABS.map((tabName, i) => (
         <S.Tab
           key={tabName + i}
           selected={i === tab}

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -28,13 +28,13 @@ import CircleButton from 'elements/buttons/CircleButton';
  */
 function PageSetup({ backToProperties }) {
   const { getUserConfirmation } = useGlobalContext();
+  const { page, errors, availableBenefits } = usePageEditorContext();
   const { setPageContent } = useEditInterfaceContext();
-  const { page, availableBenefits } = usePageEditorContext();
 
   // Form state
   const [heading, setPageHeading] = useState(page.heading);
   const [images, setImages] = useState({});
-  const [heading_link, setHeaderLink] = useState(page.header_link);
+  const [header_link, setHeaderLink] = useState(page.header_link);
   const [thank_you_redirect, setThankYouRedirect] = useState(page.thank_you_redirect);
   const [post_thank_you_redirect, setPostThankYouRedirect] = useState(page.post_thank_you_redirect);
   const [donor_benefits, setDonorBenefits] = useState(page.donor_benefits);
@@ -48,7 +48,7 @@ function PageSetup({ backToProperties }) {
     setPageContent({
       heading,
       ...images,
-      heading_link,
+      header_link,
       thank_you_redirect,
       post_thank_you_redirect,
       donor_benefits,
@@ -87,6 +87,7 @@ function PageSetup({ backToProperties }) {
           value={heading}
           onChange={(e) => setPageHeading(e.target.value)}
           testid="setup-heading-input"
+          errors={errors.heading}
         />
       </S.InputWrapper>
       <S.Images>
@@ -96,6 +97,7 @@ function PageSetup({ backToProperties }) {
             onChange={(file) => handleImageChange('header_bg_image', file)}
             label="Header background"
             helpText="Background of header bar"
+            errors={errors.header_bg_image}
           />
         </S.ImageSelectorWrapper>
         <S.ImageSelectorWrapper>
@@ -104,9 +106,18 @@ function PageSetup({ backToProperties }) {
             onChange={(file) => handleImageChange('header_logo', file)}
             label="Header logo"
             helpText="Logo to display in header"
+            errors={errors.header_logo_thumbnail}
           />
           <S.InputWrapper>
-            <Input type="text" label="Logo link" value={heading_link} onChange={(e) => setHeaderLink(e.target.value)} />
+            <Input
+              type="text"
+              label="Logo link"
+              value={header_link}
+              helpText="Where does clicking your logo take your users?"
+              onChange={(e) => setHeaderLink(e.target.value)}
+              errors={errors.header_link}
+              testid="logo-link-input"
+            />
           </S.InputWrapper>
         </S.ImageSelectorWrapper>
         <S.ImageSelectorWrapper>
@@ -115,6 +126,7 @@ function PageSetup({ backToProperties }) {
             onChange={(file) => handleImageChange('graphic', file)}
             label="Graphic"
             helpText="Graphic displays below page title"
+            errors={errors.graphic_thumbnail}
           />
         </S.ImageSelectorWrapper>
       </S.Images>
@@ -124,6 +136,7 @@ function PageSetup({ backToProperties }) {
           helpText='If you have a "Thank You" page of your own, add a link here'
           value={thank_you_redirect}
           onChange={(e) => setThankYouRedirect(e.target.value)}
+          errors={errors.thank_you_redirect}
         />
       </S.InputWrapper>
       <S.InputWrapper border>
@@ -132,10 +145,16 @@ function PageSetup({ backToProperties }) {
           helpText="If using our default Thank You page, where should we redirect your donors afterward?"
           value={post_thank_you_redirect}
           onChange={(e) => setPostThankYouRedirect(e.target.value)}
+          errors={errors.post_thank_you_redirect}
         />
       </S.InputWrapper>
-      <BenefitsWidget benefits={availableBenefits} selected={donor_benefits} setSelected={(d) => setDonorBenefits(d)} />
-      <PublishWidget publishDate={published_date} onChange={setPublishedDate} />
+      <BenefitsWidget
+        benefits={availableBenefits}
+        selected={donor_benefits}
+        setSelected={(d) => setDonorBenefits(d)}
+        errors={errors.donor_benefits}
+      />
+      <PublishWidget publishDate={published_date} onChange={setPublishedDate} errors={errors.published_date} />
       <S.Buttons>
         <CircleButton
           icon={faCheck}
@@ -155,3 +174,15 @@ function PageSetup({ backToProperties }) {
 }
 
 export default PageSetup;
+
+export const PAGE_SETUP_FIELDS = [
+  'heading',
+  'header_bg_image_thumbnail',
+  'header_logo_thumbnail',
+  'header_link',
+  'graphic_thumbnail',
+  'thank_you_redirect',
+  'post_thank_you_redirect',
+  'donor_benefits',
+  'published_date'
+];

--- a/spa/src/components/pageEditor/elementEditors/additionalInfo/AdditionalInfoEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/additionalInfo/AdditionalInfoEditor.js
@@ -26,7 +26,7 @@ function AdditionalInfoEditor(props) {
     const new_meta = [...metadata].filter((e) => e.key !== item.key);
     setMetadata(new_meta);
   };
-  console.log(metadata);
+
   return (
     <S.AdditionalInfoEditor data-testid="additional-info">
       <S.Description>Collect arbitrary data from your users by adding form fields to your page.</S.Description>

--- a/spa/src/elements/inputs/BaseField.js
+++ b/spa/src/elements/inputs/BaseField.js
@@ -30,7 +30,7 @@ function BaseField({ label, errors, inline, labelProps, helpText, children }) {
       {helpText && <S.HelpText>{helpText}</S.HelpText>}
       <AnimatePresence>
         {hasErrors(errors) && (
-          <S.Errors ref={errorsRef} {...S.errorsAnimation}>
+          <S.Errors ref={errorsRef} {...S.errorsAnimation} data-testid={`errors-${label}`}>
             {errors.map((error) => (
               <S.Error key={error}>{error}</S.Error>
             ))}


### PR DESCRIPTION
#### What's this PR do?
As reported in NRH-213, some images weren't displaying thumbnails after accepting changes. And some link fields in the setup tab weren't being saved, or error messages were displayed.  Each of these issues has a separate solution here. 
- The images needed to be explicitly converted to ObjectUrls when displaying browser-memory based thumbnails.
- One link type, the "Logo link" didn't have the right name attribute on its input.
- The other links were working, but they were returning validation errors (valid urls start with protocol). The bulk of the work in this PR is implementing a mechanism to show error messages inline for fields inside the EditInterface, in the Setup tab.

#### How should this be manually tested?
Try to add images in the setup tab: Thumbnails should appear.
Try to save all three link types. They should be saved.
Try to save an invalid url in one of those link fields. You should be shown an error message next to the failing field.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
