### PR TITLE
[NRH-260] handle string amount

### DIFF
--- a/spa/src/utilities/calculateStripeFee.js
+++ b/spa/src/utilities/calculateStripeFee.js
@@ -17,11 +17,11 @@ function calculateStripeFee(amount, isNonProfit) {
 
     NOTE: We are not including any VAT or GST, or any other taxes here, since these are donations.
   */
-
-  if (isNaN(amount)) return null;
+  const amountInt = parseFloat(amount);
+  if (isNaN(amountInt)) return null;
   const RATE = isNonProfit ? STRIPE_NP_RATE : STRIPE_FP_RATE;
   // Get "new amount" after stripe rates are applied
-  let newAmount = (amount + STRIPE_FIXED) / (1 - RATE);
+  let newAmount = (amountInt + STRIPE_FIXED) / (1 - RATE);
   // Calculate fee based on this amount, so that organizations recieve exactly the amount intended without fees
   const fee = newAmount.toFixed(2) * RATE + STRIPE_FIXED;
 


### PR DESCRIPTION
#### What's this PR do?
One of those "typescript would have caught this, but is it really worth it?" times. The "amount" argument in calculateStripeFees can be an int or a string. The string wasn't being handled properly. 

#### How should this be manually tested?
Stripe fees should be calculated accurately now.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
no
