### PR TITLE
[NRH-317] Page name dashes

### DIFF
--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -102,7 +102,7 @@ class DonationPage(AbstractPage, SafeDeleteModel):
         )
 
     def __str__(self):
-        return f"{self.heading} - {self.slug}"
+        return self.name
 
     def has_page_limit(self):
         return Feature.objects.filter(

--- a/apps/pages/tests/test_models.py
+++ b/apps/pages/tests/test_models.py
@@ -13,8 +13,7 @@ class DonationPageTest(TestCase):
         self.instance = DonationPageFactory()
 
     def test_to_string(self):
-        derived_name = f"{self.instance.heading} - {self.instance.slug}"
-        self.assertEqual(derived_name, str(self.instance))
+        self.assertEqual(self.instance.name, str(self.instance))
 
     def test_is_live(self):
         one_minute = datetime.timedelta(minutes=1)


### PR DESCRIPTION
#### What's this PR do?
DonationPage.__str__ was `heading + " - " +  slug`. This is was leftover from before pages had names. __str__ is now just `name`

#### How should this be manually tested?
Observe the much friendlier looking names in the "name" column of the DonationPage list view in django admin.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No