### PR TITLE
refs #NRH-301 Metadata with ALL and no default picked up.

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -279,7 +279,7 @@ class ContributionMetadata(IndexedTimeStampedModel):
                 collected.update({obj.key: supplied[obj.key]})
                 continue
         for obj in meta_for_all:
-            collected.update({obj.key: obj.default_value})
+            collected.update({obj.key: supplied.get(obj.key, obj.default_value)})
         final = {k: v for k, v in collected.items() if v is not None}
         return final
 

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -132,6 +132,7 @@ class ContributionMetadataTest(TestCase):
         "honoree": "MeMe",
         "test_2": "I love a good test",
         "default_1": "Default",
+        "fe_supplied_all": "abc-123",
     }
 
     def setUp(self):
@@ -144,6 +145,12 @@ class ContributionMetadataTest(TestCase):
             processor_object=ContributionMetadata.ProcessorObjects.ALL,
         )
         self.cm4 = ContributionMetadataFactory(key="default_1", label="Test 4", donor_supplied=True)
+        self.cm5 = ContributionMetadataFactory(
+            key="fe_supplied_all",
+            label="fe_supplied_all",
+            donor_supplied=False,
+            processor_object=ContributionMetadata.ProcessorObjects.ALL,
+        )
 
     def test_label(self):
         assert str(self.cm1) == self.cm1.label
@@ -157,6 +164,8 @@ class ContributionMetadataTest(TestCase):
 
         with self.subTest("Meta with all is present"):
             assert results.get("req_1", "Required")
+            # This should not be empty even though default is empty
+            assert results.get("fe_supplied_all", "abc-123")
 
         with self.subTest("Default value is present"):
             assert results.get("default_1", "") == "Default"


### PR DESCRIPTION
#### What's this PR do?
This PR fixes a bug where ContributionMetadata with the following properties:

1. Processor type of ALL
2. No Default
3. Value supplied via the Front end in a query param

was not being included in the metadata sent to stripe.

#### How should this be manually tested?
1. Add a ContributionMetadata object in the admin with the key (`sf_campaign_id`)
2. No default value
3. Go to a live donation page
4. Add the query param `?campaign=abc-123`
5. Make the donation.
6. Find the Payment, Subscription or Customer on stripe and the Metadata section should contain `sf_campaign_id = abc-123`

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
