### PR TITLE
Nrh 338  bugfix empty metadata fields in stripe

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -268,6 +268,7 @@ class ContributionMetadata(IndexedTimeStampedModel):
 
     @staticmethod
     def bundle_metadata(supplied: dict, processor_obj, payment_manager):
+        remove_from_final = ["", None]
         processor_meta = ContributionMetadata.objects.filter(processor_object=processor_obj)
         meta_for_all = ContributionMetadata.objects.filter(processor_object=ContributionMetadata.ProcessorObjects.ALL)
         collected = {}
@@ -281,7 +282,7 @@ class ContributionMetadata(IndexedTimeStampedModel):
                 continue
         for obj in meta_for_all:
             collected.update({obj.key: supplied.get(obj.key, obj.default_value)})
-        final = {k: v for k, v in collected.items() if v is not None}
+        final = {k: v for k, v in collected.items() if v not in remove_from_final}
         return final
 
     class Meta:

--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -233,9 +233,9 @@ class ContributionMetadata(IndexedTimeStampedModel):
     """
 
     lookup_map = {
-        "re_contributor_id": _get_contributor_id,
-        "re_revenue_program_id": _get_rev_program_id,
-        "re_revenue_program_slug": _get_rev_program_slug,
+        "contributor_id": _get_contributor_id,
+        "revenue_program_id": _get_rev_program_id,
+        "revenue_program_slug": _get_rev_program_slug,
     }
 
     class MetadataType(models.TextChoices):

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -189,19 +189,19 @@ class ContributionMetadataTest(TestCase):
 
     @patch("apps.contributions.payment_managers.StripePaymentManager")
     def test_bundle_meta_w_lookup_payment(self, pm_mock):
-        self.cm4 = ContributionMetadataFactory(key="re_revenue_program_id", label="re_revenue_program_id")
+        self.cm4 = ContributionMetadataFactory(key="revenue_program_id", label="revenue_program_id")
         pm_mock.return_value.get_donation_page.return_value.pk = 23
         results = ContributionMetadata.bundle_metadata(
             self.supplied, ContributionMetadata.ProcessorObjects.PAYMENT, pm_mock()
         )
-        assert results.get("re_revenue_program_id", None) is not None
-        assert results.get("re_revenue_program_id", None) == 23
+        assert results.get("revenue_program_id", None) is not None
+        assert results.get("revenue_program_id", None) == 23
 
     @patch("apps.contributions.payment_managers.StripePaymentManager")
     def test_bundle_meta_w_lookup_customer(self, pm_mock):
         self.cm5 = ContributionMetadataFactory(
-            key="re_contributor_id",
-            label="re_contributor_id",
+            key="contributor_id",
+            label="contributor_id",
             processor_object=ContributionMetadata.ProcessorObjects.CUSTOMER,
         )
 
@@ -209,5 +209,5 @@ class ContributionMetadataTest(TestCase):
         results = ContributionMetadata.bundle_metadata(
             self.supplied, ContributionMetadata.ProcessorObjects.CUSTOMER, pm_mock()
         )
-        assert results.get("re_contributor_id", None) is not None
-        assert results.get("re_contributor_id", None) == 55
+        assert results.get("contributor_id", None) is not None
+        assert results.get("contributor_id", None) == 55

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -124,7 +124,7 @@ class ContributionTest(TestCase):
 class ContributionMetadataTest(TestCase):
     supplied = {
         "email": "test@tester.com",
-        "phone": None,
+        "phone": "",
         "state": None,
         "amount": "1400",
         "source": "rev-engine",

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -106,6 +106,7 @@ export function serializeData(formRef, state) {
     state.frequency,
     state.orgIsNonProfit
   ).toString();
+  serializedData['donor_selected_amount'] = state.amount;
   serializedData['revenue_program_slug'] = state.revProgramSlug;
   serializedData['donation_page_slug'] = state.pageSlug;
   serializedData['sf_campaign_id'] = state.salesforceCampaignId;


### PR DESCRIPTION
#### What's this PR do?
Adds an additional empty string filter.

#### How should this be manually tested?
1. Add all the additional info items to a DonationPage
2. Make a contribution on that DonationPage. Leave all AdditionalInfo fields blank
3. Observe that none of the fields are transmitted to Stripe.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
