### PR TITLE
[NRH-236-237-238] Amount and Frequency queryparams and defaults

### DIFF
--- a/spa/cypress/integration/donation-page-edit.spec.js
+++ b/spa/cypress/integration/donation-page-edit.spec.js
@@ -62,20 +62,26 @@ describe('Donation page edit', () => {
 
       it('should validate frequency', () => {
         // Uncheck all the frequencies
-        cy.getByTestId('frequency-editor').find('li').click({ multiple: true });
+        cy.getByTestId('frequency-toggle').click({ multiple: true });
         cy.getByTestId('keep-element-changes-button').click();
         cy.getByTestId('alert').contains('You must have at least');
       });
 
       it('should accept valid input and changes should show on page', () => {
         // Now check one and accept
-        cy.getByTestId('frequency-editor').find('li').first().click();
+        cy.getByTestId('frequency-toggle').contains('One time').click();
         cy.getByTestId('keep-element-changes-button').click();
 
         // Donation page should only show item checked, and nothing else.
         cy.getByTestId('d-frequency').contains('One time');
         cy.getByTestId('d-frequency').should('not.contain', 'Monthly');
         cy.getByTestId('d-frequency').should('not.contain', 'Yearly');
+
+        // Cleanup
+        cy.contains('Donation frequency').click();
+        cy.getByTestId('frequency-toggle').contains('Monthly').click();
+        cy.getByTestId('frequency-toggle').contains('Yearly').click();
+        cy.getByTestId('keep-element-changes-button').click();
       });
     });
   });
@@ -207,7 +213,7 @@ describe('Donation page edit', () => {
       cy.visit('edit/my/page');
       cy.wait('@getPageDetail');
       cy.getByTestId('edit-page-button').click();
-      cy.getByTestId('setup-tab').click();
+      cy.getByTestId('setup-tab').click({ force: true });
       cy.getByTestId('logo-link-input').type('not a valid url');
       cy.getByTestId('keep-element-changes-button').click();
 

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -63,8 +63,8 @@ Cypress.Commands.add('interceptDonation', () => {
 });
 
 Cypress.Commands.add('setUpDonation', (frequency, amount) => {
-  cy.getByTestId(`frequency-${frequency}`).click();
-  cy.getByTestId(`amount-${amount}`).click();
+  cy.contains(frequency).click();
+  cy.contains(amount).click();
 });
 
 Cypress.Commands.add('makeDonation', () => {

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, createContext, useContext } from 'react';
+import { useRef, useState, useEffect, useCallback, createContext, useContext } from 'react';
 import * as S from './DonationPage.styled';
 
 import { useLocation } from 'react-router-dom';
@@ -6,11 +6,21 @@ import { useLocation } from 'react-router-dom';
 // Util
 import * as getters from 'components/donationPage/pageGetters';
 import { frequencySort } from 'components/donationPage/pageContent/DFrequency';
+import { getDefaultAmount } from 'components/donationPage/pageContent/DAmount';
 
-// Deps// Deps
+// Deps
 import queryString from 'query-string';
 
 const SALESFORCE_CAMPAIGN_ID_QUERYPARAM = process.env.REACT_APP_SALESFORCE_CAMPAIGN_ID_QUERYPARAM || 'campaign';
+const AMOUNT_QUERYPARAM = process.env.REACT_APP_AMOUNT_QUERYPARAM || 'amount';
+const FREQUENCY_QUERYPARAM = process.env.REACT_APP_FREQUENCY_QUERYPARAM || 'frequency';
+
+// Keys are the strings expected as querys params, values are our version.
+const mapQSFreqToProperFreq = {
+  once: 'one_time',
+  monthly: 'month',
+  yearly: 'year'
+};
 
 const DonationPageContext = createContext({});
 
@@ -19,14 +29,51 @@ function DonationPage({ page, live = false }) {
   const formRef = useRef();
   const [frequency, setFrequency] = useState(getInitialFrequency(page));
   const [payFee, setPayFee] = useState(false);
-  const [amount, setAmount] = useState();
+  const [amount, setAmount] = useState(getDefaultAmount(frequency, page));
+
+  // overrideAmount causes only the custom amount to show (initially)
+  const [overrideAmount, setOverrideAmount] = useState(false);
   const [errors, setErrors] = useState({});
   const [salesforceCampaignId, setSalesforceCampaignId] = useState();
+
+  /**
+   * handleIncomingAmountOrFrequency
+   * @param {string} queryString - a query string parsed by the query-string library
+   * Set frequency or amount based on incoming querystrings.
+   */
+  const handleIncomingAmountOrFrequency = useCallback(
+    (qs) => {
+      const qsAmount = qs[AMOUNT_QUERYPARAM];
+      const qsFrequency = qs[FREQUENCY_QUERYPARAM];
+
+      const mappedFrequency = mapQSFreqToProperFreq[qsFrequency];
+
+      const amountElement = page?.elements?.find((el) => el.type === 'DAmount');
+      const amounts = amountElement?.content?.options;
+
+      // Check if the incoming frequency is a valid choice
+      const frequencyElement = page?.elements?.find((el) => el.type === 'DFrequency');
+      const frequencies = frequencyElement?.content?.map((f) => f.value);
+      const freqIsAvailable = frequencies.includes(mappedFrequency);
+
+      if (qsFrequency && freqIsAvailable) setFrequency(mappedFrequency);
+      const amountIndex = amounts?.one_time?.findIndex((num) => parseFloat(num) === parseFloat(qsAmount));
+      if (qsAmount) setAmount(qsAmount);
+      if (qsAmount && amountIndex === -1) {
+        // It doesn't exist in one_time, so set override.
+        setOverrideAmount(true);
+      }
+      // If the provided frequency is available, or there is no qsFrequency, use one_time
+      if (qsAmount && (!freqIsAvailable || !qsFrequency)) setFrequency('one_time');
+    },
+    [page.elements]
+  );
 
   useEffect(() => {
     const qs = queryString.parse(location.search);
     if (qs[SALESFORCE_CAMPAIGN_ID_QUERYPARAM]) setSalesforceCampaignId(qs[SALESFORCE_CAMPAIGN_ID_QUERYPARAM]);
-  }, [location.search, setSalesforceCampaignId]);
+    if (qs[AMOUNT_QUERYPARAM] || qs[FREQUENCY_QUERYPARAM]) handleIncomingAmountOrFrequency(qs);
+  }, [location.search, setSalesforceCampaignId, handleIncomingAmountOrFrequency]);
 
   return (
     <DonationPageContext.Provider
@@ -39,6 +86,8 @@ function DonationPage({ page, live = false }) {
         formRef,
         amount,
         setAmount,
+        overrideAmount,
+        setOverrideAmount,
         errors,
         setErrors,
         salesforceCampaignId
@@ -78,9 +127,15 @@ export default DonationPage;
 function getInitialFrequency(page) {
   const frequencyElement = page?.elements?.find((el) => el.type === 'DFrequency');
   if (frequencyElement) {
+    // If there's a default frequency, use it...
+    const defaultFreq = frequencyElement.content.find((freq) => freq.isDefault);
+    if (defaultFreq) return defaultFreq.value;
+
+    // ...otherwise, use the "first" in the list.
     const content = frequencyElement.content || [];
     const sortedOptions = content.sort(frequencySort);
     return sortedOptions[0]?.value || '';
   }
+  // Or, if for some reason non of these conditions are met, just return one_time
   return 'one_time';
 }

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -56,15 +56,18 @@ function DonationPage({ page, live = false }) {
       const frequencies = frequencyElement?.content?.map((f) => f.value);
       const freqIsAvailable = frequencies.includes(mappedFrequency);
 
-      if (qsFrequency && freqIsAvailable) setFrequency(mappedFrequency);
-      const amountIndex = amounts?.one_time?.findIndex((num) => parseFloat(num) === parseFloat(qsAmount));
+      // If the provided frequency is available, or there is no qsFrequency, use one_time
+      if (qsAmount && (!freqIsAvailable || !qsFrequency)) setFrequency('one_time');
+      else if (qsFrequency && freqIsAvailable) setFrequency(mappedFrequency);
+
+      const freqAmounts = amounts && amounts[mappedFrequency];
+      const amountIndex = freqAmounts?.findIndex((num) => parseFloat(num) === parseFloat(qsAmount));
+
       if (qsAmount) setAmount(qsAmount);
-      if (qsAmount && amountIndex === -1) {
+      if (qsAmount && (amountIndex === undefined || amountIndex === -1)) {
         // It doesn't exist in one_time, so set override.
         setOverrideAmount(true);
       }
-      // If the provided frequency is available, or there is no qsFrequency, use one_time
-      if (qsAmount && (!freqIsAvailable || !qsFrequency)) setFrequency('one_time');
     },
     [page.elements]
   );

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -46,12 +46,16 @@ function DAmount({ element, ...props }) {
               key={i + amnt}
               selected={parseFloat(amount) === parseFloat(amnt)}
               onClick={() => handleAmountSelected(parseFloat(amnt))}
-              data-testid={`amnt-${amnt}`}
+              data-testid={`amount-${amnt}${parseFloat(amount) === parseFloat(amnt) ? '-selected' : ''}`}
             >{`$${amnt}`}</SelectableButton>
           );
         })}
         {(element.content?.allowOther || overrideAmount) && (
-          <S.OtherAmount selected={getAmountIndex(page, amount, frequency) === -1} onClick={handleOtherSelected}>
+          <S.OtherAmount
+            data-testid={`amount-other${getAmountIndex(page, amount, frequency) === -1 ? '-selected' : ''}`}
+            selected={getAmountIndex(page, amount, frequency) === -1}
+            onClick={handleOtherSelected}
+          >
             <span>$</span>
             <S.OtherAmountInput
               ref={inputRef}
@@ -108,7 +112,7 @@ export function getAmountIndex(page, amount, frequency) {
 export function getDefaultAmount(frequency, page) {
   const amountElement = page?.elements?.find((el) => el.type === 'DAmount');
   const amounts = amountElement?.content?.options;
-  const amountsForFreq = amounts[frequency]?.map((amnt) => parseFloat(amnt));
+  const amountsForFreq = amounts ? amounts[frequency]?.map((amnt) => parseFloat(amnt)) : {};
   const defaults = amountElement?.content?.defaults;
 
   // If defaults are defined, and a default is defined for this frequency, and the default defined is a valid amount...

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import * as S from './DAmount.styled';
 
@@ -14,38 +14,23 @@ import SelectableButton from 'elements/buttons/SelectableButton';
 import FormErrors from 'elements/inputs/FormErrors';
 
 function DAmount({ element, ...props }) {
-  const { frequency, setAmount, errors } = usePage();
-
-  const [selectedAmount, setSelectedAmount] = useState(0);
-  const [otherAmount, setOtherAmount] = useState('');
+  const { page, frequency, amount, setAmount, overrideAmount, errors } = usePage();
 
   const inputRef = useRef();
 
-  const handleAmountSelected = (s) => {
-    setSelectedAmount(s);
-    // Clear "other amount" if present
-    setOtherAmount('');
+  const handleAmountSelected = (a) => {
+    setAmount(a);
   };
 
   const handleOtherSelected = () => {
-    setSelectedAmount('other');
     inputRef.current.focus();
   };
 
-  useEffect(() => {
-    let amount;
-    if (selectedAmount === 'other') {
-      amount = parseFloat(otherAmount || 0);
-    } else {
-      // It's possible options[frequency][selectedAmount] is undefined, in the case that somebody either
-      // has stale development data, or somebody has messed around with page.elements JSONField.
-      amount =
-        element?.content?.options &&
-        element.content?.options[frequency] &&
-        element.content?.options[frequency][selectedAmount];
-    }
-    setAmount(amount);
-  }, [selectedAmount, otherAmount, frequency, element?.content?.options, setAmount]);
+  const getAmounts = (frequency) => {
+    const options = element?.content?.options;
+    const amounts = options[frequency] || [];
+    return overrideAmount ? [] : amounts;
+  };
 
   return (
     <DElement
@@ -55,24 +40,24 @@ function DAmount({ element, ...props }) {
       data-testid="d-amount"
     >
       <S.DAmount>
-        {element.content?.options &&
-          element.content?.options[frequency] &&
-          element.content?.options[frequency].map((amount, i) => (
+        {getAmounts(frequency).map((amnt, i) => {
+          return (
             <SelectableButton
-              key={i + amount}
-              selected={selectedAmount === i}
-              onClick={() => handleAmountSelected(i)}
-              data-testid={`amount-${amount}`}
-            >{`$${amount}`}</SelectableButton>
-          ))}
-        {element.content?.allowOther && (
-          <S.OtherAmount selected={selectedAmount === 'other'} onClick={handleOtherSelected}>
+              key={i + amnt}
+              selected={parseFloat(amount) === parseFloat(amnt)}
+              onClick={() => handleAmountSelected(parseFloat(amnt))}
+              data-testid={`amnt-${amnt}`}
+            >{`$${amnt}`}</SelectableButton>
+          );
+        })}
+        {(element.content?.allowOther || overrideAmount) && (
+          <S.OtherAmount selected={getAmountIndex(page, amount, frequency) === -1} onClick={handleOtherSelected}>
             <span>$</span>
             <S.OtherAmountInput
               ref={inputRef}
               type="number"
-              value={otherAmount}
-              onChange={(e) => setOtherAmount(e.target.value)}
+              value={amount && getAmountIndex(page, amount, frequency) === -1 ? amount : ''}
+              onChange={(e) => setAmount(e.target.value)}
             />
             <span data-testid="custom-amount-rate">{getFrequencyRate(frequency)}</span>
           </S.OtherAmount>
@@ -86,7 +71,8 @@ function DAmount({ element, ...props }) {
 const paymentPropTypes = {
   offerPayFees: PropTypes.bool,
   allowOther: PropTypes.bool,
-  options: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))).isRequired
+  options: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))).isRequired,
+  defaults: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))
 };
 
 DAmount.propTypes = {
@@ -103,3 +89,36 @@ DAmount.required = true;
 DAmount.unique = true;
 
 export default DAmount;
+
+export function getAmountIndex(page, amount, frequency) {
+  const amountElement = page?.elements?.find((el) => el.type === 'DAmount');
+  const amounts = amountElement?.content?.options;
+  const amountsForFreq = amounts[frequency];
+
+  if (amountsForFreq) {
+    return amounts[frequency]?.findIndex((num) => parseFloat(num) === parseFloat(amount));
+  }
+}
+
+/**
+ * getDefaultAmount
+ * @param {string} frequency - The frequency to get the default for
+ * @param {object} page -
+ */
+export function getDefaultAmount(frequency, page) {
+  const amountElement = page?.elements?.find((el) => el.type === 'DAmount');
+  const amounts = amountElement?.content?.options;
+  const amountsForFreq = amounts[frequency]?.map((amnt) => parseFloat(amnt));
+  const defaults = amountElement?.content?.defaults;
+
+  // If defaults are defined, and a default is defined for this frequency, and the default defined is a valid amount...
+  if (defaults && defaults[frequency] && amountsForFreq?.includes(parseFloat(defaults[frequency]))) {
+    // ... return the default amount for this frequency.
+    return defaults[frequency];
+  }
+  // Otherwise we have any amounts for this frequency...
+  else if (amountsForFreq) {
+    // ... return the first frequency in the list.
+    return amountsForFreq[0];
+  }
+}

--- a/spa/src/components/donationPage/pageContent/DFrequency.js
+++ b/spa/src/components/donationPage/pageContent/DFrequency.js
@@ -31,7 +31,7 @@ function DFrequency({ element, ...props }) {
             value={freq.value}
             checked={frequency === freq.value}
             onChange={handleFrequencySelected}
-            data-testid={`frequency-${freq.value}`}
+            data-testid={`frequency-${freq.value}${frequency === freq.value ? '-selected' : ''}`}
           />
         ))}
       </S.DFrequency>

--- a/spa/src/components/donationPage/pageContent/DFrequency.js
+++ b/spa/src/components/donationPage/pageContent/DFrequency.js
@@ -4,12 +4,21 @@ import * as S from './DFrequency.styled';
 // Context
 import { usePage } from '../DonationPage';
 
+// Util
+import { getDefaultAmount } from 'components/donationPage/pageContent/DAmount';
+
 // Children
 import DElement, { DynamicElementPropTypes } from 'components/donationPage/pageContent/DElement';
 import FormErrors from 'elements/inputs/FormErrors';
 
 function DFrequency({ element, ...props }) {
-  const { frequency, setFrequency, errors } = usePage();
+  const { page, frequency, setFrequency, setAmount, errors, setOverrideAmount } = usePage();
+
+  const handleFrequencySelected = (_, { value }) => {
+    setAmount(getDefaultAmount(value, page));
+    setOverrideAmount(false);
+    setFrequency(value);
+  };
 
   return (
     <DElement label="Frequency" description="Choose a contribution type" {...props} data-testid="d-frequency">
@@ -21,7 +30,7 @@ function DFrequency({ element, ...props }) {
             label={freq.displayName}
             value={freq.value}
             checked={frequency === freq.value}
-            onChange={(_e, { value }) => setFrequency(value)}
+            onChange={handleFrequencySelected}
             data-testid={`frequency-${freq.value}`}
           />
         ))}

--- a/spa/src/components/donationPage/pageContent/DRichText.styled.js
+++ b/spa/src/components/donationPage/pageContent/DRichText.styled.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
-export const DRichText = styled.div``;
+export const DRichText = styled.div`
+  margin: 2rem 0;
+`;
 
 export const RichTextContent = styled.div`
   p {

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -264,9 +264,6 @@ function PageEditor() {
     data = cleanData(data);
     data = processPageData(data);
     if (CAPTURE_PAGE_SCREENSHOT) data = await addScreenshotToCleanedData(data, page.name);
-    for (const d of data.entries()) {
-      console.log(d[0], d[1]);
-    }
     requestPatchPage(
       {
         method: 'PATCH',
@@ -283,7 +280,6 @@ function PageEditor() {
           setLoading(false);
         },
         onFailure: (e) => {
-          console.log('e.response', e.response);
           if (e?.response?.data) {
             setErrors({ ...errors, ...e.response.data });
             setSelectedButton(EDIT);

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -77,8 +77,6 @@ function PageSetup({ backToProperties }) {
     }
   };
 
-  console.log('errors', errors);
-
   return (
     <S.PageSetup data-testid="page-setup">
       <S.PageName>{page.name}</S.PageName>

--- a/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.js
@@ -73,7 +73,10 @@ function AmountEditor() {
 
   return (
     <S.AmountEditor data-testid="amount-editor">
-      <S.HelpText>Highlighted amounts will be selected by default</S.HelpText>
+      <S.HelpTexts>
+        <S.HelpText>Click an amount to set a default value</S.HelpText>
+        <S.HelpText>Highlighted amounts will be selected by default on live donation pages</S.HelpText>
+      </S.HelpTexts>
       <S.FrequenciesList>
         {frequencies ? (
           frequencies.map((freq) => {

--- a/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.js
@@ -40,7 +40,8 @@ function AmountEditor() {
     setNewAmounts({ ...newAmounts, [freq]: '' });
   };
 
-  const removeAmount = ({ value: freq }, amount) => {
+  const removeAmount = (e, freq, amount) => {
+    e.stopPropagation();
     const amountsWithout = [...elementContent.options[freq].filter((a) => a !== amount)];
     if (amountsWithout.length === 0) return;
     setElementContent({
@@ -60,48 +61,70 @@ function AmountEditor() {
     }
   };
 
+  const makeAmountDefault = (freq, amount) => {
+    setElementContent({
+      ...elementContent,
+      defaults: {
+        ...(elementContent?.defaults || {}),
+        [freq]: amount
+      }
+    });
+  };
+
   return (
     <S.AmountEditor data-testid="amount-editor">
-      {frequencies ? (
-        frequencies.map((freq) => (
-          <S.FreqGroup key={freq.value}>
-            <S.FreqHeading>{freq.displayName}</S.FreqHeading>
-            <S.AmountsList>
-              {elementContent?.options[freq.value]
-                ?.sort((a, b) => a - b)
-                .map((amount, i) => (
-                  <S.AmountItem key={amount + i}>
-                    {amount}
-                    <XButton onClick={() => removeAmount(freq, amount)} />
-                  </S.AmountItem>
-                ))}
-            </S.AmountsList>
-            <S.AmountInputGroup>
-              <S.AmountInput
-                type="number"
-                value={newAmounts[freq.value] || ''}
-                onChange={(e) => setNewAmounts({ ...newAmounts, [freq.value]: e.target.value })}
-                min="0"
-                onKeyUp={(e) => handleKeyUp(e, freq)}
-                data-testid="amount-input"
-              />
-              <PlusButton onClick={() => addAmount(freq)} data-testid="add-button" />
-            </S.AmountInputGroup>
-          </S.FreqGroup>
-        ))
-      ) : (
-        <S.NoFreqs>Add a Frequency element to your page to modify donation amounts</S.NoFreqs>
-      )}
-      <S.Toggles>
-        <S.ToggleWrapper>
-          <S.Toggle
-            label='Include "other" option'
-            checked={elementContent?.allowOther}
-            onChange={toggleAllowOther}
-            toggle
-          />
-        </S.ToggleWrapper>
-      </S.Toggles>
+      <S.HelpText>Highlighted amounts will be selected by default</S.HelpText>
+      <S.FrequenciesList>
+        {frequencies ? (
+          frequencies.map((freq) => {
+            const defaults = elementContent?.defaults || {};
+            return (
+              <S.FreqGroup key={freq.value}>
+                <S.FreqHeading>{freq.displayName}</S.FreqHeading>
+                <S.AmountsList>
+                  {elementContent?.options[freq.value]
+                    ?.sort((a, b) => a - b)
+                    .map((amount, i) => {
+                      return (
+                        <S.AmountItem
+                          key={amount + i}
+                          onClick={() => makeAmountDefault(freq.value, amount)}
+                          isDefault={amountIsDefault(amount, freq.value, defaults)}
+                        >
+                          {amount}
+                          <XButton onClick={(e) => removeAmount(e, freq.value, amount)} />
+                        </S.AmountItem>
+                      );
+                    })}
+                </S.AmountsList>
+                <S.AmountInputGroup>
+                  <S.AmountInput
+                    type="number"
+                    value={newAmounts[freq.value] || ''}
+                    onChange={(e) => setNewAmounts({ ...newAmounts, [freq.value]: e.target.value })}
+                    min="0"
+                    onKeyUp={(e) => handleKeyUp(e, freq)}
+                    data-testid="amount-input"
+                  />
+                  <PlusButton onClick={() => addAmount(freq)} data-testid="add-button" />
+                </S.AmountInputGroup>
+              </S.FreqGroup>
+            );
+          })
+        ) : (
+          <S.NoFreqs>Add a Frequency element to your page to modify donation amounts</S.NoFreqs>
+        )}
+        <S.Toggles>
+          <S.ToggleWrapper>
+            <S.Toggle
+              label='Include "other" option'
+              checked={elementContent?.allowOther}
+              onChange={toggleAllowOther}
+              toggle
+            />
+          </S.ToggleWrapper>
+        </S.Toggles>
+      </S.FrequenciesList>
     </S.AmountEditor>
   );
 }
@@ -109,3 +132,8 @@ function AmountEditor() {
 AmountEditor.for = 'DAmount';
 
 export default AmountEditor;
+
+function amountIsDefault(amount, frequency, defaults) {
+  const defaultAmount = defaults[frequency];
+  if (defaultAmount) return parseFloat(amount) === parseFloat(defaultAmount);
+}

--- a/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.styled.js
+++ b/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.styled.js
@@ -4,7 +4,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { baseInputStyles } from 'elements/inputs/BaseField.styled';
 import { Radio as SemanticRadio } from 'semantic-ui-react';
 
-export const AmountEditor = styled.ul`
+import { HelpText as BaseHelpText } from 'elements/inputs/BaseField.styled';
+import lighten from 'styles/utils/lighten';
+
+export const AmountEditor = styled.div``;
+
+export const HelpText = styled(BaseHelpText)`
+  text-align: center;
+`;
+
+export const FrequenciesList = styled.ul`
   padding: 0;
   margin: 0;
   list-style: none;
@@ -43,10 +52,13 @@ export const AmountItem = styled.li`
   justify-content: space-between;
 
   border-radius: 6px;
-  background: ${(props) => props.theme.colors.fieldBackground};
+  background: ${(props) =>
+    props.isDefault ? lighten(props.theme.colors.primary, 30) : props.theme.colors.fieldBackground};
   margin: 1rem;
   font-weight: bold;
   color: ${(props) => props.theme.colors.grey[3]};
+
+  cursor: ${(props) => (props.isDefault ? 'auto' : 'pointer')};
 `;
 
 export const RemoveAmount = styled(FontAwesomeIcon)`

--- a/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.styled.js
+++ b/spa/src/components/pageEditor/elementEditors/amount/AmountEditor.styled.js
@@ -9,9 +9,11 @@ import lighten from 'styles/utils/lighten';
 
 export const AmountEditor = styled.div``;
 
-export const HelpText = styled(BaseHelpText)`
-  text-align: center;
+export const HelpTexts = styled.div`
+  margin: 2rem 3rem 2rem 6rem;
 `;
+
+export const HelpText = styled(BaseHelpText)``;
 
 export const FrequenciesList = styled.ul`
   padding: 0;

--- a/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.js
@@ -45,6 +45,7 @@ function FrequencyEditor() {
             <S.ToggleWrapper key={frequency.value}>
               <S.Toggle
                 label={`${frequency.displayName} payments enabled`}
+                data-testid="frequency-toggle"
                 toggle
                 checked={getFrequencyState(frequency.value, elementContent)}
                 onChange={(_e, { checked }) => setToggled(checked, frequency.value)}
@@ -53,6 +54,7 @@ function FrequencyEditor() {
             <S.RadioWrapper>
               <S.Radio
                 id={`${frequency.value}-default`}
+                data-testid={`frequency-default-${frequency.value}`}
                 type="checkbox"
                 color={theme.colors.primary}
                 checked={thisFreq?.isDefault}

--- a/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.js
@@ -1,4 +1,5 @@
 import * as S from './FrequencyEditor.styled';
+import { useTheme } from 'styled-components';
 // Context
 import { useEditInterfaceContext } from 'components/pageEditor/editInterface/EditInterface';
 
@@ -14,6 +15,7 @@ const NOT_ENOUGH_FREQS = `You must have at least ${MINIMUM_FREQUENCIES} frequenc
 } for your page to function properly`;
 
 function FrequencyEditor() {
+  const theme = useTheme();
   const { elementContent = [], setElementContent } = useEditInterfaceContext();
 
   const setToggled = (checked, frequency) => {
@@ -29,18 +31,38 @@ function FrequencyEditor() {
     setElementContent(content);
   };
 
+  const makeFreqDefault = (frequency) => {
+    const freqs = [...elementContent];
+    setElementContent(freqs.map((f) => ({ ...f, isDefault: f.value === frequency })));
+  };
+
   return (
     <S.FrequencyEditor data-testid="frequency-editor">
-      {FREQUENCIES.map((frequency) => (
-        <S.ToggleWrapper key={frequency.value}>
-          <S.Toggle
-            label={`${frequency.displayName} payments enabled`}
-            toggle
-            checked={getFrequencyState(frequency.value, elementContent)}
-            onChange={(_e, { checked }) => setToggled(checked, frequency.value)}
-          />
-        </S.ToggleWrapper>
-      ))}
+      {FREQUENCIES.map((frequency) => {
+        const thisFreq = elementContent.find((f) => f.value === frequency.value);
+        return (
+          <S.FieldSetWrapper>
+            <S.ToggleWrapper key={frequency.value}>
+              <S.Toggle
+                label={`${frequency.displayName} payments enabled`}
+                toggle
+                checked={getFrequencyState(frequency.value, elementContent)}
+                onChange={(_e, { checked }) => setToggled(checked, frequency.value)}
+              />
+            </S.ToggleWrapper>
+            <S.RadioWrapper>
+              <S.Radio
+                id={`${frequency.value}-default`}
+                type="checkbox"
+                color={theme.colors.primary}
+                checked={thisFreq?.isDefault}
+                onChange={() => makeFreqDefault(frequency.value)}
+              />
+              <S.RadioLabel htmlFor={`${frequency.value}-default`}>selected by default</S.RadioLabel>
+            </S.RadioWrapper>
+          </S.FieldSetWrapper>
+        );
+      })}
     </S.FrequencyEditor>
   );
 }

--- a/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.styled.js
+++ b/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.styled.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Radio as SemanticRadio } from 'semantic-ui-react';
+import MaterialCheckbox from '@material-ui/core/Checkbox';
 
 export const FrequencyEditor = styled.ul`
   padding: 0;
@@ -9,13 +10,31 @@ export const FrequencyEditor = styled.ul`
   flex-direction: column;
 `;
 
-export const ToggleWrapper = styled.li`
-  margin: 2rem 0 2rem 6rem;
-`;
+export const ToggleWrapper = styled.div``;
 
 export const Toggle = styled(SemanticRadio)`
   &.ui.toggle.checkbox input:checked ~ .box:before,
   &.ui.toggle.checkbox input:checked ~ label:before {
     background-color: ${(props) => props.theme.colors.primary} !important;
   }
+`;
+
+export const FieldSetWrapper = styled.li`
+  display: flex;
+  flex-direction: column;
+  margin: 2rem 4rem 2rem 6rem;
+`;
+
+export const RadioWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  align-self: flex-end;
+`;
+
+export const Radio = styled(MaterialCheckbox)``;
+
+export const RadioLabel = styled.label`
+  font-size: 12px;
+  font-style: italic;
 `;


### PR DESCRIPTION
#### What's this PR do?
Tickets 236, 237 and 238 are implemented on this PR. We've added the ability to select default selected amounts per frequency, default selected frequency. We're also responding to the `amount` and `frequency` query parameters as outlined in the requirements.

#### How should this be manually tested?

1. Edit a donation page.
2. Edit the Frequency element
3. Observe that you can check one or zero "default" checkboxes.
4. Edit the Amount element
5. Observe that you can click on an amount (not the X) and it will highlight, indicating that it is the default for that frequency.
6. Save your changes and visit the page live.
7. Observe that the defaults, as set above, are selected (for each frequency).
8. Next, add `amount=99` and/or `frequency=monthly` or some combination of some amount and frequency, and observe that the behavior is as expected.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No