### PR TITLE
[NRH-288] again, ensure rev_program exists before accessing

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -176,7 +176,12 @@ def _get_rev_program_id(payment_manager):
 
 
 def _get_rev_program_slug(payment_manager):
-    return payment_manager.revenue_program.slug
+    # revenue_program isn't necessarily availabe on payment_manager at time of
+    # instantiation
+    rev_program = payment_manager.revenue_program
+    if not rev_program:
+        rev_program = payment_manager.get_revenue_program()
+    return rev_program.slug
 
 
 class ContributionMetadata(IndexedTimeStampedModel):


### PR DESCRIPTION
#### What's this PR do?
Stomps another branch of bugs stemming from metadata data accessors.

#### How should this be manually tested?
This particular error occurred in the cron `auto_accept_flagged_contributions`, but it's likely to occur when you try to accept a flagged recurring donation.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
