### PR TITLE
[NRH-307] Inconsistent treatment input block headings

### DIFF
--- a/spa/src/components/donationPage/pageContent/DDonorInfo.js
+++ b/spa/src/components/donationPage/pageContent/DDonorInfo.js
@@ -16,45 +16,43 @@ function DDonorInfo(props) {
   const [email, setEmail] = useState('');
 
   return (
-    <>
-      <DElement label="Name" {...props} data-testid="d-donor-info">
-        <Grid container spacing={3}>
-          <Grid item xs={12} md={6}>
-            <Input
-              type="text"
-              name="first_name"
-              label="First name"
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
-              errors={errors.first_name}
-              required
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <Input
-              type="text"
-              name="last_name"
-              label="Last name"
-              value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
-              errors={errors.last_name}
-              required
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <Input
-              type="email"
-              name="email"
-              label="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              errors={errors.email}
-              required
-            />
-          </Grid>
+    <DElement {...props} data-testid="d-donor-info">
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <Input
+            type="text"
+            name="first_name"
+            label="First name"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            errors={errors.first_name}
+            required
+          />
         </Grid>
-      </DElement>
-    </>
+        <Grid item xs={12} md={6}>
+          <Input
+            type="text"
+            name="last_name"
+            label="Last name"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            errors={errors.last_name}
+            required
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Input
+            type="email"
+            name="email"
+            label="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            errors={errors.email}
+            required
+          />
+        </Grid>
+      </Grid>
+    </DElement>
   );
 }
 


### PR DESCRIPTION
#### What's this PR do?
We noticed that the "Donor info" block had a heading of "Name" which was both wrong, and inconsistent with the "Donor address" block (another input-type block) not having a heading at all. We decided to remove the "Name" heading. This PR does that.

#### How should this be manually tested?
Create or view a page that has both a donor info and a donor address block. Observe that neither block has a heading.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No