### PR TITLE
[NRH-182] SF Campaign ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,6 @@ _Frontend configuration is not enabled until we can get environment variables to
 
 ~~If 'true', saving edits to a donation page will also capture a "screenshot" and save it. This is used as a thumbnail in the Donation Page List view.~~
 
-~~`SALESFORCE_CAMPAIGN_ID_QUERYPARAM`~~
+~~`REACT_APP_SALESFORCE_CAMPAIGN_ID_QUERYPARAM`~~
 
 ~~Defaults to 'campaign'. This is the string that we expect to see in urls containing Salesforce Campaign IDs. eg. `?campiagn=my-salesforce-campaign-id`~~

--- a/README.md
+++ b/README.md
@@ -325,3 +325,7 @@ _Frontend configuration is not enabled until we can get environment variables to
 ~~`REACT_APP_CAPTURE_PAGE_SCREENSHOT`~~
 
 ~~If 'true', saving edits to a donation page will also capture a "screenshot" and save it. This is used as a thumbnail in the Donation Page List view.~~
+
+~~`SALESFORCE_CAMPAIGN_ID_QUERYPARAM`~~
+
+~~Defaults to 'campaign'. This is the string that we expect to see in urls containing Salesforce Campaign IDs. eg. `?campiagn=my-salesforce-campaign-id`~~

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -163,6 +163,7 @@ class AbstractPaymentSerializer(serializers.Serializer):
     referer = serializers.URLField()
     amount = serializers.IntegerField()
     reason = serializers.CharField(max_length=255, required=False, allow_blank=True)
+    sf_campaign_id = serializers.CharField(max_length=255, required=False, allow_blank=True)
 
     # These are use to attach the contribution to the right organization,
     # and associate it with the page it came from.

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -1,16 +1,32 @@
-import { useRef, useState, createContext, useContext } from 'react';
+import { useRef, useState, useEffect, createContext, useContext } from 'react';
 import * as S from './DonationPage.styled';
+
+import { useLocation } from 'react-router-dom';
+
+// Util
 import * as getters from 'components/donationPage/pageGetters';
 import { frequencySort } from 'components/donationPage/pageContent/DFrequency';
+
+// Deps// Deps
+import queryString from 'query-string';
+
+const SALESFORCE_CAMPAIGN_ID_QUERYPARAM = process.env.SALESFORCE_CAMPAIGN_ID_QUERYPARAM || 'campaign';
 
 const DonationPageContext = createContext({});
 
 function DonationPage({ page, live = false }) {
+  const location = useLocation();
   const formRef = useRef();
   const [frequency, setFrequency] = useState(getInitialFrequency(page));
   const [payFee, setPayFee] = useState(false);
   const [amount, setAmount] = useState();
   const [errors, setErrors] = useState({});
+  const [salesforceCampaignId, setSalesforceCampaignId] = useState();
+
+  useEffect(() => {
+    const qs = queryString.parse(location.search);
+    if (qs[SALESFORCE_CAMPAIGN_ID_QUERYPARAM]) setSalesforceCampaignId(qs[SALESFORCE_CAMPAIGN_ID_QUERYPARAM]);
+  }, [location.search, setSalesforceCampaignId]);
 
   return (
     <DonationPageContext.Provider
@@ -24,7 +40,8 @@ function DonationPage({ page, live = false }) {
         amount,
         setAmount,
         errors,
-        setErrors
+        setErrors,
+        salesforceCampaignId
       }}
     >
       <S.DonationPage data-testid="donation-page">

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -10,7 +10,7 @@ import { frequencySort } from 'components/donationPage/pageContent/DFrequency';
 // Deps// Deps
 import queryString from 'query-string';
 
-const SALESFORCE_CAMPAIGN_ID_QUERYPARAM = process.env.SALESFORCE_CAMPAIGN_ID_QUERYPARAM || 'campaign';
+const SALESFORCE_CAMPAIGN_ID_QUERYPARAM = process.env.REACT_APP_SALESFORCE_CAMPAIGN_ID_QUERYPARAM || 'campaign';
 
 const DonationPageContext = createContext({});
 

--- a/spa/src/components/donationPage/live/LivePage404.js
+++ b/spa/src/components/donationPage/live/LivePage404.js
@@ -1,6 +1,20 @@
+import { useState, useEffect } from 'react';
 import * as S from './LivePage404.styled';
 
-function LivePage404(props) {
+const SHOW_TIMEOUT = 400;
+
+function LivePage404() {
+  const [shouldShow, setShouldShow] = useState(false);
+
+  useEffect(() => {
+    let timeout = setTimeout(() => {
+      setShouldShow(true);
+    }, SHOW_TIMEOUT);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!shouldShow) return null;
+
   return (
     <S.LivePage404 data-testid="live-page-404">
       <S.Wrapper>

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -30,7 +30,7 @@ const STRIPE_PAYMENT_REQUEST_LABEL = 'RevEngine Donation';
 
 function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const { url, params } = useRouteMatch();
-  const { page, amount, frequency, payFee, formRef, errors, setErrors } = usePage();
+  const { page, amount, frequency, payFee, formRef, errors, setErrors, salesforceCampaignId } = usePage();
 
   const [succeeded, setSucceeded] = useState(false);
   const [disabled, setDisabled] = useState(true);
@@ -96,7 +96,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
     e.preventDefault();
     setLoading(true);
     const orgIsNonProfit = page.organization_is_nonprofit;
-    const data = serializeData(formRef.current, { amount, payFee, orgIsNonProfit, ...params });
+    const data = serializeData(formRef.current, { amount, payFee, orgIsNonProfit, salesforceCampaignId, ...params });
     await submitPayment(
       stripe,
       data,
@@ -112,7 +112,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const handlePaymentRequestSubmit = async (state, paymentRequest) => {
     setLoading(true);
     const orgIsNonProfit = page.organization_is_nonprofit;
-    const data = serializeData(formRef.current, { orgIsNonProfit, ...state });
+    const data = serializeData(formRef.current, { orgIsNonProfit, salesforceCampaignId, ...state });
     await submitPayment(
       stripe,
       data,

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -99,6 +99,7 @@ export function serializeData(formRef, state) {
   serializedData['amount'] = getTotalAmount(state.amount, state.payFee, state.orgIsNonProfit).toString();
   serializedData['revenue_program_slug'] = state.revProgramSlug;
   serializedData['donation_page_slug'] = state.pageSlug;
+  serializedData['sf_campaign_id'] = state.salesforceCampaignId;
 
   return serializedData;
 }


### PR DESCRIPTION
#### What's this PR do?
If a donor visits `/my-rev-program/my-donation-page?campaign=my-sf-campaign-id`, the value of the `campaign` qp is passed in the form submit request body then added to Stripe Metadata for the payment object (Subscription or PaymentIntent).  The expected query parameter is `campaign`, but this is set up to be configurable if this ever needs to change. The env var `REACT_APP_SALESFORCE_CAMPAIGN_ID_QUERYPARAM` can change the value (defaults to 'campaign' if unset).

#### How should this be manually tested?
Visit a donation page with the `campaign` queryparam set. Make a donation. Observe that sf_campaign_id is set on stripe metadata

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
