### PR TITLE
[NRH-352] removes celery healthcheck

### DIFF
--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -58,7 +58,6 @@ INSTALLED_APPS = [
     "health_check.db",
     "health_check.cache",
     "health_check.contrib.migrations",
-    "health_check.contrib.celery",
     "health_check.contrib.redis",
 ]
 


### PR DESCRIPTION
#### What's this PR do?
Removes celery check from healthcheck. There was a misconfiguration of the celery healthcheck. Since that particular check wasn't requested, we won't waste time fixing it. For now, remove the check. We're keeping references to the errors received for future reference.

#### How should this be manually tested?
Visit healthcheck endpoint, note no errors.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No