### PR TITLE
[NRH-269] Update fees stuff

### DIFF
--- a/spa/cypress/integration/donation-page.spec.js
+++ b/spa/cypress/integration/donation-page.spec.js
@@ -110,8 +110,8 @@ describe('Donation page', () => {
     });
 
     it('should select agreeToPayFees by default if appropriate page property is set', () => {
-      const page = livePageOne;
-      const paymentIndex = livePageOne.elements.findIndex((el) => el.type === 'DPayment');
+      const page = { ...livePageOne };
+      const paymentIndex = page.elements.findIndex((el) => el.type === 'DPayment');
       page.elements[paymentIndex].content.payFeesDefault = true;
       cy.intercept({ method: 'GET', pathname: getEndpoint(FULL_PAGE) }, { body: page, statusCode: 200 }).as(
         'getPageWithPayFeesDefault'
@@ -130,7 +130,11 @@ describe('Donation page', () => {
       cy.intercept(
         { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
         { fixture: 'pages/live-page-1', statusCode: 200 }
-      );
+      ).as('getPage');
+
+      cy.visit('/rev-program-slug');
+      cy.url().should('include', 'rev-program-slug');
+      cy.wait('@getPage');
 
       const interval = 'One time';
       const amount = '120';
@@ -139,11 +143,16 @@ describe('Donation page', () => {
       cy.makeDonation();
       cy.wait('@stripePayment').its('request.body').should('have.property', 'interval', 'one_time');
     });
+
     it('should send a request with the expected amount', () => {
       cy.intercept(
         { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
         { fixture: 'pages/live-page-1', statusCode: 200 }
-      );
+      ).as('getPage');
+
+      cy.visit('/rev-program-slug');
+      cy.url().should('include', 'rev-program-slug');
+      cy.wait('@getPage');
 
       const interval = 'One time';
       const amount = '120';
@@ -311,15 +320,22 @@ describe('Donation page', () => {
     });
 
     it('should show different content based on the selected amount and frequency', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/live-page-1', statusCode: 200 }
+      ).as('getPage');
+      cy.visit('/revenue-program-slug/page-slug-3');
+      cy.url().should('include', 'revenue-program-slug/page-slug-3');
+      cy.wait('@getPage');
       const targetAmount = 15;
       // if frequency is recurring, show additional agreement statement...
-      cy.getByTestId(`frequency-month`).click();
+      cy.getByTestId('frequency-month').click();
       cy.getByTestId(`amount-${targetAmount}`).click();
       const expectedText = `payments of $${targetAmount}, to be processed on or adjacent to the ${new Date().getDate()}`;
       cy.getByTestId('donation-page-static-text').contains(expectedText).should('exist');
 
       // ... but if it's one-time, don't
-      cy.getByTestId(`frequency-one_time`).click();
+      cy.getByTestId('frequency-one_time').click();
       cy.getByTestId('donation-page-static-text').contains(expectedText).should('not.exist');
     });
   });

--- a/spa/cypress/integration/donation-page.spec.js
+++ b/spa/cypress/integration/donation-page.spec.js
@@ -49,7 +49,7 @@ describe('Donation page', () => {
     });
   });
 
-  describe('DonationPage elements', () => {
+  describe.only('DonationPage elements', () => {
     it('should render expected rich text content', () => {
       cy.visitDonationPage();
 
@@ -107,6 +107,21 @@ describe('Donation page', () => {
           cy.getByTestId('pay-fees').scrollIntoView().find('label').contains(calculatedFee);
         });
       });
+    });
+
+    it('should select agreeToPayFees by default if appropriate page property is set', () => {
+      const page = livePageOne;
+      const paymentIndex = livePageOne.elements.findIndex((el) => el.type === 'DPayment');
+      page.elements[paymentIndex].content.payFeesDefault = true;
+      cy.intercept({ method: 'GET', pathname: getEndpoint(FULL_PAGE) }, { body: page, statusCode: 200 }).as(
+        'getPageWithPayFeesDefault'
+      );
+      cy.visit('/revenue-program-slug/page-slug');
+      cy.url().should('include', '/revenue-program-slug/page-slug');
+      cy.wait('@getPageWithPayFeesDefault');
+
+      cy.getByTestId('pay-fees-checked').should('exist');
+      cy.getByTestId('pay-fees-not-checked').should('not.exist');
     });
   });
 

--- a/spa/cypress/integration/donation-page.spec.js
+++ b/spa/cypress/integration/donation-page.spec.js
@@ -49,7 +49,7 @@ describe('Donation page', () => {
     });
   });
 
-  describe.only('DonationPage elements', () => {
+  describe('DonationPage elements', () => {
     it('should render expected rich text content', () => {
       cy.visitDonationPage();
 
@@ -103,7 +103,7 @@ describe('Donation page', () => {
         cy.contains(freq.displayName).click();
         amounts.content.options[freq.value].forEach((amount) => {
           cy.contains(amount).click();
-          const calculatedFee = calculateStripeFee(amount, true, true);
+          const calculatedFee = calculateStripeFee(amount, freq.value, true);
           cy.getByTestId('pay-fees').scrollIntoView().find('label').contains(calculatedFee);
         });
       });

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -25,6 +25,7 @@ Cypress.Commands.add('visitDonationPage', () => {
     { fixture: 'pages/live-page-1', statusCode: 200 }
   ).as('getPageDetail');
   cy.visit('/revenue-program-slug/page-slug');
+  cy.url().should('include', '/revenue-program-slug/page-slug');
   cy.wait('@getPageDetail');
 });
 

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -35,7 +35,7 @@ function DonationPage({ page, live = false }) {
   const location = useLocation();
   const formRef = useRef();
   const [frequency, setFrequency] = useState(getInitialFrequency(page));
-  const [payFee, setPayFee] = useState(false);
+  const [payFee, setPayFee] = useState(getInitialPayFees(page));
   const [amount, setAmount] = useState(getDefaultAmount(frequency, page));
 
   // overrideAmount causes only the custom amount to show (initially)
@@ -150,4 +150,16 @@ function getInitialFrequency(page) {
   }
   // Or, if for some reason non of these conditions are met, just return one_time
   return 'one_time';
+}
+
+function getInitialPayFees(page) {
+  const paymentElement = page?.elements?.find((el) => el.type === 'DPayment');
+  const payFeesDefault = paymentElement?.content?.payFeesDefault;
+  // If payFeesDefault is true or false...
+  if (payFeesDefault === true || payFeesDefault === false) {
+    // ...initial value should be payFeesDefault...
+    return payFeesDefault;
+  }
+  // ...else, default to false
+  return false;
 }

--- a/spa/src/components/donationPage/DonationPageStaticText.js
+++ b/spa/src/components/donationPage/DonationPageStaticText.js
@@ -24,6 +24,7 @@ function DonationPageStaticText({ page, amount, payFee, frequency }) {
           `Additionally, by proceeding with this transaction, you're authorizing today's payment, along with all future recurring payments of $${getTotalAmount(
             amount,
             payFee,
+            frequency,
             page.organization_is_nonprofit
           )}, to be processed on or adjacent to the ${format(new Date(), 'do')} of the month until you cancel.`}
       </p>

--- a/spa/src/components/donationPage/pageContent/DPayment.js
+++ b/spa/src/components/donationPage/pageContent/DPayment.js
@@ -27,7 +27,10 @@ function DPayment({ element, live, ...props }) {
       {live ? (
         <S.DPayment>
           {element?.content && element.content['stripe'] && (
-            <StripePayment offerPayFees={element.content?.offerPayFees} />
+            <StripePayment
+              offerPayFees={element.content?.offerPayFees}
+              payFeesDefault={element.content?.payFeesDefault}
+            />
           )}
         </S.DPayment>
       ) : (
@@ -68,6 +71,7 @@ export function PayFeesWidget() {
         toggle
         checked={payFee}
         onChange={(_e, { checked }) => setPayFee(checked)}
+        data-testid={`pay-fees-${payFee ? 'checked' : 'not-checked'}`}
       />
       <S.PayFeesDescription>
         Paying the Stripe transaction fee, while not required, directs more money in support of our mission.

--- a/spa/src/components/donationPage/pageContent/DPayment.js
+++ b/spa/src/components/donationPage/pageContent/DPayment.js
@@ -65,7 +65,9 @@ export function PayFeesWidget() {
       <S.Checkbox
         label={
           amount
-            ? `$${calculateStripeFee(amount, page.organization_is_nonprofit)} ${getFrequencyAdverb(frequency)}`
+            ? `$${calculateStripeFee(amount, frequency, page.organization_is_nonprofit)} ${getFrequencyAdverb(
+                frequency
+              )}`
             : ''
         }
         toggle

--- a/spa/src/components/pageEditor/elementEditors/payment/PaymentEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/payment/PaymentEditor.js
@@ -1,4 +1,5 @@
 import * as S from './PaymentEditor.styled';
+import { useTheme } from 'styled-components';
 
 import { useEditInterfaceContext } from 'components/pageEditor/editInterface/EditInterface';
 
@@ -11,6 +12,7 @@ const STRIPE_PAYMENT_METHODS = [
 const NOT_ENOUGH_PAYMENT_METHODS = 'You must enable at least one payment method';
 
 function PaymentEditor() {
+  const theme = useTheme();
   const { elementContent, setElementContent } = useEditInterfaceContext();
 
   const setToggled = (checked, method, provider) => {
@@ -30,6 +32,11 @@ function PaymentEditor() {
   const toggleOfferPayFees = (_, { checked }) => {
     const offerPayFees = checked;
     setElementContent({ ...elementContent, offerPayFees });
+  };
+
+  const togglePayFeesDefault = (_, checked) => {
+    const payFeesDefault = checked;
+    setElementContent({ ...elementContent, payFeesDefault });
   };
 
   return (
@@ -55,6 +62,17 @@ function PaymentEditor() {
             toggle
           />
         </S.ToggleWrapper>
+        <S.RadioWrapper>
+          <S.Radio
+            id="pay-fees-by-default"
+            data-testid="pay-fees-by-default"
+            type="checkbox"
+            color={theme.colors.primary}
+            checked={elementContent?.payFeesDefault}
+            onChange={togglePayFeesDefault}
+          />
+          <S.RadioLabel htmlFor="pay-fees-by-default">selected by default</S.RadioLabel>
+        </S.RadioWrapper>
       </S.OtherOptionsList>
     </S.PaymentEditor>
   );

--- a/spa/src/components/pageEditor/elementEditors/payment/PaymentEditor.styled.js
+++ b/spa/src/components/pageEditor/elementEditors/payment/PaymentEditor.styled.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Radio as SemanticRadio } from 'semantic-ui-react';
+import MaterialCheckbox from '@material-ui/core/Checkbox';
 
 export const PaymentEditor = styled.div``;
 
@@ -24,4 +25,18 @@ export const Toggle = styled(SemanticRadio)`
 
 export const OtherOptionsList = styled(PaymentTypesList)`
   border-top: 1px solid ${(props) => props.theme.colors.grey[1]};
+`;
+
+export const RadioWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  align-self: flex-end;
+`;
+
+export const Radio = styled(MaterialCheckbox)``;
+
+export const RadioLabel = styled.label`
+  font-size: 12px;
+  font-style: italic;
 `;

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -98,7 +98,14 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
     e.preventDefault();
     setLoading(true);
     const orgIsNonProfit = page.organization_is_nonprofit;
-    const data = serializeData(formRef.current, { amount, payFee, orgIsNonProfit, salesforceCampaignId, ...params });
+    const data = serializeData(formRef.current, {
+      amount,
+      payFee,
+      orgIsNonProfit,
+      frequency,
+      salesforceCampaignId,
+      ...params
+    });
     await submitPayment(
       stripe,
       data,
@@ -114,7 +121,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const handlePaymentRequestSubmit = async (state, paymentRequest) => {
     setLoading(true);
     const orgIsNonProfit = page.organization_is_nonprofit;
-    const data = serializeData(formRef.current, { orgIsNonProfit, salesforceCampaignId, ...state });
+    const data = serializeData(formRef.current, { orgIsNonProfit, frequency, salesforceCampaignId, ...state });
     await submitPayment(
       stripe,
       data,
@@ -134,7 +141,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
    */
   useEffect(() => {
     const orgIsNonProfit = page.organization_is_nonprofit;
-    const amnt = amountToCents(getTotalAmount(amount, payFee, orgIsNonProfit));
+    const amnt = amountToCents(getTotalAmount(amount, payFee, frequency, orgIsNonProfit));
     const amountIsValid = !isNaN(amnt) && amnt > 0;
     if (stripe && amountIsValid && !paymentRequest) {
       const pr = stripe.paymentRequest({
@@ -178,7 +185,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
    */
   useEffect(() => {
     const orgIsNonProfit = page.organization_is_nonprofit;
-    const amnt = amountToCents(getTotalAmount(amount, payFee, orgIsNonProfit));
+    const amnt = amountToCents(getTotalAmount(amount, payFee, frequency, orgIsNonProfit));
     const amountIsValid = !isNaN(amnt) && amnt > 0;
     if (paymentRequest && amountIsValid) {
       paymentRequest.update({
@@ -188,12 +195,13 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
         }
       });
     }
-  }, [amount, payFee, paymentRequest]);
+  }, [amount, payFee, paymentRequest, frequency]);
 
   // We add a catch here for the times when the ad-hoc donation amount ("other") value
   // is not a valid number (e.g. first clicking on the element, or typing a decimal "0.5")
-  if (isNaN(amount) || amount < 1)
+  if (isNaN(amount) || amount < 1) {
     return <S.EnterValidAmount>Please enter an amount of at least $1</S.EnterValidAmount>;
+  }
   return !forceManualCard && paymentRequest ? (
     <>
       <S.PaymentRequestWrapper>
@@ -220,7 +228,8 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
         loading={loading}
         data-testid="donation-submit"
       >
-        Give ${getTotalAmount(amount, payFee, page.organization_is_nonprofit)} {getFrequencyAdverb(frequency)}
+        Give ${getTotalAmount(amount, payFee, frequency, page.organization_is_nonprofit)}{' '}
+        {getFrequencyAdverb(frequency)}
       </Button>
 
       <S.IconWrapper>

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -46,14 +46,16 @@ export default submitPayment;
  * @param {number} amount - float or integer, human-readable amount to be donated
  * @param {number} fee - the fee to include, if shouldPayFee
  * @param {boolean} shouldPayFee - whether or not to include the fee in the total value
+ * @param {string} frequency - The donation interval (ie 'one_time', 'monthly', etc). Used to determine stripe fee
+ * @param {boolean} orgIsNonProfit - whether or not the org reports as non-profit. Used to determine stripe fee
  * @returns A human readable amount in dollars
  */
-export function getTotalAmount(amount, shouldPayFee, orgIsNonProfit) {
+export function getTotalAmount(amount, shouldPayFee, frequency, orgIsNonProfit) {
   /*
     If we get 10, we should see 10. If we get 10.3, we should see 10.30.
   */
   let total = parseFloat(amount);
-  if (shouldPayFee) total += parseFloat(calculateStripeFee(amount, orgIsNonProfit));
+  if (shouldPayFee) total += parseFloat(calculateStripeFee(amount, frequency, orgIsNonProfit));
   total = total.toFixed(2);
   if (total.endsWith('.00')) total = total.substring(0, total.length - 3);
   return total;
@@ -96,7 +98,12 @@ function serializeForm(form) {
  */
 export function serializeData(formRef, state) {
   const serializedData = serializeForm(formRef);
-  serializedData['amount'] = getTotalAmount(state.amount, state.payFee, state.orgIsNonProfit).toString();
+  serializedData['amount'] = getTotalAmount(
+    state.amount,
+    state.payFee,
+    state.frequency,
+    state.orgIsNonProfit
+  ).toString();
   serializedData['revenue_program_slug'] = state.revProgramSlug;
   serializedData['donation_page_slug'] = state.pageSlug;
   serializedData['sf_campaign_id'] = state.salesforceCampaignId;

--- a/spa/src/utilities/calculateStripeFee.js
+++ b/spa/src/utilities/calculateStripeFee.js
@@ -1,8 +1,9 @@
-const STRIPE_NP_RATE = 0.027;
+const STRIPE_NP_RATE = 0.022;
 const STRIPE_FP_RATE = 0.029;
 const STRIPE_FIXED = 0.3;
+const SUBSCRIPTION_UPCHARGE = 0.005;
 
-function calculateStripeFee(amount, isNonProfit) {
+function calculateStripeFee(amount, interval, isNonProfit) {
   /*
     Stripe calculates a fee based on a rate and a flat fee. We must apply the flat fee first,
     then apply the rate to amount + flat fee.
@@ -17,9 +18,14 @@ function calculateStripeFee(amount, isNonProfit) {
 
     NOTE: We are not including any VAT or GST, or any other taxes here, since these are donations.
   */
+
   const amountInt = parseFloat(amount);
   if (isNaN(amountInt)) return null;
-  const RATE = isNonProfit ? STRIPE_NP_RATE : STRIPE_FP_RATE;
+  const isRecurring = interval !== 'one_time';
+  let RATE = isNonProfit ? STRIPE_NP_RATE : STRIPE_FP_RATE;
+
+  if (isRecurring) RATE += SUBSCRIPTION_UPCHARGE;
+
   const amountWithFee = roundTo2DecimalPlaces((amountInt + STRIPE_FIXED) / (1 - RATE));
   return roundTo2DecimalPlaces(amountWithFee - amountInt);
 }

--- a/spa/src/utilities/calculateStripeFee.js
+++ b/spa/src/utilities/calculateStripeFee.js
@@ -21,10 +21,10 @@ function calculateStripeFee(amount, interval, isNonProfit) {
 
   const amountInt = parseFloat(amount);
   if (isNaN(amountInt)) return null;
-  const isRecurring = interval !== 'one_time';
+  // const isRecurring = interval !== 'one_time';
   let RATE = isNonProfit ? STRIPE_NP_RATE : STRIPE_FP_RATE;
 
-  if (isRecurring) RATE += SUBSCRIPTION_UPCHARGE;
+  // if (isRecurring) RATE += SUBSCRIPTION_UPCHARGE;
 
   const amountWithFee = roundTo2DecimalPlaces((amountInt + STRIPE_FIXED) / (1 - RATE));
   return roundTo2DecimalPlaces(amountWithFee - amountInt);


### PR DESCRIPTION
#### What's this PR do?
First of all, this PR adds the ability to select whether or not "Pay fees" comes pre-selected.
Second, this PR adds the code to add a 0.5% upcharge for subscription fees. As per the discussion in this basecamp post, we've commented out the final piece of this code so that it does not take effect. We'll rip it out or uncomment it later depending.

#### How should this be manually tested?
For now, just check the "selected by default" toggle in the Payment editor beneath "Offer pay fees".  Observe that the live page has the Pay fees bit checked by default.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No