### PR TITLE
[NRH-312] Amount "other" weirdness

### DIFF
--- a/spa/src/components/analytics/HubTrackedPage.js
+++ b/spa/src/components/analytics/HubTrackedPage.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLocation, Route } from 'react-router';
+import { useLocation } from 'react-router';
 
 import Analytics from 'analytics';
 import { HUB_ANALYTICS_APP_NAME, HUB_GA_V3_ID, HUB_GA_V3_PLUGIN_NAME } from 'constants/analyticsConstants';

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -67,7 +67,7 @@ function DonationPage({ page, live = false }) {
       if (qsAmount && (!freqIsAvailable || !qsFrequency)) setFrequency('one_time');
       else if (qsFrequency && freqIsAvailable) setFrequency(mappedFrequency);
 
-      const freqAmounts = amounts && amounts[mappedFrequency];
+      const freqAmounts = amounts && amounts[mappedFrequency || 'one_time'];
       const amountIndex = freqAmounts?.findIndex((num) => parseFloat(num) === parseFloat(qsAmount));
 
       if (qsAmount) setAmount(qsAmount);

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import * as S from './DAmount.styled';
 
@@ -15,6 +15,7 @@ import FormErrors from 'elements/inputs/FormErrors';
 
 function DAmount({ element, ...props }) {
   const { page, frequency, amount, setAmount, overrideAmount, errors } = usePage();
+  const [otherFocused, setOtherFocused] = useState(false);
 
   const inputRef = useRef();
 
@@ -23,7 +24,13 @@ function DAmount({ element, ...props }) {
   };
 
   const handleOtherSelected = () => {
+    setAmount('');
+    setOtherFocused(true);
     inputRef.current.focus();
+  };
+
+  const handleOtherBlurred = () => {
+    setOtherFocused(false);
   };
 
   const getAmounts = (frequency) => {
@@ -34,6 +41,10 @@ function DAmount({ element, ...props }) {
     }
     return [];
   };
+
+  const amountIsPreset = useMemo(() => {
+    return getAmountIndex(page, amount, frequency) !== -1;
+  }, [page, amount, frequency]);
 
   return (
     <DElement
@@ -47,7 +58,7 @@ function DAmount({ element, ...props }) {
           return (
             <SelectableButton
               key={i + amnt}
-              selected={parseFloat(amount) === parseFloat(amnt)}
+              selected={parseFloat(amount) === parseFloat(amnt) && !otherFocused}
               onClick={() => handleAmountSelected(parseFloat(amnt))}
               data-testid={`amount-${amnt}${parseFloat(amount) === parseFloat(amnt) ? '-selected' : ''}`}
             >{`$${amnt}`}</SelectableButton>
@@ -55,16 +66,17 @@ function DAmount({ element, ...props }) {
         })}
         {(element.content?.allowOther || overrideAmount) && (
           <S.OtherAmount
-            data-testid={`amount-other${getAmountIndex(page, amount, frequency) === -1 ? '-selected' : ''}`}
-            selected={getAmountIndex(page, amount, frequency) === -1}
+            data-testid={`amount-other${otherFocused ? '-selected' : ''}`}
+            selected={otherFocused}
             onClick={handleOtherSelected}
           >
             <span>$</span>
             <S.OtherAmountInput
               ref={inputRef}
               type="number"
-              value={amount && getAmountIndex(page, amount, frequency) === -1 ? amount : ''}
+              value={otherFocused || !amountIsPreset ? amount : ''}
               onChange={(e) => setAmount(e.target.value)}
+              onBlur={handleOtherBlurred}
             />
             <span data-testid="custom-amount-rate">{getFrequencyRate(frequency)}</span>
           </S.OtherAmount>

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -66,7 +66,7 @@ function DAmount({ element, ...props }) {
         })}
         {(element.content?.allowOther || overrideAmount) && (
           <S.OtherAmount
-            data-testid={`amount-other${otherFocused ? '-selected' : ''}`}
+            data-testid={`amount-other${otherFocused || !amountIsPreset ? '-selected' : ''}`}
             selected={otherFocused}
             onClick={handleOtherSelected}
           >

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -15,7 +15,6 @@ import { isBefore, isAfter } from 'date-fns';
 // Children
 import ImageWithPreview from 'elements/inputs/ImageWithPreview';
 import Input from 'elements/inputs/Input';
-import BenefitsWidget from './BenefitsWidget';
 import PublishWidget from './PublishWidget';
 import CircleButton from 'elements/buttons/CircleButton';
 

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -69,7 +69,9 @@ export function getTotalAmount(amount, shouldPayFee, frequency, orgIsNonProfit) 
 export const amountToCents = (amount) => {
   if (isNaN(amount)) return null;
   const cents = amount * 100;
-  return cents;
+  // amount * 100 above can results in something like 26616.000000000004.
+  // We just round to an integer here.
+  return Math.round(cents);
 };
 
 function serializeForm(form) {


### PR DESCRIPTION
#### What's this PR do?
Bugfix. To reproduce original bug:
Say you've got a page with a static donation option of $10. Try to type "100" in to the "Other" section, and noticed that the focus gets "stolen" by the $10 bit before you can type the second "0". 

This PR fixes that.

#### How should this be manually tested?
Do the above and observe that the focus is no longer stolen.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No