### PR TITLE
[NRH-292] DonationPage reCAPTCHA

### DIFF
--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -176,6 +176,7 @@ class AbstractPaymentSerializer(serializers.Serializer):
 
     # Params/Pass-through
     sf_campaign_id = serializers.CharField(max_length=255, required=False, allow_blank=True)
+    captcha_token = serializers.CharField(max_length=2550, required=False, allow_blank=True)
 
     # Request metadata
     ip = serializers.IPAddressField()

--- a/spa/cypress/integration/donation-page.spec.js
+++ b/spa/cypress/integration/donation-page.spec.js
@@ -161,6 +161,24 @@ describe('Donation page', () => {
       cy.makeDonation();
       cy.wait('@stripePayment').its('request.body').should('have.property', 'amount', amount);
     });
+
+    it('should send a request with a Google reCAPTCHA token in request body', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/live-page-1', statusCode: 200 }
+      ).as('getPage');
+
+      cy.visit('/rev-program-slug');
+      cy.url().should('include', 'rev-program-slug');
+      cy.wait('@getPage');
+
+      const interval = 'One time';
+      const amount = '120';
+      cy.interceptDonation();
+      cy.setUpDonation(interval, amount);
+      cy.makeDonation();
+      cy.wait('@stripePayment').its('request.body').should('have.property', 'captcha_token');
+    });
   });
 
   describe('Donation page side effects', () => {

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -109,6 +109,7 @@ export function serializeData(formRef, state) {
   serializedData['revenue_program_slug'] = state.revProgramSlug;
   serializedData['donation_page_slug'] = state.pageSlug;
   serializedData['sf_campaign_id'] = state.salesforceCampaignId;
+  if (state.reCAPTCHAToken) serializedData['captcha_token'] = state.reCAPTCHAToken;
 
   return serializedData;
 }

--- a/spa/src/constants/genericConstants.js
+++ b/spa/src/constants/genericConstants.js
@@ -1,3 +1,3 @@
 // Google reCAPTCHA
 export const GRECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js';
-export const GRECAPTCHA_SITE_KEY = '6LdZRCMcAAAAAB4orkPjt3X2KQPEso4w2JbHQ4BI';
+export const GRECAPTCHA_SITE_KEY = '6Lfuse8UAAAAAD9E6tCxKYrxO1IbnXp8IBa4u5Ri';

--- a/spa/src/constants/genericConstants.js
+++ b/spa/src/constants/genericConstants.js
@@ -1,0 +1,3 @@
+// Google reCAPTCHA
+export const GRECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js';
+export const GRECAPTCHA_SITE_KEY = '6LdZRCMcAAAAAB4orkPjt3X2KQPEso4w2JbHQ4BI';

--- a/spa/src/hooks/useReCAPTCHAScript.js
+++ b/spa/src/hooks/useReCAPTCHAScript.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+// Constants
+import { GRECAPTCHA_SCRIPT_URL, GRECAPTCHA_SITE_KEY } from 'constants/genericConstants';
+
+/**
+ * Load Google reCAPTCHA script and set token callback
+ * https://developers.google.com/recaptcha/docs/v3#programmatically_invoke_the_challenge
+ */
+function useReCAPTCHAScript() {
+  /**
+   * Load the gReCAPTCHA script with site key on mount.
+   */
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = GRECAPTCHA_SCRIPT_URL + `?render=${GRECAPTCHA_SITE_KEY}`;
+    document.body.appendChild(script);
+    return () => document.body.removeChild(script);
+  }, []);
+}
+
+export default useReCAPTCHAScript;


### PR DESCRIPTION
DON’T MERGE ME IN TO DEVELOP UNTIL:
- [ ]  All the bugs have been merged in to develop and verified.


#### What's this PR do?
Adds Google reCAPTCHA v3 to donation pages. We decided to go with the "[Programmatically invoke the challenge](https://developers.google.com/recaptcha/docs/v3#programmatically_invoke_the_challenge)" method of implementation, as our for isn't quite as simple as "submit". The resultant token is added to the data sent to our API for payment completion. It's serialized in to a subsequent request to BadActor under the key `captcha_token`.

#### How should this be manually tested?
1. First, notice the presence of the reCaptcha floaty icon thing on donation pages. 
2. Next, make a donation. 
3. Then maybe inspect the request payload in the browser developer console and find the key `captcha_token`. You can filter network requests by `payment/` to get the one you want here.
4. If you're quick about it, you can make a POST request to the Google reCAPTCHA verify endpoint ([as described here](https://developers.google.com/recaptcha/docs/verify#api_request)). The token expires after 2 mins, so be snappy.
5. If you're a robot, your score will be close to 0, otherwise it'll be close to 1.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
