### PR TITLE
refs #NRH-315 Adds a guard for UUIDs without corresponding File

### DIFF
--- a/apps/element_media/tests.py
+++ b/apps/element_media/tests.py
@@ -15,19 +15,28 @@ from ..common.tests.test_resources import AbstractTestCase
 from .models import MediaImage
 
 
-def setup_sidebar_fixture(e_type="DImage"):
+def setup_sidebar_fixture(e_type="DImage", extra=False):
     img1 = get_test_image_file_jpeg(filename=get_random_jpg_filename())
     img2 = get_test_image_file_jpeg(filename=get_random_jpg_filename())
+    img3 = get_test_image_file_jpeg(filename=get_random_jpg_filename())
     uuid1 = uuid4()
     uuid2 = uuid4()
     sidebar_elements = {
-        "sidebar_elements": json.dumps(
-            [
-                {"uuid": f"{uuid1}", "type": e_type, "content": ""},
-                {"uuid": f"{uuid2}", "type": e_type, "content": ""},
-            ]
-        )
+        "sidebar_elements": [
+            {"uuid": f"{uuid1}", "type": e_type, "content": ""},
+            {"uuid": f"{uuid2}", "type": e_type, "content": ""},
+        ]
     }
+    if extra:
+        uuid3 = uuid4()
+        extra_elem = {
+            "uuid": f"{uuid3}",
+            "type": e_type,
+            "content": {"url": f"/media/images/{img3.name}", "thumbnail": f"/media/thumbs/{img3.name}"},
+        }
+        sidebar_elements["sidebar_elements"].append(extra_elem)
+    sidebar_elements["sidebar_elements"] = json.dumps(sidebar_elements["sidebar_elements"])
+
     files = {
         f"{uuid1}": img1,
         f"{uuid2}": img2,
@@ -80,5 +89,11 @@ class TestMediaImage(AbstractTestCase):
 
     def test_no_creation_if_no_images(self):
         sidebar, files = setup_sidebar_fixture(e_type="DRichText")
-        result = MediaImage.create_from_request(data=sidebar, files=files, donation_page=self.dp.pk)
+        MediaImage.create_from_request(data=sidebar, files=files, donation_page=self.dp.pk)
         assert not MediaImage.objects.all()
+
+    def test_existing_uuid_with_no_file(self):
+        sidebar, files = setup_sidebar_fixture(extra=True)
+        result = MediaImage.create_from_request(data=sidebar, files=files, donation_page=self.dp.pk)
+        assert MediaImage.objects.all().count() == 2
+        assert len(result["sidebar_elements"]) == 3


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug that would cause the backend to 500 when an image was added to a page with existing images. 

#### How should this be manually tested?
1. Add multiple images to a sidebar
2. Save
3. Observe that the images save successfully
4. Add another image to the sidebar
5. Save
6. Observe that the page saves successfully and the images are not broken.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No.
