### PR TITLE
[NRH-314] Richtext outline

### DIFF
--- a/spa/src/components/pageEditor/editInterface/pageElements/addElementModal/AddElementModal.js
+++ b/spa/src/components/pageEditor/editInterface/pageElements/addElementModal/AddElementModal.js
@@ -25,9 +25,9 @@ function AddElementModal({ addElementModalOpen, setAddElementModalOpen, destinat
 
   const handleElementSelected = (element) => {
     if (destination === 'sidebar') {
-      setSidebarElements([buildElement(element), ...(sidebarElements || [])]);
+      setSidebarElements([...(sidebarElements || []), buildElement(element)]);
     } else {
-      setElements([buildElement(element), ...(elements || [])]);
+      setElements([...(elements || []), buildElement(element)]);
     }
     setAddElementModalOpen(false);
   };

--- a/spa/src/components/pageEditor/elementEditors/richText/RichTextEditor.styled.js
+++ b/spa/src/components/pageEditor/elementEditors/richText/RichTextEditor.styled.js
@@ -5,4 +5,9 @@ export const RichTextEditorWrapper = styled.div`
   & div.rdw-link-wrapper {
     width: 100%;
   }
+
+  & div.rdw-editor-main {
+    border: 1px solid ${(props) => props.theme.colors.grey[0]};
+    padding: 0.5rem;
+  }
 `;


### PR DESCRIPTION
DON’T MERGE ME IN TO DEVELOP UNTIL:
- [ ]  All the bugs have been merged in to develop and verified.


#### What's this PR do?
The Page element RichText editor interface was a bit confusing because the text area you type in didn't have an outline. It's invisible if you don't have text in it already. So we've added a border.

Also, added incidentally-- adding new elements to the page adds them to the bottom of the list/page, rather than the top.

#### How should this be manually tested?
Check out a rich text editor and notice the border.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No