### PR TITLE
Disable page screenshot

### DIFF
--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -46,8 +46,7 @@ import EditInterface from 'components/pageEditor/editInterface/EditInterface';
 
 const PageEditorContext = createContext();
 
-// Since env vars on the frontend aren't working, let's just set this to true for now.
-const CAPTURE_PAGE_SCREENSHOT = true; //process.env.REACT_APP_CAPTURE_PAGE_SCREENSHOT === 'true';
+const CAPTURE_PAGE_SCREENSHOT = process.env.REACT_APP_CAPTURE_PAGE_SCREENSHOT === 'true';
 
 export const EDIT = 'EDIT';
 export const PREVIEW = 'PREVIEW';


### PR DESCRIPTION
#### What's this PR do?
Causes page screenshot to only occur if REACT_APP_CAPTURE_PAGE_SCREENSHOT is 'true'. Since REACT_APP_ env vars aren't working right now, this effectively disables screenshot capture. It is hoped that this will fix the page save 503 issue referenced in [this PR](https://github.com/newsrevenuehub/rev-engine/pull/104)

#### How should this be manually tested?
Hopefully page edits can be saved now.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
set REACT_APP_CAPTURE_PAGE_SCREENSHOT to 'true' if we want to enable screen capture.