### PR TITLE
Nrh 283  apply benefit level

### DIFF
--- a/spa/cypress/integration/donation-page-edit.spec.js
+++ b/spa/cypress/integration/donation-page-edit.spec.js
@@ -175,7 +175,7 @@ describe('Donation page edit', () => {
     });
   });
 
-  describe.only('Validations', () => {
+  describe('Validations', () => {
     it('should render an alert with a list of missing required elements', () => {
       const missingElementType = 'DPayment';
       const page = { ...livePage };

--- a/spa/src/components/donationPage/pageContent/DBenefits.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.js
@@ -21,7 +21,7 @@ function DBenefits({ live }) {
     if (live) return null;
     return <ElementError>No Donor Benefits configured for this page</ElementError>;
   }
-  debugger;
+
   return (
     <DElement data-testid="d-benefits">
       <S.BenefitsContent>

--- a/spa/src/components/donationPage/pageContent/DBenefits.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.js
@@ -14,40 +14,48 @@ import ElementError from 'components/donationPage/pageContent/ElementError';
 
 function DBenefits({ live }) {
   const {
-    page: { donor_benefits }
+    page: { benefit_levels }
   } = usePage();
 
-  if (!donor_benefits || donor_benefits.name === '----none----') {
+  if (!benefit_levels) {
     if (live) return null;
     return <ElementError>No Donor Benefits configured for this page</ElementError>;
   }
-
+  debugger;
   return (
     <DElement data-testid="d-benefits">
       <S.BenefitsContent>
-        <S.BenefitsName>{donor_benefits.name}</S.BenefitsName>
-        <S.TiersList>
-          {donor_benefits.tiers?.map((tier, i) => {
-            const prevTier = i !== 0 ? donor_benefits.tiers[i - 1] : 0;
+        <S.LevelsList data-testid="levels-list">
+          {benefit_levels?.map((level, i) => {
+            const prevLevel = i !== 0 ? benefit_levels[i - 1] : 0;
             return (
-              <S.Tier key={tier.name + i}>
-                <S.TierName>{tier.name}</S.TierName>
-                <S.TierDescription>{tier.description}</S.TierDescription>
-                {i !== 0 && <S.TierInclusion>Everything from {prevTier.name}, plus</S.TierInclusion>}
-                <S.TierBenefitList>
-                  {tier.benefits?.map((benefit, i) => (
-                    <S.Benefit key={benefit.name + i}>
-                      <S.BenefitCheck>
-                        <S.BenefitIcon icon={ICONS.CHECK_MARK} />
-                      </S.BenefitCheck>
-                      <S.BenefitDescription>{benefit.name}</S.BenefitDescription>
-                    </S.Benefit>
-                  ))}
-                </S.TierBenefitList>
-              </S.Tier>
+              <S.Level key={level.name + i} data-testid="level">
+                <S.BenefitLevelName>
+                  {level.name}: {level.donation_range}
+                </S.BenefitLevelName>
+                <S.LevelDescription data-testid="level-description">{level.description}</S.LevelDescription>
+                {i !== 0 && <S.LevelInclusion>Everything from {prevLevel.name}, plus</S.LevelInclusion>}
+                <S.LevelBenefitList data-testid="level-benefit-list">
+                  {level.benefits?.map((benefit, i) => {
+                    return (
+                      <S.Benefit key={benefit.name + i} data-testid="level-benefit">
+                        <S.BenefitCheck>
+                          <S.BenefitIcon icon={ICONS.CHECK_MARK} />
+                        </S.BenefitCheck>
+                        <S.BenefitDetails>
+                          <S.BenefitName>{benefit.name}</S.BenefitName>
+                          <S.BenefitDescription data-testid="level-benefit__description">
+                            {benefit.description}
+                          </S.BenefitDescription>
+                        </S.BenefitDetails>
+                      </S.Benefit>
+                    );
+                  })}
+                </S.LevelBenefitList>
+              </S.Level>
             );
           })}
-        </S.TiersList>
+        </S.LevelsList>
       </S.BenefitsContent>
     </DElement>
   );

--- a/spa/src/components/donationPage/pageContent/DBenefits.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.js
@@ -30,10 +30,10 @@ function DBenefits({ live }) {
             const prevLevel = i !== 0 ? benefit_levels[i - 1] : 0;
             return (
               <S.Level key={level.name + i} data-testid="level">
-                <S.BenefitLevelName>
-                  {level.name}: {level.donation_range}
-                </S.BenefitLevelName>
-                <S.LevelDescription data-testid="level-description">{level.description}</S.LevelDescription>
+                <S.BenefitLevelDetails>
+                  <S.LevelName>{level.name}</S.LevelName>
+                  <S.LevelRange data-testid="level-range">{level.donation_range}</S.LevelRange>
+                </S.BenefitLevelDetails>
                 {i !== 0 && <S.LevelInclusion>Everything from {prevLevel.name}, plus</S.LevelInclusion>}
                 <S.LevelBenefitList data-testid="level-benefit-list">
                   {level.benefits?.map((benefit, i) => {

--- a/spa/src/components/donationPage/pageContent/DBenefits.styled.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.styled.js
@@ -6,41 +6,36 @@ export const DBenefits = styled.aside``;
 
 export const BenefitsContent = styled.div``;
 
-export const BenefitsName = styled.h2`
+export const BenefitLevelName = styled.h2`
   font-size: ${(props) => props.theme.fontSizes[2]};
   font-weight: normal;
   padding-bottom: 1rem;
   border-bottom: 1px ${(props) => props.theme.ruleStyle || 'solid'} ${(props) => props.theme.colors.grey[1]};
 `;
 
-export const TiersList = styled.ul`
+export const LevelsList = styled.ul`
   padding: 0;
   margin: 0;
   list-style: none;
 `;
 
-export const Tier = styled.li`
-  &:not(:last-child) {
-    border-bottom: 1px ${(props) => props.theme.ruleStyle || 'solid'} ${(props) => props.theme.colors.grey[1]};
-    margin-bottom: 2rem;
-  }
-`;
+export const Level = styled.li``;
 
-export const TierName = styled.h3`
+export const LevelName = styled.h3`
   font-size: ${(props) => props.theme.fontSizes[1]};
 `;
 
-export const TierDescription = styled.p`
+export const LevelDescription = styled.p`
   font-size: ${(props) => props.theme.fontSizes[2]};
 `;
 
-export const TierInclusion = styled.p`
+export const LevelInclusion = styled.p`
   font-size: ${(props) => props.theme.fontSizes[0]};
   font-style: italic;
   margin-bottom: 2rem;
 `;
 
-export const TierBenefitList = styled.ul`
+export const LevelBenefitList = styled.ul`
   padding: 0;
   margin: 0;
   list-style: none;
@@ -49,8 +44,8 @@ export const TierBenefitList = styled.ul`
 export const Benefit = styled.li`
   display: flex;
   flex-direction: row;
-  align-items: center;
-  margin-bottom: 2rem;
+  align-items: top;
+  margin-bottom: 1rem;
 `;
 
 export const BenefitCheck = styled.i`
@@ -72,9 +67,26 @@ export const BenefitIcon = styled(SvgIcon)`
   fill: ${(props) => props.theme.colors.white};
 `;
 
+export const BenefitDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+  margin-bottom: 1rem;
+  line-height: normal;
+`;
+
+export const BenefitName = styled.h4`
+  display: inline-block;
+  margin-left: 2rem;
+  flex: 1;
+`;
+
+export const HR = styled.br``;
+
 export const BenefitDescription = styled.p`
   display: inline-block;
   margin-left: 2rem;
+  font-style: italic;
   flex: 1;
   white-space: wrap;
 `;

--- a/spa/src/components/donationPage/pageContent/DBenefits.styled.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.styled.js
@@ -6,11 +6,20 @@ export const DBenefits = styled.aside``;
 
 export const BenefitsContent = styled.div``;
 
-export const BenefitLevelName = styled.h2`
+export const BenefitLevelDetails = styled.h2`
   font-size: ${(props) => props.theme.fontSizes[2]};
   font-weight: normal;
   padding-bottom: 1rem;
   border-bottom: 1px ${(props) => props.theme.ruleStyle || 'solid'} ${(props) => props.theme.colors.grey[1]};
+  margin-bottom: 1rem;
+`;
+
+export const LevelName = styled.h3`
+  font-size: ${(props) => props.theme.fontSizes[1]};
+`;
+
+export const LevelRange = styled.p`
+  font-size: ${(props) => props.theme.fontSizes[2]};
 `;
 
 export const LevelsList = styled.ul`
@@ -20,14 +29,6 @@ export const LevelsList = styled.ul`
 `;
 
 export const Level = styled.li``;
-
-export const LevelName = styled.h3`
-  font-size: ${(props) => props.theme.fontSizes[1]};
-`;
-
-export const LevelDescription = styled.p`
-  font-size: ${(props) => props.theme.fontSizes[2]};
-`;
 
 export const LevelInclusion = styled.p`
   font-size: ${(props) => props.theme.fontSizes[0]};
@@ -80,8 +81,6 @@ export const BenefitName = styled.h4`
   margin-left: 2rem;
   flex: 1;
 `;
-
-export const HR = styled.br``;
 
 export const BenefitDescription = styled.p`
   display: inline-block;

--- a/spa/src/components/donationPage/pageContent/DBenefits.styled.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.styled.js
@@ -9,8 +9,6 @@ export const BenefitsContent = styled.div``;
 export const BenefitLevelDetails = styled.h2`
   font-size: ${(props) => props.theme.fontSizes[2]};
   font-weight: normal;
-  padding-bottom: 1rem;
-  border-bottom: 1px ${(props) => props.theme.ruleStyle || 'solid'} ${(props) => props.theme.colors.grey[1]};
   margin-bottom: 1rem;
 `;
 
@@ -28,7 +26,10 @@ export const LevelsList = styled.ul`
   list-style: none;
 `;
 
-export const Level = styled.li``;
+export const Level = styled.li`
+  border-bottom: 1px ${(props) => props.theme.ruleStyle || 'solid'} ${(props) => props.theme.colors.grey[1]};
+  padding: 2rem 0;
+`;
 
 export const LevelInclusion = styled.p`
   font-size: ${(props) => props.theme.fontSizes[0]};
@@ -46,7 +47,10 @@ export const Benefit = styled.li`
   display: flex;
   flex-direction: row;
   align-items: top;
-  margin-bottom: 1rem;
+
+  &:not(:last-child) {
+    margin-bottom: 2rem;
+  }
 `;
 
 export const BenefitCheck = styled.i`
@@ -72,7 +76,6 @@ export const BenefitDetails = styled.div`
   display: flex;
   flex-direction: column;
   align-items: left;
-  margin-bottom: 1rem;
   line-height: normal;
 `;
 

--- a/spa/src/components/donationPage/pageContent/DImage.styled.js
+++ b/spa/src/components/donationPage/pageContent/DImage.styled.js
@@ -4,4 +4,5 @@ export const DImage = styled.div``;
 
 export const Image = styled.img`
   height: auto;
+  max-width: 100%;
 `;

--- a/spa/src/components/donationPage/pageContent/DImage.styled.js
+++ b/spa/src/components/donationPage/pageContent/DImage.styled.js
@@ -3,6 +3,5 @@ import styled from 'styled-components';
 export const DImage = styled.div``;
 
 export const Image = styled.img`
-  width: 100%;
   height: auto;
 `;

--- a/spa/src/components/donationPage/pageContent/DRichText.styled.js
+++ b/spa/src/components/donationPage/pageContent/DRichText.styled.js
@@ -15,7 +15,6 @@ export const RichTextContent = styled.div`
     padding: 0.5rem 0 0.5rem 1rem;
     border-left: 6px solid ${(props) => props.theme.colors.grey[0]};
     line-height: 1.6;
-
     font-weight: 200;
   }
 `;

--- a/spa/src/components/donationPage/pageContent/dynamicSidebarElements.js
+++ b/spa/src/components/donationPage/pageContent/dynamicSidebarElements.js
@@ -1,4 +1,3 @@
 export { default as DRichText } from './DRichText';
 export { default as DImage } from './DImage';
-// TODO: Enable once Benefit refactor is complete
-// export { default as DBenefits } from './DBenefits';
+export { default as DBenefits } from './DBenefits';


### PR DESCRIPTION
#### What's this PR do?
This PR make it so a hub admin can add the Benefits block for a revenue program to the sidebar of the page.

#### How should this be manually tested?
1. Create some Benefits `admin/organizations/benefit/`
2. Create  a/some Benefit Level(s) `admin/organizations/benefitlevel/`
3. Add the Benefits you created to the Benefit Level
4. Add the Benefit Level(s) you created to a Revenue Program.
5. Navigate a Page that is attached to that Revenue Program.
6. Open the Sidebar editor
7. Click the add button
8. Select the Donor Benefits Element.

Note: The order the Benefit Levels appear on the page right now only makes sense if the levels are ordered from least to most inclusive (i.e., Bronze is ordered before Silver and Silver's benefits include everything in Bronze plus the added silver benefits)

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No.
