### PR TITLE
[NRH-339] Spinning live page

### DIFF
--- a/spa/cypress/integration/donation-page.spec.js
+++ b/spa/cypress/integration/donation-page.spec.js
@@ -310,9 +310,13 @@ describe('Donation page', () => {
         { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
         { fixture: 'pages/live-page-1', statusCode: 200 }
       ).as('getPage');
+      cy.intercept('/api/v1/organizations/stripe_account_id/**', { fixture: 'stripe/org-account-id.json' }).as(
+        'getStripeAccountId'
+      );
       cy.visit('/revenue-program-slug/page-slug');
       cy.url().should('include', '/revenue-program-slug/page-slug');
       cy.wait('@getPage');
+      cy.wait('@getStripeAccountId');
     });
 
     it('should render page footer with link to fundjournalism.org', () => {

--- a/spa/cypress/integration/donation-page.spec.js
+++ b/spa/cypress/integration/donation-page.spec.js
@@ -309,8 +309,10 @@ describe('Donation page', () => {
       cy.intercept(
         { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
         { fixture: 'pages/live-page-1', statusCode: 200 }
-      );
+      ).as('getPage');
       cy.visit('/revenue-program-slug/page-slug');
+      cy.url().should('include', '/revenue-program-slug/page-slug');
+      cy.wait('@getPage');
     });
 
     it('should render page footer with link to fundjournalism.org', () => {

--- a/spa/cypress/integration/donation-page.spec.js
+++ b/spa/cypress/integration/donation-page.spec.js
@@ -1,4 +1,4 @@
-import { STRIPE_PAYMENT, FULL_PAGE } from 'ajax/endpoints';
+import { STRIPE_PAYMENT, FULL_PAGE, ORG_STRIPE_ACCOUNT_ID } from 'ajax/endpoints';
 import { getEndpoint, getPageElementByType } from '../support/util';
 import livePageOne from '../fixtures/pages/live-page-1.json';
 
@@ -144,7 +144,7 @@ describe('Donation page', () => {
       cy.wait('@stripePayment').its('request.body').should('have.property', 'interval', 'one_time');
     });
 
-    it('should send a request with the expected amount', () => {
+    it('should send a request with the expecxted amount', () => {
       cy.intercept(
         { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
         { fixture: 'pages/live-page-1', statusCode: 200 }
@@ -256,6 +256,51 @@ describe('Donation page', () => {
 
       // assert that the right things are checked
       cy.getByTestId('frequency-month-selected').should('exist');
+    });
+  });
+
+  describe('404 behavior', () => {
+    it('should show 404 if request live page returns non-200', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/live-page-1', statusCode: 404 }
+      ).as('getLivePage');
+      cy.visit('/revenue-program-slug/page-slug');
+      cy.url().should('include', '/revenue-program-slug/page-slug');
+      cy.wait('@getLivePage');
+      cy.getByTestId('live-page-404').should('exist');
+    });
+
+    it('should show 404 if request stripe account id returns non-200', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/live-page-1', statusCode: 200 }
+      );
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(ORG_STRIPE_ACCOUNT_ID) },
+        { body: { stripe_account_id: 'abc123' }, statusCode: 500 }
+      ).as('getStripeAccountId');
+      cy.visit('/revenue-program-slug/page-slug');
+      cy.url().should('include', '/revenue-program-slug/page-slug');
+      cy.wait('@getStripeAccountId');
+      cy.getByTestId('live-page-404').should('exist');
+    });
+
+    it('should not show 404 otherwise', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/live-page-1', statusCode: 200 }
+      ).as('getLivePage');
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(ORG_STRIPE_ACCOUNT_ID) },
+        { body: { stripe_account_id: 'abc123' }, statusCode: 200 }
+      ).as('getStripeAccountId');
+      cy.visit('/revenue-program-slug/page-slug');
+      cy.url().should('include', '/revenue-program-slug/page-slug');
+      cy.wait('@getLivePage');
+      cy.wait('@getStripeAccountId');
+      cy.getByTestId('live-page-404').should('not.exist');
+      cy.getByTestId('donation-page').should('exist');
     });
   });
 

--- a/spa/cypress/integration/pages.spec.js
+++ b/spa/cypress/integration/pages.spec.js
@@ -7,8 +7,10 @@ const expectedRevPrograms = new Set(pagesList.map((p) => p.revenue_program.name)
 describe('Donation pages list', () => {
   before(() => {
     cy.login('user/stripe-verified.json');
-    cy.intercept(getEndpoint(LIST_PAGES), { fixture: 'pages/list-pages-1' });
+    cy.intercept(getEndpoint(LIST_PAGES), { fixture: 'pages/list-pages-1' }).as('listPages');
     cy.visit('/dashboard/pages/');
+    cy.url().should('include', '/dashboard/pages/');
+    cy.wait('@listPages');
   });
 
   it('should render the pages list component', () => {

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -31,7 +31,7 @@ const mapQSFreqToProperFreq = {
 
 const DonationPageContext = createContext({});
 
-function DonationPage({ page, live = false }) {
+function DonationPage({ page, stripeAccountId, live = false }) {
   const location = useLocation();
   const formRef = useRef();
   const [frequency, setFrequency] = useState(getInitialFrequency(page));
@@ -89,6 +89,7 @@ function DonationPage({ page, live = false }) {
     <DonationPageContext.Provider
       value={{
         page,
+        stripeAccountId,
         frequency,
         setFrequency,
         payFee,

--- a/spa/src/components/donationPage/DonationPageRouter.js
+++ b/spa/src/components/donationPage/DonationPageRouter.js
@@ -2,10 +2,13 @@ import { useEffect, useCallback, useReducer } from 'react';
 
 // AJAX
 import useRequest from 'hooks/useRequest';
-import { FULL_PAGE } from 'ajax/endpoints';
+import { FULL_PAGE, ORG_STRIPE_ACCOUNT_ID } from 'ajax/endpoints';
 
 // Router
 import { useParams } from 'react-router-dom';
+
+// Utils
+import isEmpty from 'lodash.isempty';
 
 // Children
 import SegregatedStyles from 'components/donationPage/SegregatedStyles';
@@ -13,35 +16,38 @@ import LiveLoading from 'components/donationPage/live/LiveLoading';
 import LivePage404 from 'components/donationPage/live/LivePage404';
 import DonationPage from 'components/donationPage/DonationPage';
 
-export const PAGE_FETCH_START = 'PAGE_FETCH_START';
-export const PAGE_FETCH_SUCCESS = 'PAGE_FETCH_SUCCESS';
-export const PAGE_FETCH_ERROR = 'PAGE_FETCH_ERROR';
+const FETCH_START = 'FETCH_START';
+const FETCH_SUCCESS = 'FETCH_SUCCESS';
+const FETCH_ERROR = 'FETCH_ERROR';
+
+const PAGE = 'page';
+const STRIPE_ACCOUNT_ID = 'stripeAccountId';
 
 const initialState = {
   loading: false,
-  data: null,
-  error: null
+  data: {},
+  errors: {}
 };
 
 const livePageReducer = (state, action) => {
   switch (action.type) {
-    case PAGE_FETCH_START:
+    case FETCH_START:
       return {
         loading: true,
         data: initialState.data,
-        error: initialState.error
+        errors: initialState.errors
       };
-    case PAGE_FETCH_SUCCESS:
+    case FETCH_SUCCESS:
       return {
         loading: false,
-        data: action.payload,
-        error: initialState.error
+        data: { ...state.data, ...action.payload },
+        errors: initialState.errors
       };
-    case PAGE_FETCH_ERROR:
+    case FETCH_ERROR:
       return {
         loading: false,
         data: state.data,
-        error: action?.payload || initialState.error
+        errors: { ...state.errors, ...action.payload }
       };
     default:
       return state;
@@ -49,12 +55,28 @@ const livePageReducer = (state, action) => {
 };
 
 function DonationPageRouter({ setOrgAnalytics }) {
-  const [{ loading, error, data }, dispatch] = useReducer(livePageReducer, initialState);
+  const [{ loading, errors, data }, dispatch] = useReducer(livePageReducer, initialState);
   const params = useParams();
   const requestFullPage = useRequest();
+  const requestOrgStripeAccountId = useRequest();
+
+  const fetchOrgStripeAccountId = useCallback(async () => {
+    dispatch({ type: FETCH_START });
+    const requestParams = { revenue_program_slug: params.revProgramSlug };
+    requestOrgStripeAccountId(
+      { method: 'GET', url: ORG_STRIPE_ACCOUNT_ID, params: requestParams },
+      {
+        onSuccess: ({ data: responseData }) => {
+          const stripeAccountId = responseData.stripe_account_id;
+          dispatch({ type: FETCH_SUCCESS, payload: { [STRIPE_ACCOUNT_ID]: stripeAccountId } });
+        },
+        onFailure: (e) => dispatch({ type: FETCH_ERROR, payload: { [STRIPE_ACCOUNT_ID]: e } })
+      }
+    );
+  }, [params.revProgramSlug]);
 
   const fetchLivePageContent = useCallback(async () => {
-    dispatch({ type: PAGE_FETCH_START });
+    dispatch({ type: FETCH_START });
     const { revProgramSlug, pageSlug } = params;
     const requestParams = {
       revenue_program: revProgramSlug,
@@ -75,9 +97,9 @@ function DonationPageRouter({ setOrgAnalytics }) {
             google_analytics_v4_id: orgGaV4Id
           } = data?.revenue_program;
           setOrgAnalytics(orgGaV3Id, orgGaDomain, orgGaV4Id);
-          dispatch({ type: PAGE_FETCH_SUCCESS, payload: data });
+          dispatch({ type: FETCH_SUCCESS, payload: { [PAGE]: data } });
         },
-        onFailure: () => dispatch({ type: PAGE_FETCH_ERROR })
+        onFailure: (e) => dispatch({ type: FETCH_ERROR, payload: { [PAGE]: e } })
       }
     );
   }, [params]);
@@ -86,9 +108,19 @@ function DonationPageRouter({ setOrgAnalytics }) {
     fetchLivePageContent();
   }, [params, fetchLivePageContent]);
 
+  useEffect(() => {
+    fetchOrgStripeAccountId();
+  }, [params, fetchOrgStripeAccountId]);
+
   return (
-    <SegregatedStyles page={data}>
-      {loading ? <LiveLoading /> : error || !data ? <LivePage404 /> : <DonationPage live page={data} />}
+    <SegregatedStyles page={data[PAGE]}>
+      {loading ? (
+        <LiveLoading />
+      ) : !isEmpty(errors) || !data[PAGE] || !data[STRIPE_ACCOUNT_ID] ? (
+        <LivePage404 />
+      ) : (
+        <DonationPage live page={data[PAGE]} stripeAccountId={data[STRIPE_ACCOUNT_ID]} />
+      )}
     </SegregatedStyles>
   );
 }

--- a/spa/src/components/donationPage/pageContent/DPayment.js
+++ b/spa/src/components/donationPage/pageContent/DPayment.js
@@ -13,6 +13,7 @@ import { usePage } from '../DonationPage';
 import StripePayment from 'components/paymentProviders/stripe/StripePayment';
 
 function DPayment({ element, live, ...props }) {
+  const { stripeAccountId } = usePage();
   /*
     element.content is an object, whose keys are providers.
     For instance, element.content.stripe is an array of supported payment types:
@@ -27,10 +28,7 @@ function DPayment({ element, live, ...props }) {
       {live ? (
         <S.DPayment>
           {element?.content && element.content['stripe'] && (
-            <StripePayment
-              offerPayFees={element.content?.offerPayFees}
-              payFeesDefault={element.content?.payFeesDefault}
-            />
+            <StripePayment offerPayFees={element.content?.offerPayFees} stripeAccountId={stripeAccountId} />
           )}
         </S.DPayment>
       ) : (

--- a/spa/src/components/paymentProviders/stripe/StripePayment.js
+++ b/spa/src/components/paymentProviders/stripe/StripePayment.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import * as S from './StripePayment.styled';
 
 import { HUB_STRIPE_PUBLISHABLE_KEY } from 'App';
@@ -7,40 +7,17 @@ import { HUB_STRIPE_PUBLISHABLE_KEY } from 'App';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 
-// Ajax
-import useRequest from 'hooks/useRequest';
-import { ORG_STRIPE_ACCOUNT_ID } from 'ajax/endpoints';
-
-// Routing
-import { useParams } from 'react-router-dom';
-
 // Children
 import ElementLoading from 'components/donationPage/pageContent/ElementLoading';
 import StripePaymentForm from 'components/paymentProviders/stripe/StripePaymentForm';
 
-function StripePayment({ offerPayFees }) {
+function StripePayment({ offerPayFees, stripeAccountId }) {
   const [loading, setLoading] = useState(false);
   const [stripe, setStripe] = useState();
-  const requestOrgStripeAccountId = useRequest();
-  const params = useParams();
-
-  const setOrgStripeAccountId = useCallback(async () => {
-    const requestParams = { revenue_program_slug: params.revProgramSlug };
-    requestOrgStripeAccountId(
-      { method: 'GET', url: ORG_STRIPE_ACCOUNT_ID, params: requestParams },
-      {
-        onSuccess: ({ data }) => {
-          const stripeAccount = data.stripe_account_id;
-          setStripe(loadStripe(HUB_STRIPE_PUBLISHABLE_KEY, { stripeAccount }));
-        },
-        onFailure: () => {}
-      }
-    );
-  }, [params.revProgramSlug]);
 
   useEffect(() => {
-    setOrgStripeAccountId();
-  }, [setOrgStripeAccountId]);
+    if (stripeAccountId) setStripe(loadStripe(HUB_STRIPE_PUBLISHABLE_KEY, { stripeAccountId }));
+  }, [stripeAccountId]);
 
   return (
     <S.StripePayment>


### PR DESCRIPTION
#### What's this PR do?
Addresses the issue mentioned in [this basecamp post](https://3.basecamp.com/3120230/buckets/21497549/messages/4088827225). Instead of spinning here, we'll get a 404 now. The underlying issue causing the page not to load is that the organization being used in the video in that post was missing required information for stripe to work. It shouldn't be possible to get in to that state without messing with stuff in the django admin, but just in case, we should handle that with a 404.

#### How should this be manually tested?
Try to access the page mentioned in the basecamp post and notice a 404 instead of a spinner.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No