### PR TITLE
[NRH-335] Default frequency weirdness

### DIFF
--- a/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/frequency/FrequencyEditor.js
@@ -33,7 +33,8 @@ function FrequencyEditor() {
 
   const makeFreqDefault = (frequency) => {
     const freqs = [...elementContent];
-    setElementContent(freqs.map((f) => ({ ...f, isDefault: f.value === frequency })));
+    const freqIsEnabled = freqs.find((f) => f.value === frequency);
+    if (freqIsEnabled) setElementContent(freqs.map((f) => ({ ...f, isDefault: f.value === frequency })));
   };
 
   return (
@@ -57,7 +58,7 @@ function FrequencyEditor() {
                 data-testid={`frequency-default-${frequency.value}`}
                 type="checkbox"
                 color={theme.colors.primary}
-                checked={thisFreq?.isDefault}
+                checked={!!thisFreq?.isDefault}
                 onChange={() => makeFreqDefault(frequency.value)}
               />
               <S.RadioLabel htmlFor={`${frequency.value}-default`}>selected by default</S.RadioLabel>


### PR DESCRIPTION
#### What's this PR do?
A bug was noticed in default frequency selection that cause strange behavior in the checkboxes. This PR fixes that.

#### How should this be manually tested?
Try to reproduce the behavior demonstrated in the [comment with a video on basecamp](https://3.basecamp.com/3120230/buckets/21497549/todos/3983673693). Note that it's been fixed.

It's worth noting that the inability to uncheck a checked box is the expected behavior. You cannot not have a default selected frequency.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
