### PR TITLE
[NRH-323] DonationPage credit card clearing behavior

### DIFF
--- a/spa/src/hooks/usePreviousState.js
+++ b/spa/src/hooks/usePreviousState.js
@@ -1,0 +1,16 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * Given a value, store a reference to it and return the previous value on render.
+ */
+function usePreviousState(value) {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
+
+export default usePreviousState;


### PR DESCRIPTION
#### What's this PR do?
There was a bug, reproducible by:
1. Entering a custom amount to donate
2. Filling out credit card info (note that before you finish filling out CC info, the submit button is disabled)
3. Clearing the custom amount to zero
4. Note that the payment widget has disappeared
5. Re-enter a new custom amount
6. Note that the payment widget has reappeared, but that the submit button is _not disabled_

This PR checks the previous donation amount and, if it's not the same, disables the submit button.

#### How should this be manually tested?
Do all of the above and observe that the submit button is disabled at the end, instead of enabled.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
