### PR TITLE
[NRH-176] fix mobile padding a little

### DIFF
--- a/spa/src/components/contributor/contributorDashboard/ContributorDashboard.styled.js
+++ b/spa/src/components/contributor/contributorDashboard/ContributorDashboard.styled.js
@@ -4,6 +4,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export const ContributorDashboard = styled.main`
   padding: 4rem 2rem;
+
+  @media (${(props) => props.theme.breakpoints.phoneOnly}) {
+    padding: 0;
+  }
 `;
 
 export const Disclaimer = styled.p`


### PR DESCRIPTION
#### What's this PR do?
I almost punted on this, since it's contributor portal, but it turns out it was already done. This would have been fixed by fixing the "Org admin contributions list", as it's the same code. There's a PR here because I didn't like the padding when I viewed the Contributor portal and it was a tiny change.

#### How should this be manually tested?
Go to contributor portal and view it at mobile breakpoints. Observe lack of obtrusive padding around edges. More to the point of the ticket though, observe that the table is no longer a table, but in fact a list of cards. 

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
