### PR TITLE
Nrh 346  skip cypress tests skipcy

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - '*runcy*'
+      - '!*skipcy*'
 
 jobs:
   cypress-run:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,32 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, "runcy") }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: spa
+          build: npx cypress info
+          start: npm run start
+          wait-on: http://localhost:3000
+          browser: chrome
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: spa/cypress/screenshots
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-videos
+          path: spa/cypress/videos

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,6 +3,7 @@ name: tests
 on:
   push:
     branches:
+      - '*'
       - '!*skipcy*'
 
 jobs:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,14 +1,13 @@
 name: tests
 
 on:
-  pull_request:
   push:
-    branches: [main, develop]
+    branches:
+      - '*runcy*'
 
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, "runcy") }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,28 +64,3 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: revengine.settings.dev
           DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
-
-  cypress-run:
-    runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, "runcy") }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cypress tests
-        uses: cypress-io/github-action@v2
-        with:
-          working-directory: spa
-          build: npx cypress info
-          start: npm run start
-          wait-on: http://localhost:3000
-          browser: chrome
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: spa/cypress/screenshots
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-videos
-          path: spa/cypress/videos

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,6 @@ jobs:
 
   cypress-run:
     runs-on: ubuntu-latest
-    if: contains(github.ref, "runcy")
     steps:
       - name: Extract branch name
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,11 +67,8 @@ jobs:
 
   cypress-run:
     runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, "runcy") }}
     steps:
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cypress tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,9 +66,13 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
 
   cypress-run:
-    if: startsWith(github.event.ref, 'refs/tags/run-cypress')
     runs-on: ubuntu-latest
+    if: contains(github.ref, "runcy")
     steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cypress tests

--- a/README.md
+++ b/README.md
@@ -329,3 +329,27 @@ _Frontend configuration is not enabled until we can get environment variables to
 ~~`REACT_APP_SALESFORCE_CAMPAIGN_ID_QUERYPARAM`~~
 
 ~~Defaults to 'campaign'. This is the string that we expect to see in urls containing Salesforce Campaign IDs. eg. `?campiagn=my-salesforce-campaign-id`~~
+
+
+## Git tags
+
+This project has cypress tests, which are great, but they can take a long time to run.
+
+If you are working on a branch that needs cypress tests run, you can set a tag that will tell github actions
+to enable the cypress tests workflow.
+
+On the branch you need to run tests, add a `run-cypress` tag
+
+```shell
+(revengine)$> git tag run-cypress
+```
+
+If the tag already exists, which it should if this is the original repo, then an error will tell you so.
+
+Now when you push a branch make sure you include the tag if you want cypress to run.
+
+```shell
+(revengine)$> git push --set-upstream origin <BRANCH_NAME> run-cypress
+```
+
+If you do not add this tag, cypress tests will be skipped.

--- a/README.md
+++ b/README.md
@@ -333,13 +333,14 @@ _Frontend configuration is not enabled until we can get environment variables to
 
 ## Git tags
 
-This project has cypress tests, which are great, but they can take a long time to run.
+This project has cypress tests, which are great, but they can take a long time to run. Sometimes they 
+are not necessary. 
 
-If you are working on a branch that needs cypress tests run, you will need to name your branch with the
+So, if you are working on a branch that does not need cypress tests, you will need to name your branch with the
 following text in it somewhere: `skipcy`
 
 ```shell
-(revengine)$> git checkout -b NRH-2837438--new-component-with-tests-runcy
+(revengine)$> git checkout -b NRH-2837438--new-component-with-tests-skipcy
 ```
 
-Any branch that does not have the text `runcy` present will skip the cypress testing.
+Any branch that does not have the text `skipcy` present will run cypress tests this includes `develop` and `main`.

--- a/README.md
+++ b/README.md
@@ -335,21 +335,11 @@ _Frontend configuration is not enabled until we can get environment variables to
 
 This project has cypress tests, which are great, but they can take a long time to run.
 
-If you are working on a branch that needs cypress tests run, you can set a tag that will tell github actions
-to enable the cypress tests workflow.
-
-On the branch you need to run tests, add a `run-cypress` tag
+If you are working on a branch that needs cypress tests run, you will need to name your branch with the
+following text in it somewhere: `skipcy`
 
 ```shell
-(revengine)$> git tag run-cypress
+(revengine)$> git checkout -b NRH-2837438--new-component-with-tests-runcy
 ```
 
-If the tag already exists, which it should if this is the original repo, then an error will tell you so.
-
-Now when you push a branch make sure you include the tag if you want cypress to run.
-
-```shell
-(revengine)$> git push --set-upstream origin <BRANCH_NAME> run-cypress
-```
-
-If you do not add this tag, cypress tests will be skipped.
+Any branch that does not have the text `runcy` present will skip the cypress testing.


### PR DESCRIPTION
#### What's this PR do?
Adds an action workflow for cypress that is skipped if a branch has `skipcy` in its name.

#### How should this be manually tested?
No need look at this branch. When this branch is merged to develop it should run cypress tests.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
