### PR TITLE
[NRH-287] Just do exactly what stripe says for passing on fees

### DIFF
--- a/spa/src/utilities/calculateStripeFee.js
+++ b/spa/src/utilities/calculateStripeFee.js
@@ -1,5 +1,5 @@
 const STRIPE_NP_RATE = 0.027;
-const STRIPE_FP_RATE = 0.034;
+const STRIPE_FP_RATE = 0.029;
 const STRIPE_FIXED = 0.3;
 
 function calculateStripeFee(amount, isNonProfit) {
@@ -20,12 +20,11 @@ function calculateStripeFee(amount, isNonProfit) {
   const amountInt = parseFloat(amount);
   if (isNaN(amountInt)) return null;
   const RATE = isNonProfit ? STRIPE_NP_RATE : STRIPE_FP_RATE;
-  // Get "new amount" after stripe rates are applied
-  let newAmount = (amountInt + STRIPE_FIXED) / (1 - RATE);
-  // Calculate fee based on this amount, so that organizations recieve exactly the amount intended without fees
-  const fee = newAmount.toFixed(2) * RATE + STRIPE_FIXED;
-
-  return fee.toFixed(2);
+  return roundTo2DecimalPlaces((amount + STRIPE_FIXED) / (1 - RATE));
 }
 
 export default calculateStripeFee;
+
+function roundTo2DecimalPlaces(num) {
+  return Math.round(num * 100) / 100;
+}


### PR DESCRIPTION
#### What's this PR do?
Changes calculateStripeFees to use the rates:
NP = 2.7%
FP = 2.9%
Fixed = $0.30

And changes the formula to just use exactly what stripe says we should use to pass on fees.

#### How should this be manually tested?
Make a donation with and without paying fees. You should probably do this on an org that does not report being non-profit. Stripe won't recognize any of our test orgs as being nonprofits and will always charge the for-profit rate. If you're particularly keen to test a proper non-profit org, you can[ see here ](https://stripe.com/docs/connect/testing#test-business-tax-ids)roughly what will be necessary. Once you've made the donation successfully and it has been 'paid', go to the Stripe dashboard for that org and view the transaction. Stripe will show you a breakdown of the charges. Your final take-home should be the amount you wanted to contribute.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
