### PR TITLE
[NRH-316] Desquish benefit icon

### DIFF
--- a/spa/src/components/donationPage/pageContent/DBenefits.styled.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.styled.js
@@ -73,6 +73,7 @@ export const BenefitIcon = styled(SvgIcon)`
 `;
 
 export const BenefitDetails = styled.div`
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: left;
@@ -90,5 +91,4 @@ export const BenefitDescription = styled.p`
   margin-left: 2rem;
   font-style: italic;
   flex: 1;
-  white-space: wrap;
 `;


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug where the check mark icon next the benefits on a donation page would squish if the text beside it was too long.

#### How should this be manually tested?
Note the dearth of squish

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No