### PR TITLE
[NRH] Improve Stripe InvalidRequestError message

### DIFF
--- a/apps/contributions/payment_managers.py
+++ b/apps/contributions/payment_managers.py
@@ -343,7 +343,11 @@ class StripePaymentManager(PaymentManager):
             self.contribution.status = previous_status
             self.contribution.save()
             logger.warning(
-                f"Stripe returned an InvalidRequestError at {timezone.now()}. This was caused by attempting to {'reject' if reject else 'capture'} a payment that was flagged in our system, but was already captured or rejected in Stripe's system.",
+                (
+                    f"Stripe returned an InvalidRequestError at {timezone.now()}. This was caused by attempting to {'reject' if reject else 'capture'} a payment that was flagged in our system, but was already captured or rejected in Stripe's system.\n"
+                    f"This occured for Contribution {self.contribution.pk}.\n"
+                    f"Stripe response: {str(invalid_request_error)}"
+                )
             )
             raise PaymentProviderError(invalid_request_error)
         except stripe.error.StripeError as stripe_error:

--- a/apps/contributions/tests/test_payment_managers.py
+++ b/apps/contributions/tests/test_payment_managers.py
@@ -37,6 +37,9 @@ class MockPaymentIntent(StripeObject):
 
 
 class MockInvalidRequestError(stripe_errors.InvalidRequestError):
+    _message = "mock invalid request error"
+    request_id = "123"
+
     def __init__(self, *args, **kwargs):
         pass
 


### PR DESCRIPTION
#### What's this PR do?
We get a decent number of these Stripe InvalidRequestErrors. Without the contribution pk, the error messages aren't very useful. This ticket adds the contribution pk, as well as the original stripe response to that error log.

#### How should this be manually tested?
Don't know.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
