### PR TITLE
Misnamed stripe_account param in loadStripe

### DIFF
--- a/spa/src/components/paymentProviders/stripe/StripePayment.js
+++ b/spa/src/components/paymentProviders/stripe/StripePayment.js
@@ -16,7 +16,7 @@ function StripePayment({ offerPayFees, stripeAccountId }) {
   const [stripe, setStripe] = useState();
 
   useEffect(() => {
-    if (stripeAccountId) setStripe(loadStripe(HUB_STRIPE_PUBLISHABLE_KEY, { stripeAccountId }));
+    if (stripeAccountId) setStripe(loadStripe(HUB_STRIPE_PUBLISHABLE_KEY, { stripeAccount: stripeAccountId }));
   }, [stripeAccountId]);
 
   return (

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -41,7 +41,6 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const [disabled, setDisabled] = useState(true);
   const [paymentRequest, setPaymentRequest] = useState(null);
   const [forceManualCard, setForceManualCard] = useState(false);
-  const [emailForDonation, setEmailForDonation] = useState('');
 
   const theme = useTheme();
   const history = useHistory();
@@ -75,9 +74,9 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
 
   /**
    * extractEmailFromFormRef
-   * Provided a ref to the form element containing the email address, will set that email
-   * address to state as emailForDonation
+   * Provided a ref to the form element containing the email address, will return that email address
    * @param {Element} form - a ref to the Form element containing the email addreess
+   * @returns {string} email address
    */
   const extractEmailFromFormRef = (form) => {
     const emailInput = form.elements['email'];
@@ -106,8 +105,8 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
 
   const handlePaymentFailure = (error, pr) => {
     if (error instanceof StripeError) {
-      setErrors({ stripe: `Payment failed ${error.message}` });
-      alert.error(`Payment failed ${error.message}`);
+      setErrors({ stripe: `Payment failed: ${error}` });
+      alert.error(`Payment failed: ${error}`);
     } else {
       const internalErrors = error?.response?.data;
       if (internalErrors) {

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -1,5 +1,6 @@
 import axios from 'ajax/axios';
 import { STRIPE_PAYMENT } from 'ajax/endpoints';
+import { GENERIC_ERROR } from 'constants/textConstants';
 import calculateStripeFee from 'utilities/calculateStripeFee';
 
 const STRIPE_PAYMENT_TIMEOUT = 12 * 1000;
@@ -152,10 +153,10 @@ async function createPaymentIntent(formData) {
  */
 async function confirmCardPayment(stripe, clientSecret, payment_method, handleActions) {
   const { paymentIntent, error } = await stripe.confirmCardPayment(clientSecret, { payment_method }, { handleActions });
-  if (error) throw new StripeError(error);
+  if (error) throw new StripeError(error?.message || GENERIC_ERROR);
   if (paymentIntent.status === 'requires_action') {
     const { error } = await stripe.confirmCardPayment(clientSecret);
-    if (error) throw new StripeError(error);
+    if (error) throw new StripeError(error?.message || GENERIC_ERROR);
   }
 }
 
@@ -178,7 +179,7 @@ async function tryRecurringPayment(stripe, data, { card, paymentRequest }) {
 
   if (!paymentMethod) {
     const { paymentMethod: pm, error } = await createPaymentMethod(stripe, card, data);
-    if (error) throw new StripeError(error);
+    if (error) throw new StripeError(error?.message || GENERIC_ERROR);
     paymentMethod = pm.id;
   }
 


### PR DESCRIPTION
#### What's this PR do?
Fixes a misnamed key in the loadStripe configuration parameter that was causing payments to be created on Hub Stripe, not Org Stripe. Thereby disabling payments altogether.

#### How should this be manually tested?
Payments should work now.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No