### PR TITLE
Nrh 347  validate dpayment

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The Django admin is at `/admin/`.
 **11. Test Email Setup**
 To test production email settings `export TEST_EMAIL=True`, otherwise emails will use the console backend.
 
-**11. Run tests**
+**11. Run Django Tests**
 
 revengine uses pytest as a test runner.
 
@@ -211,6 +211,30 @@ revengine uses pytest as a test runner.
 ```sh
     (revengine)$ make run-tests
 ```
+
+**11. Run Cypress Tests**
+Running cypress locally requires 2 terminals
+
+Term 1:
+```shell
+  (revengine)$ cd spa/
+  (revengine)$ npm run start
+```
+
+Term 2:
+```shell
+  (revengine)$ cd spa/
+  (revengine)$ npm run cypress:open
+```
+Will open the cypress application
+
+OR in `spa/` directory:
+
+```shell
+  (revengine)$ cd spa/
+  (revengine)$ npm run cypress:run
+```
+Will run the cypress tests headless.
 
 **12. Reset Media and Database**
 

--- a/spa/cypress/fixtures/pages/live-page-element-validation.json
+++ b/spa/cypress/fixtures/pages/live-page-element-validation.json
@@ -5,19 +5,12 @@
   "published_date": "2020-09-17T00:00:00",
   "organization_is_nonprofit": true,
   "elements": [
-    {"type": "DRichText", "uuid": "testRichText1", "content": "<p><strong>Your support keeps us going! Become a member today.</strong></p> <p>Because of your generosity, we have the courage, freedom, and independence to dedicate our entire newsroom to telling stories that spark action, improve lives and protect our democracy. Thank you for your support that keeps us going.</p>"},
-    {"type": "DFrequency", "uuid": "testFreq1", "content": [{"value": "one_time", "displayName": "One time"}, {"value": "month", "displayName": "Monthly"}, {"value": "year", "displayName": "Yearly"}]},
-    {"type": "DAmount", "uuid": "testAmount1", "content": { "allowOther": true, "options": {
-        "one_time": [120, 180, 365],
-        "month": [10, 15, 25],
-        "year": [120, 180, 365],
-        "other": [22.45, 33]
-      }}
-    },
+    {"type": "DRichText", "uuid": "testRichText1", "content": "<p><strong>Your support keeps us going! Become a member today.</strong></p> <p>Because of your generosity, we have the courage, freedom, and independence to dedicate our entire newsroom to telling stories that spark action, improve lives and protect our democracy. Thank you for your support that keeps us going.</p>"}, 
+
     {"type": "DDonorInfo", "uuid": "testDonorInfo1"},
     {"type": "DDonorAddress", "uuid": "testDonorAddress1"},
     {"type": "DAdditionalInfo", "uuid": "testAdditionalInfo", "content": []},
-    {"type": "DPayment", "uuid": "testPayment1", "content": {"offerPayFees": true, "stripe": ["card", "apple", "google", "browser"]}}
+    {"type": "DPayment", "uuid": "testPayment1"}
   ],
   "sidebar_elements": [
     {"type":  "DRichText", "uuid": "testRichTextSE1", "content": "<p><strong>Sidebar Blurb</strong>"},

--- a/spa/cypress/integration/donation-page-edit.spec.js
+++ b/spa/cypress/integration/donation-page-edit.spec.js
@@ -182,7 +182,7 @@ describe('Donation page edit', () => {
     });
   });
 
-  describe('Validations', () => {
+  describe.only('Validations', () => {
     it('should render an alert with a list of missing required elements', () => {
       const missingElementType = 'DPayment';
       const page = { ...livePage };
@@ -247,6 +247,29 @@ describe('Donation page edit', () => {
       // Now we should see the Setup tab and our error message
       cy.getByTestId('edit-interface').should('exist');
       cy.getByTestId('errors-Logo link').contains(expectedErrorMessage);
+    });
+
+    it('should catch missing elements and an element that has not been configured.', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(FULL_PAGE) },
+        { fixture: 'pages/live-page-element-validation.json' }
+      ).as('getPageDetailModified');
+      cy.login('user/stripe-verified.json');
+      cy.visit('edit/my/page');
+      cy.wait('@getPageDetailModified');
+      // Need to fake an update to the page to enable save
+      cy.getByTestId('edit-page-button').click();
+      cy.contains('Rich text').click();
+
+      // Accept changes
+      cy.getByTestId('keep-element-changes-button').click();
+
+      // Save changes
+      cy.getByTestId('save-page-button').click();
+      cy.getByTestId('missing-elements-alert').should('exist').contains('Payment');
+      cy.getByTestId('missing-elements-alert').contains('Payment');
+      cy.getByTestId('missing-elements-alert').contains('Donation frequency');
+      cy.getByTestId('missing-elements-alert').contains('Donation amount');
     });
   });
 

--- a/spa/cypress/integration/donation-page-edit.spec.js
+++ b/spa/cypress/integration/donation-page-edit.spec.js
@@ -182,7 +182,7 @@ describe('Donation page edit', () => {
     });
   });
 
-  describe.only('Validations', () => {
+  describe('Validations', () => {
     it('should render an alert with a list of missing required elements', () => {
       const missingElementType = 'DPayment';
       const page = { ...livePage };

--- a/spa/src/components/donationPage/pageContent/DPayment.js
+++ b/spa/src/components/donationPage/pageContent/DPayment.js
@@ -43,6 +43,8 @@ DPayment.displayName = 'Payment';
 DPayment.description = 'Allow donors to contribute';
 DPayment.required = true;
 DPayment.unique = true;
+DPayment.requireContent = true;
+DPayment.contentMissingMsg = `${DPayment.displayName} needs to have at least one payment method configured.`;
 
 export default DPayment;
 

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -308,8 +308,8 @@ function PageEditor() {
 
   useEffect(() => {
     if (!isEmpty(errors)) {
-      if (errors.missing) {
-        alert.error(<MissingElementErrors missing={errors.missing} />);
+      if (errors.elementErrors) {
+        alert.error(<ElementErrors elementErrors={errors.elementErrors} />, { timeout: 0 });
       }
     }
   }, [errors, alert]);
@@ -379,13 +379,13 @@ export const usePageEditorContext = () => useContext(PageEditorContext);
 
 export default PageEditor;
 
-function MissingElementErrors({ missing = [] }) {
+function ElementErrors({ elementErrors = [] }) {
   return (
     <>
       The following elements are required for your page to function properly:
       <ul data-testid="missing-elements-alert">
-        {missing.map((missingEl) => (
-          <li key={missingEl}>{dynamicElements[missingEl].displayName}</li>
+        {elementErrors.map((elError) => (
+          <li key={elError.element}>{elError.message}</li>
         ))}
       </ul>
     </>

--- a/spa/src/components/pageEditor/validatePage.js
+++ b/spa/src/components/pageEditor/validatePage.js
@@ -46,7 +46,8 @@ function validateRequiredElements(elements) {
 
     if (elementMissingRequirements(el_instance[0])) {
       // Right now this only supports a single instance of a type.
-      // TODO: Make this support multiple instances of a type.
+      // TODO: Support multiple instances of a type.
+      // TODO: Support multiple requirements.
       errors.elementErrors.push({ element: requiredElement, message: `${dElement?.contentMissingMsg}` });
     }
   }

--- a/spa/src/components/pageEditor/validatePage.js
+++ b/spa/src/components/pageEditor/validatePage.js
@@ -1,6 +1,9 @@
 import isEmpty from 'lodash.isempty';
 import * as dynamicElements from 'components/donationPage/pageContent/dynamicElements';
 
+const requiredContent = Object.keys(dynamicElements).filter((key) => dynamicElements[key].requireContent);
+const requiredElements = Object.keys(dynamicElements).filter((key) => dynamicElements[key].required);
+
 function validatePage(page) {
   const errors = {
     ...validateRequiredElements(page.elements)
@@ -8,15 +11,43 @@ function validatePage(page) {
   return !isEmpty(errors) && errors;
 }
 
+function elementMissingRequirements(element) {
+  if (requiredContent.includes(element.type)) {
+    return !element?.content;
+  }
+  return false;
+}
+
 function validateRequiredElements(elements) {
+  /* validateRequiredElements
+   * Examines each element on a page and determines first if the element is required and then checks existing elements
+   * that have `requireContent = true` to ensure that they have at least one feature set on the element.
+   *
+   * Elements that have `requireContent = true` should also implement `contentMissingMsg` on the element or nothing will display
+   * for the user causing assured confusion.
+   *
+   * Currently this is a gross check and does not try to validate internal interactions of the element. It is assumed,
+   * that these are handled in the ElementEditor component.
+   */
   if (!elements) return;
-  const requiredElements = Object.keys(dynamicElements).filter((key) => dynamicElements[key].required);
+
   const errors = {};
   for (let i = 0; i < requiredElements.length; i++) {
+    errors.elementErrors = errors.elementErrors || [];
     const requiredElement = requiredElements[i];
-    if (!elements.find((el) => el.type === requiredElement)) {
-      errors.missing = errors.missing || [];
-      errors.missing.push(requiredElement);
+    const is_missing = !elements.find((el) => el.type === requiredElement);
+    const el_instance = elements.filter((el) => el.type === requiredElement);
+    const dElement = dynamicElements[requiredElement];
+
+    if (is_missing) {
+      errors.elementErrors.push({ element: requiredElement, message: `${dElement.displayName} is missing.` });
+      continue;
+    }
+
+    if (elementMissingRequirements(el_instance[0])) {
+      // Right now this only supports a single instance of a type.
+      // TODO: Make this support multiple instances of a type.
+      errors.elementErrors.push({ element: requiredElement, message: `${dElement?.contentMissingMsg}` });
     }
   }
   return errors;

--- a/spa/src/components/pageEditor/validatePage.js
+++ b/spa/src/components/pageEditor/validatePage.js
@@ -31,7 +31,7 @@ function validateRequiredElements(elements) {
    */
   if (!elements) return;
 
-  const elementErrors = {};
+  const elementErrors = [{}];
   for (let i = 0; i < requiredElements.length; i++) {
     const requiredElement = requiredElements[i];
     const is_missing = !elements.find((el) => el.type === requiredElement);

--- a/spa/src/components/pageEditor/validatePage.js
+++ b/spa/src/components/pageEditor/validatePage.js
@@ -31,27 +31,26 @@ function validateRequiredElements(elements) {
    */
   if (!elements) return;
 
-  const errors = {};
+  const elementErrors = {};
   for (let i = 0; i < requiredElements.length; i++) {
-    errors.elementErrors = errors.elementErrors || [];
     const requiredElement = requiredElements[i];
     const is_missing = !elements.find((el) => el.type === requiredElement);
     const el_instance = elements.filter((el) => el.type === requiredElement);
     const dElement = dynamicElements[requiredElement];
 
     if (is_missing) {
-      errors.elementErrors.push({ element: requiredElement, message: `${dElement.displayName} is missing.` });
+      elementErrors.push({ element: requiredElement, message: `${dElement.displayName} is missing.` });
       continue;
     }
 
     if (elementMissingRequirements(el_instance[0])) {
-      // Right now this only supports a single instance of a type.
       // TODO: Support multiple instances of a type.
       // TODO: Support multiple requirements.
-      errors.elementErrors.push({ element: requiredElement, message: `${dElement?.contentMissingMsg}` });
+      elementErrors.push({ element: requiredElement, message: `${dElement?.contentMissingMsg}` });
     }
   }
-  return errors;
+  // Only return a truthy value here if there really are errors.
+  if (elementErrors.length > 0) return { elementErrors };
 }
 
 export default validatePage;


### PR DESCRIPTION
#### What's this PR do?
Modifies the page validation system to support the detection of element level mis-configurations, whereas before it simply detected the absence of a required element.

At the moment this validation is simple. First, elements that need to be validated on page save need to have two properties added to the Element definition:

- `requireContent`
- `contentMissingMsg`

If `requireContent` is true the validator will check to see if the content of the element exists. If it does not, then the element will fail validation and the `contentMissingMsg` will display in the error notification.

Currently this is only implemented on `DPayment` elements

#### How should this be manually tested?

1. Create a new page.
2. Add any element to a page
3. Add a Payment element to the page, but do not edit it. This will leave it with no payment methods enabled.
4. Attempt to save the page
5. Observe an error message that indicates a Payment method should be added.

Additionally you can leave off required elements like `Amount` and the error message should inform you that the page is missing that element as well.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No.
