### PR TITLE
[NRH-348] add padding to 404 text

### DIFF
--- a/spa/src/components/donationPage/live/LivePage404.styled.js
+++ b/spa/src/components/donationPage/live/LivePage404.styled.js
@@ -27,4 +27,6 @@ export const FourOhFour = styled.h2`
   }
 `;
 
-export const Description = styled.div``;
+export const Description = styled.div`
+  padding: 0 2rem;
+`;


### PR DESCRIPTION
#### What's this PR do?
Adds padding to 404 text for small screens

#### How should this be manually tested?
Go to a nonexistent url and shrink the viewport. The text should have a bit of padding around it to prevent collision with the edge of the screen.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No