### PR TITLE
[NRH-204] Page edit, published date datepicker nav missing on Safari

### DIFF
--- a/spa/src/components/pageEditor/editInterface/pageSetup/PublishWidget.styled.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PublishWidget.styled.js
@@ -3,9 +3,15 @@ import { baseInputStyles } from 'elements/inputs/BaseField.styled';
 
 export const PublishWidget = styled.div`
   width: 100%;
+
   .react-datepicker-wrapper {
     display: block;
   }
+
+  .react-datepicker__navigation-icon {
+    width: 0;
+  }
+
   padding: 2rem 0;
   border-bottom: 1px solid;
   border-color: ${(props) => props.theme.colors.grey[0]};


### PR DESCRIPTION
#### What's this PR do?
On Safari, the prev and next buttons for moving between months in the published_date widget were missing.
I won't go in to too much detail as to why, suffice it to say that Safari treats <span> elements with relative positioning inside buttons as something like block level elements, whereas Chrome and other browsers treat them as 0-width inline elements. Setting the width to 0 explicitly fixes this bug.

#### How should this be manually tested?
Using Safari go to page edit, setup tab, scroll down to published date and click the datepicker. Notice that the left and right arrows to move between months are visible.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
