### PR TITLE
adds "per year" to benefit range

### DIFF
--- a/spa/src/components/donationPage/pageContent/DBenefits.js
+++ b/spa/src/components/donationPage/pageContent/DBenefits.js
@@ -32,7 +32,7 @@ function DBenefits({ live }) {
               <S.Level key={level.name + i} data-testid="level">
                 <S.BenefitLevelDetails>
                   <S.LevelName>{level.name}</S.LevelName>
-                  <S.LevelRange data-testid="level-range">{level.donation_range}</S.LevelRange>
+                  <S.LevelRange data-testid="level-range">{level.donation_range} per year</S.LevelRange>
                 </S.BenefitLevelDetails>
                 {i !== 0 && <S.LevelInclusion>Everything from {prevLevel.name}, plus</S.LevelInclusion>}
                 <S.LevelBenefitList data-testid="level-benefit-list">


### PR DESCRIPTION
#### What's this PR do?
adds "per year" to benefit range

#### How should this be manually tested?
confirm "per year" appears in the benefit column where benefit ranges are displayed

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
i don't think so
