### PR TITLE
[NRH-249]  Contributions stuck in processing

### DIFF
--- a/apps/slack/slack_manager.py
+++ b/apps/slack/slack_manager.py
@@ -3,6 +3,7 @@ import logging
 from django.conf import settings
 
 from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
 
 from apps.organizations.models import Organization
 
@@ -112,11 +113,23 @@ class SlackManager:
         return f"{self.common_header_text}: {contribution.formatted_amount} from {contribution.contributor.email}"
 
     def send_hub_message(self, channel, text, blocks):
-        self.hub_client.chat_postMessage(channel=channel, text=text, blocks=blocks)
+        try:
+            self.hub_client.chat_postMessage(channel=channel, text=text, blocks=blocks)
+        except SlackApiError as slack_error:
+            error_type = slack_error.response["error"]
+            if error_type == "invalid_auth":
+                pass
+            pass
 
     def send_org_message(self, channel, text, blocks):
         org_client = self.get_org_client()
-        org_client.chat_postMessage(channel=channel, text=text, blocks=blocks)
+        try:
+            org_client.chat_postMessage(channel=channel, text=text, blocks=blocks)
+        except SlackApiError as slack_error:
+            error_type = slack_error.response["error"]
+            if error_type == "invalid_auth":
+                pass
+            pass
 
     def send_hub_notifications(self, contribution):
         main_channel = self.hub_integration.channel

--- a/apps/slack/slack_manager.py
+++ b/apps/slack/slack_manager.py
@@ -46,9 +46,6 @@ class SlackManager:
         try:
             return org.slack_integration
         except Organization.slack_integration.RelatedObjectDoesNotExist:
-            logger.debug(
-                f"Tried to send slack notification, but {org.name} does not have a SlackIntegration configured"
-            )
             logger.info(f"Tried to send slack notification, but {org.name} does not have a SlackIntegration configured")
 
     @classmethod

--- a/apps/slack/tests/test_slack_integration.py
+++ b/apps/slack/tests/test_slack_integration.py
@@ -3,6 +3,8 @@ from unittest.mock import call, patch
 from django.test import TestCase
 from django.utils import timezone
 
+from slack_sdk.errors import SlackApiError
+
 from apps.contributions.models import ContributionInterval
 from apps.contributions.tests.factories import ContributionFactory, ContributorFactory
 from apps.organizations.tests.factories import OrganizationFactory
@@ -69,6 +71,66 @@ class SlackIntegrationTest(TestCase):
             ),
         ]
         mock_postmessage.assert_has_calls(calls=calls, any_order=True)
+
+    @patch("apps.slack.slack_manager.logger")
+    def test_logging_when_bad_api_key(self, mock_logger, mock_postmessage):
+        mock_postmessage.side_effect = SlackApiError("my_slack_error", {"error": "invalid_auth"})
+
+        slack_manager = self._create_slack_manager()
+        slack_manager.publish_contribution(self.contribution)
+
+        # Org slack errors are warnings
+        mock_logger.warn.assert_called()
+        warning_args = mock_logger.warn.call_args.args[0]
+        self.assertIn(self.org.name, warning_args)
+        self.assertNotIn("HubSlackIntegration", warning_args)
+        self.assertIn("invalid token", warning_args)
+
+        # Hub slack errors are errors
+        mock_logger.error.assert_called()
+        error_args = mock_logger.error.call_args.args[0]
+        self.assertIn("HubSlackIntegration", error_args)
+        self.assertIn("invalid token", error_args)
+
+    @patch("apps.slack.slack_manager.logger")
+    def test_logging_when_bad_channel_name(self, mock_logger, mock_postmessage):
+        mock_postmessage.side_effect = SlackApiError("my_slack_error", {"error": "channel_not_found"})
+
+        slack_manager = self._create_slack_manager()
+        slack_manager.publish_contribution(self.contribution)
+
+        # Org slack errors are warnings
+        mock_logger.warn.assert_called()
+
+        for warning_args in mock_logger.warn.call_args.args:
+            self.assertNotIn("HubSlackIntegration", warning_args)
+            self.assertIn(f'No such channel "{ORG_CHANNEL}" for {self.org.name}', warning_args)
+
+        # Hub slack errors are errors
+        mock_logger.error.assert_called()
+        error_args = mock_logger.error.call_args.args[0]
+        self.assertIn("HubSlackIntegration", error_args)
+        self.assertIn(f'No such channel "{self.org_channel_name}" for HubSlackIntegration', error_args)
+
+    @patch("apps.slack.slack_manager.logger.warn")
+    def test_log_info_when_generic_slack_error(self, mock_warn, mock_postmessage):
+        error_message = "some_other_error"
+        mock_postmessage.side_effect = SlackApiError("my_slack_error", {"error": error_message})
+
+        slack_manager = self._create_slack_manager()
+        slack_manager.publish_contribution(self.contribution)
+
+        # 2 Hub warnings first...
+        hub_warning = mock_warn.call_args_list[0]
+        hub_warning = hub_warning.args[0]
+        self.assertIn("Generic SlackApiError", hub_warning)
+        self.assertIn(error_message, hub_warning)
+
+        # ... then an org warning.
+        org_warning = mock_warn.call_args_list[2]
+        org_warning = org_warning.args[0]
+        self.assertIn(f'Generic SlackApiError for Org "{self.org.name}" to channel "{ORG_CHANNEL}"', org_warning)
+        self.assertIn(error_message, org_warning)
 
     @patch("apps.slack.slack_manager.logger.info")
     def test_log_info_when_no_integration(self, mock_info_logger, mock_postmessage):


### PR DESCRIPTION
#### What's this PR do?
A bugfix. Contributions were stuck in processing. This was reproducible if you provided invalid Slack credentials to either an org or Hub. It seems to be the case that Contribution.save was failing because we failed to except SlackApiErrors. Those should be caught now.

#### How should this be manually tested?
Set all SlackIntegrations values to invalid values (ie empty strings) and make a contribution. Previously, this contribution would get stuck in "processing". It should now have its status updated, even if slack notifications failed to send. Additionally, warn and error level logging should occur-- which at least at time of writing, triggers sentry notifications and admin emails respectively.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No.
