### PR TITLE
[NRH-311] Default freqs/amounts in edit mode not changing page

### DIFF
--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -331,7 +331,8 @@ function PageEditor() {
         )}
         {page && (
           <SegregatedStyles page={page}>
-            <DonationPage live={false} page={page} />
+            {/* set stringified page as key to guarantee that ALL page changes will re-render the page in edit mode */}
+            <DonationPage key={page ? JSON.stringify(page) : ''} live={false} page={page} />
           </SegregatedStyles>
         )}
         <S.ButtonOverlay>


### PR DESCRIPTION
#### What's this PR do?
When selecting a default Frequency or Amount in page edit mode, the user expects the page display to reflect that change.  It wasn't because of the depth of the object diffing being done by react to determine whether or not to re-render. This PR forces React in to doing a string comparison of a JSON stringified page object rather than a shallow object diff to determine re-render.

#### How should this be manually tested?
Go in to page edit and select a default amount or frequency. That amount/frequency should be highlighted on the page.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No