### PR TITLE
[NRH-281] Reject-flagged showing as paid

### DIFF
--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -568,9 +568,9 @@ class ProcessFlaggedContributionTest(APITestCase):
     def test_response_when_successful_reject(self, mock_process_flagged):
         response = self._make_request(contribution_pk=self.contribution.pk, request_args={"reject": True})
         self.assertEqual(response.status_code, 200)
-        mock_process_flagged.assert_called_with(reject=True)
+        mock_process_flagged.assert_called_with(reject="True")
 
     def test_response_when_successful_accept(self, mock_process_flagged):
         response = self._make_request(contribution_pk=self.contribution.pk, request_args={"reject": False})
         self.assertEqual(response.status_code, 200)
-        mock_process_flagged.assert_called_with(reject=False)
+        mock_process_flagged.assert_called_with(reject="False")

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -222,7 +222,7 @@ def process_flagged(request, pk=None):
 
     try:
         contribution = Contribution.objects.get(pk=pk)
-        contribution.process_flagged_payment(reject=reject == "True")
+        contribution.process_flagged_payment(reject=reject)
     except Contribution.DoesNotExist:
         return Response({"detail": "Could not find contribution"}, status=status.HTTP_404_NOT_FOUND)
     except PaymentProviderError as pp_error:


### PR DESCRIPTION
#### What's this PR do?
This aims to fix a bug in which payments selected for rejection in the Org Dashboard ended up being marked as "paid".

#### How should this be manually tested?
Reject a flagged contribution by clicking on a list item that is flagged in the contributions list, scrolling down and clicking "Reject". Refresh the page to view the new status of that particular contribution. It should now say "Rejected" instead of "Paid".

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
