### PR TITLE
[NRH-170] "Must be user instance" Sentry error

### DIFF
--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 
 class ReadOnly(permissions.BasePermission):
-    def has_object_permission(self, request, view, obj):
+    def has_object_permission(self, request, *args):
         # Read permissions are allowed to any request,
         # so we'll always allow GET, HEAD or OPTIONS requests.
         if request.method in permissions.SAFE_METHODS:

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -30,10 +30,17 @@ class OrganizationLimitedListView:
     model = None
 
     def get_queryset(self):
+        """
+        Filters querysets such that only instances belonging to the logged in user's organization are returned.
+        """
         if isinstance(self, Organization):
             return self.model.objects.filter(pk=self.id)
 
-        if isinstance(self.request.user, user_model) and self.action == "list" and hasattr(self.model, "organization"):
+        # Ensure the user in question is a User, not a Contributor
+        is_org_user = isinstance(self.request.user, user_model)
+        # Ensure the model in question has a relationship to Organization
+        model_has_org_rel = hasattr(self.model, "organization")
+        if is_org_user and model_has_org_rel and self.action == "list":
             return self.model.objects.filter(organization__users=self.request.user)
         return self.model.objects.all()
 

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
@@ -11,6 +12,8 @@ from apps.api.permissions import UserBelongsToOrg
 from apps.organizations import serializers
 from apps.organizations.models import Feature, Organization, Plan, RevenueProgram
 
+
+user_model = get_user_model()
 
 logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
@@ -30,7 +33,7 @@ class OrganizationLimitedListView:
         if isinstance(self, Organization):
             return self.model.objects.filter(pk=self.id)
 
-        if self.action == "list" and hasattr(self.model, "organization"):
+        if isinstance(self.request.user, user_model) and self.action == "list" and hasattr(self.model, "organization"):
             return self.model.objects.filter(organization__users=self.request.user)
         return self.model.objects.all()
 


### PR DESCRIPTION
#### What's this PR do?
We've occasionally received a sentry error, `Cannot query "<some email address here>": Must be "User" instance.`. It doesn't seem to break anything, but as it appears to be related to authentication/permissions, it seemed like a good idea to sort it out. It looks like there was a `get_queryset` method being used to limit results to authorized users, but that was failing to check that the user type was "User" and not "Contributor". This error will have occurred after somebody has logged in to the contributor dashboard via magic link, then attempted to access a resource from the either Django admin, or the org dashboard. The does not appear to be a security issue here, just a non-breaking error.  This PR just adds a check to the `get_queryset` method for usertype.

#### How should this be manually tested?
This bug isn't super easy to reproduce. Some magic combination of authenticating with contributor magic link and then trying to view orgs in django admin or some such...? Add to that the fact that this error does surface to the user and I would recommend against trying to test this one. If we get this sentry error again, we'll know something else is going on.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No