### PR TITLE
[NRH-361] OrgAdmin page templates

### DIFF
--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -15,3 +15,7 @@ def normalize_slug(name="", slug="", max_length=50):
     if len(slug) > max_length:
         slug = slug[:max_length].rstrip("-")
     return slug
+
+
+def cleanup_keys(data_dict, unwanted_keys):
+    return {k: v for k, v in data_dict.items() if k not in unwanted_keys}

--- a/apps/organizations/admin.py
+++ b/apps/organizations/admin.py
@@ -17,9 +17,6 @@ from apps.organizations.models import (
 from apps.users.admin import UserOrganizationInline
 
 
-# from apps.common.admin import OrganizationAddressInline, RevenueProgramAddressInline
-
-
 class RevenueProgramBenefitLevelInline(admin.TabularInline):
     model = RevenueProgram.benefit_levels.through
     verbose_name = "Benefit level"

--- a/apps/organizations/tests/test_org_views.py
+++ b/apps/organizations/tests/test_org_views.py
@@ -1,6 +1,7 @@
 import django.db.utils
 from django.contrib.auth import get_user_model
 
+from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
@@ -203,10 +204,11 @@ class FeatureViewSetTest(APITestCase):
         for i in range(3):
             try:
                 DonationPageFactory(organization=org)
-            except django.core.exceptions.ValidationError as e:
+            except ValidationError as e:
                 self.fail(f"Save raised a validation error on expected valid inputs: {e.message}")
-        with self.assertRaises(django.core.exceptions.ValidationError) as cm:
+        with self.assertRaises(ValidationError) as cm:
             DonationPageFactory(organization=org)
         self.assertEquals(
-            cm.exception.message, f"Your organization has reached its limit of {self.limit_feature.feature_value} pages"
+            str(cm.exception.detail[0]),
+            f"Your organization has reached its limit of {self.limit_feature.feature_value} pages",
         )

--- a/apps/pages/admin.py
+++ b/apps/pages/admin.py
@@ -75,14 +75,6 @@ class TemplateAdmin(DonationPageAdminAbstract):
                         messages.ERROR,
                     )
                     return HttpResponseRedirect(reverse("admin:pages_template_change", kwargs={"object_id": obj.id}))
-            except Template.TemplateError as e:
-                logger.error(e)
-                self.message_user(
-                    request,
-                    "Something went wrong. The page this template was created from cannot be found.",
-                    messages.ERROR,
-                )
-                return HttpResponseRedirect(reverse("admin:pages_template_change", kwargs={"object_id": obj.id}))
             return HttpResponseRedirect(reverse("admin:pages_donationpage_change", kwargs={"object_id": new_page.id}))
         return super().response_change(request, obj)
 

--- a/apps/pages/admin.py
+++ b/apps/pages/admin.py
@@ -134,28 +134,16 @@ class DonationPageAdmin(DonationPageAdminAbstract, SafeDeleteAdmin):
 
     @admin.action(description="Make templates from selected pages")
     def make_template(self, request, queryset):
-        updated = 0
-        duplicated = 0
+        created_template_count = 0
         for page in queryset:
-            _, created = page.save_as_template()
-            if created:
-                updated += 1
-            else:
-                duplicated += 1
+            page.make_template_from_page()
+            created_template_count += 1
 
-        if updated:
-            self.message_user(
-                request,
-                f"{updated} {'template' if updated == 1 else 'templates'} created.",
-                messages.SUCCESS,
-            )
-
-        if duplicated:
-            self.message_user(
-                request,
-                f"{duplicated} {'template' if duplicated == 1 else 'templates'} already {'exists' if duplicated == 1 else 'exist'}",
-                messages.WARNING,
-            )
+        self.message_user(
+            request,
+            f"{created_template_count} {'template' if created_template_count == 1 else 'templates'} created.",
+            messages.SUCCESS,
+        )
 
 
 @admin.register(Style)

--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -1,7 +1,7 @@
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 
+from rest_framework.exceptions import ValidationError
 from safedelete.models import SafeDeleteModel
 from sorl.thumbnail import ImageField as SorlImageField
 
@@ -73,9 +73,7 @@ class Template(AbstractPage):
         We also clean up template and page data here, so that we only copy the fields we want.
         """
         template_data = self.__dict__
-        temporary_name = f"{template_data['name']} [COPY]"
-        existing_copies_count = DonationPage.objects.filter(name__contains=temporary_name).count()
-        template_data["name"] = f"{temporary_name}({int(existing_copies_count)})"
+        template_data["name"] = f"New Page From Template ({template_data['name']})"
         template_data["slug"] = normalize_slug(name=template_data["name"])
         template_data["revenue_program"] = self.organization.revenueprogram_set.first()
 
@@ -173,9 +171,6 @@ class DonationPage(AbstractPage, SafeDeleteModel):
         page = cleanup_keys(self.__dict__, unwanted_keys)
         template = cleanup_keys(template_data, unwanted_keys)
         merged_template = page | template
-        target_name = f"{merged_template['name']} [TEMPLATE]"
-        existing_copies_count = Template.objects.filter(name__contains=target_name).count()
-        merged_template["name"] = f"{target_name}({int(existing_copies_count)})"
         merged_template["organization"] = Organization.objects.get(pk=merged_template.pop("organization_id"))
         return Template.objects.create(**merged_template)
 

--- a/apps/pages/serializers.py
+++ b/apps/pages/serializers.py
@@ -187,7 +187,6 @@ class TemplateDetailSerializer(serializers.ModelSerializer):
             "name",
             "heading",
             "graphic",
-            "organization",
             "header_bg_image",
             "header_logo",
             "header_link",

--- a/apps/pages/tests/test_admin.py
+++ b/apps/pages/tests/test_admin.py
@@ -28,25 +28,6 @@ class DonationPageAdminTestCase(TestCase):
         new_templates = Template.objects.all()
         self.assertEqual(prev_template_count + 1, len(new_templates))
 
-        # New Template gets its name from previous page's heading
-        self.assertEqual(new_templates[0].name, self.page.name)
-
-    def test_make_template_no_duplicate(self):
-        request = self.factory.get(reverse("admin:pages_donationpage_changelist"))
-        setup_request(self.user, request)
-        prev_template_count = Template.objects.count()
-        page_queryset = DonationPage.objects.all()
-
-        self.page_admin.make_template(request, page_queryset)
-
-        new_templates = Template.objects.all()
-        self.assertNotEqual(prev_template_count, len(new_templates))
-
-        # Run it again with same pages
-        self.page_admin.make_template(request, page_queryset)
-        last_templates_count = Template.objects.count()
-        self.assertEqual(last_templates_count, len(new_templates))
-
 
 class TemplateAdminTest(TestCase):
     def setUp(self):
@@ -56,7 +37,7 @@ class TemplateAdminTest(TestCase):
         self.client.force_login(self.user)
         self.template_admin = TemplateAdmin(Template, AdminSite())
         self.original_page = DonationPageFactory()
-        self.template = self.original_page.save_as_template()[0]
+        self.template = self.original_page.make_template_from_page()
 
     def test_make_template_button_appears_in_change_form(self):
         change_url = reverse("admin:pages_template_change", kwargs={"object_id": self.template.id})
@@ -74,23 +55,6 @@ class TemplateAdminTest(TestCase):
 
         new_pages = DonationPage.objects.all()
         self.assertNotEqual(prev_page_count, len(new_pages))
-
-        # New page's heading should be previous template's name
-        self.assertEqual(new_pages[0].name, self.template.name)
-
-    def test_new_page_creation_fails_gracefully(self):
-        request_body = {"_page-from-template": True}
-        url = reverse("admin:pages_template_change", kwargs={"object_id": self.template.id})
-        self.original_page.name = "A new name"
-        self.original_page.save()
-        request = self.factory.post(url, request_body)
-        setup_request(self.user, request)
-        prev_page_count = DonationPage.objects.count()
-        template = Template.objects.first()
-        response = self.template_admin.response_change(request, template)
-
-        new_pages = DonationPage.objects.all()
-        self.assertEqual(prev_page_count, len(new_pages))
 
     def test_response_change_without_button_click_passes_through(self):
         url = reverse("admin:pages_template_change", kwargs={"object_id": self.template.id})

--- a/apps/pages/tests/test_admin.py
+++ b/apps/pages/tests/test_admin.py
@@ -1,12 +1,14 @@
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from apps.common.tests.test_utils import setup_request
+from apps.organizations.tests.factories import RevenueProgramFactory
 from apps.pages.admin import DonationPageAdmin, TemplateAdmin
 from apps.pages.models import DonationPage, Template
-from apps.pages.tests.factories import DonationPageFactory, TemplateFactory
+from apps.pages.tests.factories import DonationPageFactory
 
 
 class DonationPageAdminTestCase(TestCase):
@@ -14,19 +16,30 @@ class DonationPageAdminTestCase(TestCase):
         self.factory = RequestFactory()
         user_model = get_user_model()
         self.user = user_model.objects.create_superuser(email="test@test.com", password="testing")
+        self.revenue_program = RevenueProgramFactory()
         self.page_admin = DonationPageAdmin(DonationPage, AdminSite())
-        self.page = DonationPageFactory()
+        self.page = DonationPageFactory(name="My Test Page", revenue_program=self.revenue_program)
+        self.change_url = reverse("admin:pages_donationpage_changelist")
 
-    def test_make_template_from_page(self):
-        request = self.factory.get(reverse("admin:pages_donationpage_changelist"))
+    def test_make_template_from_page_success(self):
+        request = self.factory.get(self.change_url)
         setup_request(self.user, request)
         prev_template_count = Template.objects.count()
-        page_queryset = DonationPage.objects.all()
+        page_queryset = DonationPage.objects.filter(pk=self.page.pk)
 
         self.page_admin.make_template(request, page_queryset)
 
         new_templates = Template.objects.all()
         self.assertEqual(prev_template_count + 1, len(new_templates))
+
+    def test_make_template_error_messages_when_duplicate_name(self):
+        self.client.force_login(user=self.user)
+        # Make template from target page once...
+        Template.objects.create(name=self.page.name, organization=self.page.organization)
+        # ...then try to make one by the same name (through admin action)
+        response = self.client.post(self.change_url, {"action": "make_template", "_selected_action": [self.page.pk]})
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertEqual(messages, [f'Template name "{self.page.name}" already used in organization'])
 
 
 class TemplateAdminTest(TestCase):
@@ -36,18 +49,21 @@ class TemplateAdminTest(TestCase):
         self.user = user_model.objects.create_superuser(email="test@test.com", password="testing")
         self.client.force_login(self.user)
         self.template_admin = TemplateAdmin(Template, AdminSite())
-        self.original_page = DonationPageFactory()
+        self.original_page = DonationPageFactory(name="My Test Page")
         self.template = self.original_page.make_template_from_page()
 
+    def _get_change_url(self, template_id):
+        return reverse("admin:pages_template_change", kwargs={"object_id": template_id})
+
     def test_make_template_button_appears_in_change_form(self):
-        change_url = reverse("admin:pages_template_change", kwargs={"object_id": self.template.id})
+        change_url = self._get_change_url(self.template.id)
         response = self.client.get(change_url)
         self.assertContains(response, "Make page from this template")
 
     def test_new_page_is_created_from_template(self):
         request_body = {"_page-from-template": True}
-        url = reverse("admin:pages_template_change", kwargs={"object_id": self.template.id})
-        request = self.factory.post(url, request_body)
+        change_url = self._get_change_url(self.template.id)
+        request = self.factory.post(change_url, request_body)
         setup_request(self.user, request)
         prev_page_count = DonationPage.objects.count()
         template = Template.objects.first()
@@ -57,11 +73,25 @@ class TemplateAdminTest(TestCase):
         self.assertNotEqual(prev_page_count, len(new_pages))
 
     def test_response_change_without_button_click_passes_through(self):
-        url = reverse("admin:pages_template_change", kwargs={"object_id": self.template.id})
-        request = self.factory.post(url)
+        change_url = self._get_change_url(self.template.id)
+        request = self.factory.post(change_url)
         setup_request(self.user, request)
         template = Template.objects.first()
         response = self.template_admin.response_change(request, template)
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(reverse("admin:pages_template_changelist"), response.url)
+
+    def test_make_page_error_messages_when_duplicate_name(self):
+        change_url = self._get_change_url(self.template.id)
+        # Make page with target name once...
+        self.client.post(change_url, {"_page-from-template": True})
+        # ...then try to do it again
+        response = self.client.post(change_url, {"_page-from-template": True})
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertEqual(
+            messages,
+            [
+                f'Donation Page name "New Page From Template ({self.template.name})" already used in organization. Did you forget to update the name of a previous page created from this template?'
+            ],
+        )

--- a/apps/pages/tests/test_models.py
+++ b/apps/pages/tests/test_models.py
@@ -27,18 +27,6 @@ class DonationPageTest(TestCase):
 
         self.assertFalse(self.instance.is_live)
 
-    def test_save_as_template(self):
-        # without name arugment, uses page.heading for template.name
-        template, _ = self.instance.save_as_template()
-
-        self.assertEqual(template.name, self.instance.name)
-
-        # with name argument, uses that for template.name
-        new_name = "My New Template"
-        template, _ = self.instance.save_as_template(name=new_name)
-
-        self.assertEqual(template.name, new_name)
-
 
 class StyleTest(TestCase):
     def setUp(self):

--- a/apps/pages/tests/test_serializers.py
+++ b/apps/pages/tests/test_serializers.py
@@ -167,6 +167,18 @@ class TemplateDetailSerializerTest(APITestCase):
         self.assertIn("page", v_error.exception.detail)
         self.assertEqual(str(v_error.exception.detail["page"][0]), "This page no longer exists")
 
+    def test_serializer_does_not_require_org(self):
+        """
+        The organization associated with newly created templates is derived from the originating page.
+        Adding it to the serializer here would require it as a request parameter.
+        """
+        template_data = {
+            "page_pk": self.page.pk,
+            "name": "My New Template",
+        }
+        serializer = self.serializer(data=template_data)
+        self.assertTrue(serializer.is_valid())
+
 
 class StyleListSerializerTest(APITestCase):
     def setUp(self):

--- a/apps/pages/tests/test_serializers.py
+++ b/apps/pages/tests/test_serializers.py
@@ -1,5 +1,6 @@
 from django.utils import timezone
 
+from rest_framework import serializers
 from rest_framework.test import APITestCase
 
 from apps.organizations.models import BenefitLevelBenefit, RevenueProgramBenefitLevel
@@ -9,8 +10,12 @@ from apps.organizations.tests.factories import (
     OrganizationFactory,
     RevenueProgramFactory,
 )
-from apps.pages.serializers import DonationPageFullDetailSerializer, StyleListSerializer
-from apps.pages.tests.factories import DonationPageFactory, StyleFactory
+from apps.pages.serializers import (
+    DonationPageFullDetailSerializer,
+    StyleListSerializer,
+    TemplateDetailSerializer,
+)
+from apps.pages.tests.factories import DonationPageFactory, StyleFactory, TemplateFactory
 
 
 class DonationPageFullDetailSerializerTest(APITestCase):
@@ -87,6 +92,80 @@ class DonationPageFullDetailSerializerTest(APITestCase):
         serializer = self.serializer(self.page)
         data = serializer.data
         self.assertEqual(data["organization_is_nonprofit"], False)
+
+    def test_check_against_soft_deleted_slugs(self):
+        validated_data = {"slug": self.page.slug}
+        serializer = self.serializer(self.page)
+        # It should return none if slug isn't a deleted slug
+        self.assertIsNone(serializer._check_against_soft_deleted_slugs(validated_data))
+
+        # Delete w/ soft-delete (default) raises validation error
+        self.page.delete()
+        serializer = self.serializer(self.page)
+        self.assertRaises(serializers.ValidationError, serializer._check_against_soft_deleted_slugs, validated_data)
+
+    def test_create_with_template_pk_uses_template_as_data(self):
+        template = TemplateFactory(organization=self.organization)
+        # new_page_name
+        new_page_data = {
+            "template_pk": template.pk,
+            "name": "My New Page From a Template",
+            "slug": "my-new-page-from-a-template",
+            "revenue_program_pk": self.revenue_program.pk,
+        }
+        serializer = self.serializer(data=new_page_data)
+        self.assertTrue(serializer.is_valid())
+        new_page = serializer.save()
+        self.assertEqual(new_page.heading, template.heading)
+
+    def test_create_with_template_pk_throws_error_if_template_missing(self):
+        template = TemplateFactory(organization=self.organization)
+        new_page_data = {
+            "template_pk": 99999,
+            "name": "My New Page From a Template",
+            "slug": "my-new-page-from-a-template",
+            "revenue_program_pk": self.revenue_program.pk,
+        }
+        serializer = self.serializer(data=new_page_data)
+        self.assertTrue(serializer.is_valid())
+        # Should raise validation error if invalid pk
+        with self.assertRaises(serializers.ValidationError) as v_error:
+            serializer.save()
+        self.assertIn("template", v_error.exception.detail)
+        self.assertEqual(str(v_error.exception.detail["template"][0]), "This template no longer exists")
+
+
+class TemplateDetailSerializerTest(APITestCase):
+    def setUp(self):
+        self.organization = OrganizationFactory()
+        self.template = TemplateFactory(organization=self.organization)
+        self.page = DonationPageFactory()
+        self.serializer = TemplateDetailSerializer
+
+    def test_create_with_page_pk_uses_page_as_template(self):
+        template_data = {
+            "page_pk": self.page.pk,
+            "name": "My New Template",
+            "organization": self.organization.pk,
+        }
+        serializer = self.serializer(data=template_data)
+        self.assertTrue(serializer.is_valid())
+        new_template = serializer.save()
+        self.assertEqual(new_template.heading, self.page.heading)
+
+    def test_create_with_page_pk_raises_error_when_page_missing(self):
+        template_data = {
+            "page_pk": self.page.pk,
+            "name": "My New Template",
+            "organization": self.organization.pk,
+        }
+        serializer = self.serializer(data=template_data)
+        self.assertTrue(serializer.is_valid())
+        self.page.delete()
+        with self.assertRaises(serializers.ValidationError) as v_error:
+            new_template = serializer.save()
+        self.assertIn("page", v_error.exception.detail)
+        self.assertEqual(str(v_error.exception.detail["page"][0]), "This page no longer exists")
 
 
 class StyleListSerializerTest(APITestCase):

--- a/apps/pages/tests/test_viewsets.py
+++ b/apps/pages/tests/test_viewsets.py
@@ -33,6 +33,7 @@ class PageViewSetTest(AbstractTestCase):
         self.authenticate_user_for_resource(self.rev_program)
         self.login()
 
+    # CREATE
     def test_page_create_adds_page(self):
         self.assertEqual(len(self.resources), self.resource_count)
         self.login()
@@ -86,6 +87,16 @@ class PageViewSetTest(AbstractTestCase):
         self.assertIn("revenue_program", response.data)
         self.assertIn("slug", response.data["revenue_program"])
 
+    def test_page_create_adds_template_values_when_valid_pk(self):
+        pass
+
+    def test_page_create_returns_validation_error_when_invalid_template_pk(self):
+        pass
+
+    def test_page_create_returns_validation_error_when_template_has_invalid_styles_pk(self):
+        pass
+
+    # UPDATE
     def test_page_update_updates_page(self):
         page = self.resources[0]
         self.authenticate_user_for_resource(page)
@@ -308,15 +319,15 @@ class TemplateViewSetTest(AbstractTestCase):
         template = self.resources[0]
         self.authenticate_user_for_resource(template)
         self.login()
-        old_template_heading = template.heading
+        old_template_name = template.name
         old_template_pk = template.pk
         detail_url = f"/api/v1/templates/{old_template_pk}/"
-        new_heading = "Old Template With New Heading"
-        response = self.client.patch(detail_url, {"heading": new_heading})
+        new_name = "Old Template With New Name"
+        self.client.patch(detail_url, {"name": new_name})
         template = Template.objects.filter(pk=old_template_pk).first()
         self.assertEqual(template.pk, old_template_pk)
-        self.assertNotEqual(template.heading, old_template_heading)
-        self.assertEqual(template.heading, new_heading)
+        self.assertNotEqual(template.name, old_template_name)
+        self.assertEqual(template.name, new_name)
 
     def test_template_delete_deletes_template(self):
         template = self.resources[0]
@@ -324,7 +335,7 @@ class TemplateViewSetTest(AbstractTestCase):
         self.login()
         old_template_pk = template.pk
         detail_url = f"/api/v1/templates/{old_template_pk}/"
-        response = self.client.delete(detail_url)
+        self.client.delete(detail_url)
         self.assertRaises(Template.DoesNotExist, Template.objects.get, pk=old_template_pk)
 
     def test_template_list_uses_list_serializer(self):
@@ -361,9 +372,9 @@ class TemplateViewSetTest(AbstractTestCase):
         data = response.json()
 
         # Should return expected number of pages
-        self.assertEqual(user_templates.count(), data["count"])
+        self.assertEqual(user_templates.count(), len(data))
 
-        returned_ids = [p["id"] for p in data["results"]]
+        returned_ids = [p["id"] for p in data]
         expected_ids = [p.id for p in user_templates]
         # Should return expected pages
         self.assertEqual(set(expected_ids), set(returned_ids))

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -100,9 +100,18 @@ class PageViewSet(OrganizationLimitedListView, viewsets.ModelViewSet):
 class TemplateViewSet(OrganizationLimitedListView, viewsets.ModelViewSet):
     model = Template
     permission_classes = [IsAuthenticated, UserBelongsToOrg]
+    pagination_class = None
 
     def get_serializer_class(self):
-        return serializers.TemplateDetailSerializer if self.action == "retrieve" else serializers.TemplateListSerializer
+        return (
+            serializers.TemplateDetailSerializer
+            if self.action
+            in (
+                "retrieve",
+                "create",
+            )
+            else serializers.TemplateListSerializer
+        )
 
 
 class StyleViewSet(OrganizationLimitedListView, viewsets.ModelViewSet):

--- a/spa/cypress/fixtures/pages/templates.json
+++ b/spa/cypress/fixtures/pages/templates.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "name": "My First Template"
+  },
+  {
+    "id": 2,
+    "name": "My Second Template"
+  },
+  {
+    "id": 3,
+    "name": "My Third Template"
+  }
+]

--- a/spa/cypress/integration/donation-page-list.spec.js
+++ b/spa/cypress/integration/donation-page-list.spec.js
@@ -1,4 +1,4 @@
-import { LIST_PAGES, REVENUE_PROGRAMS } from 'ajax/endpoints';
+import { LIST_PAGES, REVENUE_PROGRAMS, TEMPLATES } from 'ajax/endpoints';
 import { CONTENT_SLUG } from 'routes';
 import { getEndpoint } from '../support/util';
 
@@ -51,5 +51,15 @@ describe('Donation page list', () => {
       cy.getByTestId('page-name').blur();
       cy.getByTestId('page-slug').should('have.value', 'my-testing-page');
     });
+
+    it('should show template list dropdown, if templates exist', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(TEMPLATES) },
+        { fixture: 'pages/templates.json', statusCode: 200 }
+      );
+      cy.getByTestId('template-picker').should('exist');
+    });
+
+    it('should contain rev_program_pk and template_pk in outoing request', () => {});
   });
 });

--- a/spa/cypress/integration/donation-page-list.spec.js
+++ b/spa/cypress/integration/donation-page-list.spec.js
@@ -57,9 +57,33 @@ describe('Donation page list', () => {
         { method: 'GET', pathname: getEndpoint(TEMPLATES) },
         { fixture: 'pages/templates.json', statusCode: 200 }
       );
+      cy.getByTestId('page-create-button').click();
       cy.getByTestId('template-picker').should('exist');
     });
 
-    it('should contain rev_program_pk and template_pk in outoing request', () => {});
+    it('should contain rev_program_pk and template_pk in outoing request', () => {
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(REVENUE_PROGRAMS) },
+        { fixture: 'org/revenue-programs-1.json', statusCode: 200 }
+      );
+      cy.intercept(
+        { method: 'GET', pathname: getEndpoint(TEMPLATES) },
+        { fixture: 'pages/templates.json', statusCode: 200 }
+      );
+      cy.getByTestId('page-create-button').click();
+      cy.getByTestId('page-name').type('My Testing Page');
+      cy.getByTestId('page-name').blur();
+      cy.getByTestId('revenue-program-picker').click();
+      cy.getByTestId('select-item-0').click();
+      cy.getByTestId('template-picker').click();
+      cy.getByTestId('select-item-0').click();
+
+      cy.intercept({ method: 'POST', pathname: getEndpoint(LIST_PAGES) }).as('createNewPage');
+      cy.getByTestId('save-new-page-button').click();
+      cy.wait('@createNewPage').then(({ request }) => {
+        expect(request.body).to.have.property('revenue_program_pk');
+        expect(request.body).to.have.property('template_pk');
+      });
+    });
   });
 });

--- a/spa/cypress/integration/donation-page-list.spec.js
+++ b/spa/cypress/integration/donation-page-list.spec.js
@@ -65,12 +65,13 @@ describe('Donation page list', () => {
       cy.intercept(
         { method: 'GET', pathname: getEndpoint(REVENUE_PROGRAMS) },
         { fixture: 'org/revenue-programs-1.json', statusCode: 200 }
-      );
+      ).as('getRevPrograms');
       cy.intercept(
         { method: 'GET', pathname: getEndpoint(TEMPLATES) },
         { fixture: 'pages/templates.json', statusCode: 200 }
-      );
+      ).as('getTemplates');
       cy.getByTestId('page-create-button').click();
+      cy.wait(['@getRevPrograms', '@getTemplates']);
       cy.getByTestId('page-name').type('My Testing Page');
       cy.getByTestId('page-name').blur();
       cy.getByTestId('revenue-program-picker').click();

--- a/spa/cypress/integration/donation-page-list.spec.js
+++ b/spa/cypress/integration/donation-page-list.spec.js
@@ -61,7 +61,7 @@ describe('Donation page list', () => {
       cy.getByTestId('template-picker').should('exist');
     });
 
-    it('should contain rev_program_pk and template_pk in outoing request', () => {
+    it.only('should contain rev_program_pk and template_pk in outoing request', () => {
       cy.intercept(
         { method: 'GET', pathname: getEndpoint(REVENUE_PROGRAMS) },
         { fixture: 'org/revenue-programs-1.json', statusCode: 200 }

--- a/spa/src/ajax/endpoints.js
+++ b/spa/src/ajax/endpoints.js
@@ -13,6 +13,9 @@ export const LIST_PAGES = 'pages/';
 export const PATCH_PAGE = 'pages/';
 export const DELETE_PAGE = 'pages/';
 
+// Templates
+export const TEMPLATES = 'templates/';
+
 // Styles
 export const LIST_STYLES = 'styles/';
 

--- a/spa/src/components/content/pages/AddPageModal.js
+++ b/spa/src/components/content/pages/AddPageModal.js
@@ -162,7 +162,7 @@ function AddPageModal({ isOpen, closeModal }) {
               />
             </S.InputWrapper>
             {revenuePrograms.length > 0 && (
-              <S.InputWrapper data-testid="revenue-program-picker">
+              <S.InputWrapper>
                 <Select
                   label="Choose a revenue program for this page"
                   onSelectedItemChange={({ selectedItem }) => setRevenueProgram(selectedItem)}
@@ -172,6 +172,7 @@ function AddPageModal({ isOpen, closeModal }) {
                   placeholder="Select a revenue program"
                   dropdownPosition="above"
                   displayAccessor="name"
+                  testId="revenue-program-picker"
                 />
               </S.InputWrapper>
             )}
@@ -182,7 +183,7 @@ function AddPageModal({ isOpen, closeModal }) {
               </S.NoRevPrograms>
             )}
             {templates.length > 0 && (
-              <S.InputWrapper data-testid="template-picker">
+              <S.InputWrapper>
                 <Select
                   label="[Optional] Choose a page template"
                   onSelectedItemChange={({ selectedItem }) => setTemplate(selectedItem)}
@@ -192,6 +193,7 @@ function AddPageModal({ isOpen, closeModal }) {
                   placeholder="Select a template"
                   dropdownPosition="above"
                   displayAccessor="name"
+                  testId="template-picker"
                 />
               </S.InputWrapper>
             )}

--- a/spa/src/components/content/pages/AddPageModal.js
+++ b/spa/src/components/content/pages/AddPageModal.js
@@ -104,7 +104,9 @@ function AddPageModal({ isOpen, closeModal }) {
     [alert]
   );
 
-  const handleSave = async () => {
+  const handleSave = async (e) => {
+    e.preventDefault();
+    if (!canSavePage()) return;
     setLoading(true);
 
     const formData = {
@@ -135,81 +137,83 @@ function AddPageModal({ isOpen, closeModal }) {
     <Modal isOpen={isOpen} closeModal={closeModal}>
       <S.AddPageModal data-testid="page-create-modal">
         <S.ModalTitle>Create a new donation page</S.ModalTitle>
-        <S.PageForm>
-          <S.InputWrapper>
-            <Input
-              label="Name"
-              helpText="Unique name for this page"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              onBlur={handleNameBlur}
-              errors={errors?.name}
-              testid="page-name"
-            />
-          </S.InputWrapper>
-          <S.InputWrapper>
-            <Input
-              label="Slug"
-              helpText="How this page appears in the url"
-              value={slug}
-              onChange={(e) => setSlug(e.target.value)}
-              onBlur={handleSlugBlur}
-              errors={errors?.slug}
-              testid="page-slug"
-            />
-          </S.InputWrapper>
-          {revenuePrograms.length > 0 && (
-            <S.InputWrapper data-testid="revenue-program-picker">
-              <Select
-                label="Choose a revenue program for this page"
-                onSelectedItemChange={({ selectedItem }) => setRevenueProgram(selectedItem)}
-                selectedItem={revenueProgram}
-                items={revenuePrograms}
-                itemToString={(i) => i.name}
-                placeholder="Select a revenue program"
-                dropdownPosition="above"
-                displayAccessor="name"
+        <S.PageForm onSubmit={handleSave}>
+          <S.FormFields>
+            <S.InputWrapper>
+              <Input
+                label="Name"
+                helpText="Unique name for this page"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onBlur={handleNameBlur}
+                errors={errors?.name}
+                testid="page-name"
               />
             </S.InputWrapper>
-          )}
-          {!loading && revenuePrograms.length === 0 && (
-            <S.NoRevPrograms>
-              You need to set up a revenue program to create a page.{' '}
-              <S.CreateRevProgramLink onClick={handleCreateRevProgram}>Create one?</S.CreateRevProgramLink>
-            </S.NoRevPrograms>
-          )}
-          {templates.length > 0 && (
-            <S.InputWrapper data-testid="template-picker">
-              <Select
-                label="[Optional] Choose a page template"
-                onSelectedItemChange={({ selectedItem }) => setTemplate(selectedItem)}
-                selectedItem={template}
-                items={templates}
-                itemToString={(i) => i.name}
-                placeholder="Select a template"
-                dropdownPosition="above"
-                displayAccessor="name"
+            <S.InputWrapper>
+              <Input
+                label="Slug"
+                helpText="How this page appears in the url"
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                onBlur={handleSlugBlur}
+                errors={errors?.slug}
+                testid="page-slug"
               />
             </S.InputWrapper>
-          )}
+            {revenuePrograms.length > 0 && (
+              <S.InputWrapper data-testid="revenue-program-picker">
+                <Select
+                  label="Choose a revenue program for this page"
+                  onSelectedItemChange={({ selectedItem }) => setRevenueProgram(selectedItem)}
+                  selectedItem={revenueProgram}
+                  items={revenuePrograms}
+                  itemToString={(i) => i.name}
+                  placeholder="Select a revenue program"
+                  dropdownPosition="above"
+                  displayAccessor="name"
+                />
+              </S.InputWrapper>
+            )}
+            {!loading && revenuePrograms.length === 0 && (
+              <S.NoRevPrograms>
+                You need to set up a revenue program to create a page.{' '}
+                <S.CreateRevProgramLink onClick={handleCreateRevProgram}>Create one?</S.CreateRevProgramLink>
+              </S.NoRevPrograms>
+            )}
+            {templates.length > 0 && (
+              <S.InputWrapper data-testid="template-picker">
+                <Select
+                  label="[Optional] Choose a page template"
+                  onSelectedItemChange={({ selectedItem }) => setTemplate(selectedItem)}
+                  selectedItem={template}
+                  items={templates}
+                  itemToString={(i) => i.name}
+                  placeholder="Select a template"
+                  dropdownPosition="above"
+                  displayAccessor="name"
+                />
+              </S.InputWrapper>
+            )}
+          </S.FormFields>
+          <S.Buttons>
+            <CircleButton
+              type="submit"
+              icon={faSave}
+              color={theme.colors.success}
+              buttonType="neutral"
+              disabled={!canSavePage()}
+              data-testid="save-new-page-button"
+            />
+            <CircleButton
+              onClick={handleDiscard}
+              icon={faTrash}
+              color={theme.colors.caution}
+              buttonType="neutral"
+              data-testid="discard-new-page-button"
+            />
+          </S.Buttons>
         </S.PageForm>
-        <S.Buttons>
-          <CircleButton
-            onClick={handleSave}
-            icon={faSave}
-            color={theme.colors.success}
-            type="neutral"
-            disabled={!canSavePage()}
-            data-testid="save-new-page-button"
-          />
-          <CircleButton
-            onClick={handleDiscard}
-            icon={faTrash}
-            color={theme.colors.caution}
-            type="neutral"
-            data-testid="discard-new-page-button"
-          />
-        </S.Buttons>
       </S.AddPageModal>
     </Modal>
   );

--- a/spa/src/components/content/pages/AddPageModal.js
+++ b/spa/src/components/content/pages/AddPageModal.js
@@ -200,14 +200,14 @@ function AddPageModal({ isOpen, closeModal }) {
             color={theme.colors.success}
             type="neutral"
             disabled={!canSavePage()}
-            data-testid="save-styles-button"
+            data-testid="save-new-page-button"
           />
           <CircleButton
             onClick={handleDiscard}
             icon={faTrash}
             color={theme.colors.caution}
             type="neutral"
-            data-testid="discard-styles-button"
+            data-testid="discard-new-page-button"
           />
         </S.Buttons>
       </S.AddPageModal>

--- a/spa/src/components/content/pages/AddPageModal.styled.js
+++ b/spa/src/components/content/pages/AddPageModal.styled.js
@@ -14,7 +14,9 @@ export const ModalTitle = styled.h2`
   padding: 2rem 4rem 0;
 `;
 
-export const PageForm = styled.form`
+export const PageForm = styled.form``;
+
+export const FormFields = styled.div`
   flex: 1;
   overflow-y: auto;
   padding: 2rem 4rem;

--- a/spa/src/components/pageEditor/CreateTemplateModal.js
+++ b/spa/src/components/pageEditor/CreateTemplateModal.js
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import * as S from './CreateTemplateModal.styled';
+
+// Assets
+import { faSave, faTrash } from '@fortawesome/free-solid-svg-icons';
+
+// Deps
+import { useTheme } from 'styled-components';
+import { useAlert } from 'react-alert';
+
+// AJAX
+import useRequest from 'hooks/useRequest';
+import { TEMPLATES } from 'ajax/endpoints';
+
+// Constants
+import { GENERIC_ERROR } from 'constants/textConstants';
+
+// Components
+import CircleButton from 'elements/buttons/CircleButton';
+import Modal from 'elements/modal/Modal';
+import Input from 'elements/inputs/Input';
+
+function CreateTemplateModal({ isOpen, closeModal, page = {} }) {
+  const alert = useAlert();
+  const theme = useTheme();
+
+  const requestCreateTemplate = useRequest();
+
+  const [name, setName] = useState(page?.name || '');
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState({});
+
+  const onSuccess = ({ data }) => {
+    const templateName = data['name'];
+    const successMessage = `Create a new template: ${templateName}`;
+    alert.success(successMessage);
+    closeModal();
+  };
+
+  const onFailure = (e) => {
+    if (e?.response?.data) {
+      setErrors(e.response.data);
+    } else {
+      alert.error(GENERIC_ERROR);
+    }
+  };
+
+  const handleSave = () => {
+    setLoading(true);
+    const data = {
+      page_pk: page.id,
+      name
+    };
+    requestCreateTemplate(
+      {
+        method: 'POST',
+        url: TEMPLATES,
+        data
+      },
+      {
+        onSuccess,
+        onFailure
+      }
+    );
+    setLoading(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} closeModal={closeModal}>
+      <S.CreateTemplateModal data-testid="page-create-modal">
+        <S.ModalTitle>Create a template from page "{page.name}"</S.ModalTitle>
+        <S.PageForm>
+          <S.InputWrapper>
+            <Input
+              label="Name this template"
+              helpText="Unique name for this template"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              errors={errors?.name}
+              testid="page-name"
+            />
+          </S.InputWrapper>
+        </S.PageForm>
+        <S.Buttons>
+          <CircleButton
+            onClick={handleSave}
+            icon={faSave}
+            color={theme.colors.success}
+            type="neutral"
+            disabled={!name || loading}
+            data-testid="save-styles-button"
+          />
+          <CircleButton
+            onClick={closeModal}
+            icon={faTrash}
+            color={theme.colors.caution}
+            type="neutral"
+            disabled={loading}
+            data-testid="discard-styles-button"
+          />
+        </S.Buttons>
+      </S.CreateTemplateModal>
+    </Modal>
+  );
+}
+
+export default CreateTemplateModal;

--- a/spa/src/components/pageEditor/CreateTemplateModal.js
+++ b/spa/src/components/pageEditor/CreateTemplateModal.js
@@ -67,7 +67,7 @@ function CreateTemplateModal({ isOpen, closeModal, page = {} }) {
 
   return (
     <Modal isOpen={isOpen} closeModal={closeModal}>
-      <S.CreateTemplateModal data-testid="page-create-modal">
+      <S.CreateTemplateModal data-testid="template-create-modal">
         <S.ModalTitle>Create a template from page "{page.name}"</S.ModalTitle>
         <S.PageForm>
           <S.InputWrapper>
@@ -88,7 +88,7 @@ function CreateTemplateModal({ isOpen, closeModal, page = {} }) {
             color={theme.colors.success}
             type="neutral"
             disabled={!name || loading}
-            data-testid="save-styles-button"
+            data-testid="save-template-button"
           />
           <CircleButton
             onClick={closeModal}
@@ -96,7 +96,7 @@ function CreateTemplateModal({ isOpen, closeModal, page = {} }) {
             color={theme.colors.caution}
             type="neutral"
             disabled={loading}
-            data-testid="discard-styles-button"
+            data-testid="discard-template-button"
           />
         </S.Buttons>
       </S.CreateTemplateModal>

--- a/spa/src/components/pageEditor/CreateTemplateModal.js
+++ b/spa/src/components/pageEditor/CreateTemplateModal.js
@@ -19,6 +19,7 @@ import { GENERIC_ERROR } from 'constants/textConstants';
 import CircleButton from 'elements/buttons/CircleButton';
 import Modal from 'elements/modal/Modal';
 import Input from 'elements/inputs/Input';
+import FormErrors from 'elements/inputs/FormErrors';
 
 function CreateTemplateModal({ isOpen, closeModal, page = {} }) {
   const alert = useAlert();
@@ -45,7 +46,8 @@ function CreateTemplateModal({ isOpen, closeModal, page = {} }) {
     }
   };
 
-  const handleSave = () => {
+  const handleSave = (e) => {
+    e.preventDefault();
     setLoading(true);
     const data = {
       page_pk: page.id,
@@ -69,36 +71,39 @@ function CreateTemplateModal({ isOpen, closeModal, page = {} }) {
     <Modal isOpen={isOpen} closeModal={closeModal}>
       <S.CreateTemplateModal data-testid="template-create-modal">
         <S.ModalTitle>Create a template from page "{page.name}"</S.ModalTitle>
-        <S.PageForm>
-          <S.InputWrapper>
-            <Input
-              label="Name this template"
-              helpText="Unique name for this template"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              errors={errors?.name}
-              testid="page-name"
+        <S.TemplateForm onSubmit={handleSave}>
+          <S.FormFields>
+            <S.InputWrapper>
+              <Input
+                label="Name this template"
+                helpText="Unique name for this template"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                errors={errors?.name}
+                testid="page-name"
+              />
+            </S.InputWrapper>
+            <FormErrors errors={errors?.non_field_errors} />
+          </S.FormFields>
+          <S.Buttons>
+            <CircleButton
+              type="submit"
+              icon={faSave}
+              color={theme.colors.success}
+              buttonType="neutral"
+              disabled={!name || loading}
+              data-testid="save-template-button"
             />
-          </S.InputWrapper>
-        </S.PageForm>
-        <S.Buttons>
-          <CircleButton
-            onClick={handleSave}
-            icon={faSave}
-            color={theme.colors.success}
-            type="neutral"
-            disabled={!name || loading}
-            data-testid="save-template-button"
-          />
-          <CircleButton
-            onClick={closeModal}
-            icon={faTrash}
-            color={theme.colors.caution}
-            type="neutral"
-            disabled={loading}
-            data-testid="discard-template-button"
-          />
-        </S.Buttons>
+            <CircleButton
+              onClick={closeModal}
+              icon={faTrash}
+              color={theme.colors.caution}
+              buttonType="neutral"
+              disabled={loading}
+              data-testid="discard-template-button"
+            />
+          </S.Buttons>
+        </S.TemplateForm>
       </S.CreateTemplateModal>
     </Modal>
   );

--- a/spa/src/components/pageEditor/CreateTemplateModal.styled.js
+++ b/spa/src/components/pageEditor/CreateTemplateModal.styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const AddPageModal = styled.div`
+export const CreateTemplateModal = styled.div`
   display: flex;
   flex-direction: column;
   max-height: 90vh;
@@ -23,13 +23,6 @@ export const PageForm = styled.form`
 export const InputWrapper = styled.div`
   width: 300px;
   margin-bottom: 1.5rem;
-`;
-
-export const NoRevPrograms = styled.p``;
-
-export const CreateRevProgramLink = styled.span`
-  color: ${(props) => props.theme.colors.link};
-  cursor: pointer;
 `;
 
 export const Buttons = styled.div`

--- a/spa/src/components/pageEditor/CreateTemplateModal.styled.js
+++ b/spa/src/components/pageEditor/CreateTemplateModal.styled.js
@@ -14,7 +14,9 @@ export const ModalTitle = styled.h2`
   padding: 2rem 4rem 0;
 `;
 
-export const PageForm = styled.form`
+export const TemplateForm = styled.form``;
+
+export const FormFields = styled.div`
   flex: 1;
   overflow-y: auto;
   padding: 2rem 4rem;

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -361,7 +361,7 @@ function PageEditor() {
             onClick={handlePreview}
             selected={selectedButton === PREVIEW}
             icon={faEye}
-            type="neutral"
+            buttonType="neutral"
             color={theme.colors.primary}
             data-testid="preview-page-button"
           />
@@ -369,18 +369,23 @@ function PageEditor() {
             onClick={handleEdit}
             selected={selectedButton === EDIT}
             icon={faEdit}
-            type="neutral"
+            buttonType="neutral"
             data-testid="edit-page-button"
           />
           <CircleButton
             onClick={handleSave}
             icon={faSave}
-            type="neutral"
+            buttonType="neutral"
             data-testid="save-page-button"
             disabled={!updatedPage}
           />
-          <CircleButton onClick={handleMakeTemplate} icon={faClone} type="neutral" data-testid="clone-page-button" />
-          <CircleButton onClick={handleDelete} icon={faTrash} type="caution" data-testid="delete-page-button" />
+          <CircleButton
+            onClick={handleMakeTemplate}
+            icon={faClone}
+            buttonType="neutral"
+            data-testid="clone-page-button"
+          />
+          <CircleButton onClick={handleDelete} icon={faTrash} buttonType="caution" data-testid="delete-page-button" />
 
           <BackButton to={CONTENT_SLUG} />
         </S.ButtonOverlay>

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -379,7 +379,7 @@ function PageEditor() {
             data-testid="save-page-button"
             disabled={!updatedPage}
           />
-          <CircleButton onClick={handleMakeTemplate} icon={faClone} type="neutral" data-testid="edit-page-button" />
+          <CircleButton onClick={handleMakeTemplate} icon={faClone} type="neutral" data-testid="clone-page-button" />
           <CircleButton onClick={handleDelete} icon={faTrash} type="caution" data-testid="delete-page-button" />
 
           <BackButton to={CONTENT_SLUG} />

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -30,7 +30,7 @@ import { CONTENT_SLUG } from 'routes';
 import { GENERIC_ERROR } from 'constants/textConstants';
 
 // Assets
-import { faEye, faEdit, faSave, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faEye, faEdit, faSave, faTrash, faClone } from '@fortawesome/free-solid-svg-icons';
 
 // Context
 import { useGlobalContext } from 'components/MainLayout';
@@ -47,6 +47,7 @@ import DonationPage from 'components/donationPage/DonationPage';
 import GlobalLoading from 'elements/GlobalLoading';
 import EditInterface from 'components/pageEditor/editInterface/EditInterface';
 import BackButton from 'elements/BackButton';
+import CreateTemplateModal from 'components/pageEditor/CreateTemplateModal';
 
 const PageEditorContext = createContext();
 
@@ -84,6 +85,7 @@ function PageEditor() {
   const [page, setPage] = useState();
   const [availableStyles, setAvailableStyles] = useState([]);
   const [contributionMetadata, setContributionMetadata] = useState([]);
+  const [showCreateTemplateModal, setShowCreateTemplateModal] = useState(false);
 
   const [updatedPage, setUpdatedPage] = useState();
   const [selectedButton, setSelectedButton] = useState(PREVIEW);
@@ -162,6 +164,16 @@ function PageEditor() {
   const handleEdit = () => {
     setSelectedButton(EDIT);
     setShowEditInterface(true);
+  };
+
+  const handleMakeTemplate = () => {
+    if (updatedPage) {
+      getUserConfirmation('Page template will not include unsaved changes. Continue?', () =>
+        setShowCreateTemplateModal(true)
+      );
+    } else {
+      setShowCreateTemplateModal(true);
+    }
   };
 
   const handleSave = () => {
@@ -287,6 +299,7 @@ function PageEditor() {
           alert.success(successMessage);
           setErrors({});
           setPage(data);
+          setUpdatedPage(null);
           setSelectedButton(PREVIEW);
           setLoading(false);
         },
@@ -366,11 +379,19 @@ function PageEditor() {
             data-testid="save-page-button"
             disabled={!updatedPage}
           />
-          <CircleButton onClick={handleDelete} icon={faTrash} type="neutral" data-testid="delete-page-button" />
+          <CircleButton onClick={handleMakeTemplate} icon={faClone} type="neutral" data-testid="edit-page-button" />
+          <CircleButton onClick={handleDelete} icon={faTrash} type="caution" data-testid="delete-page-button" />
 
           <BackButton to={CONTENT_SLUG} />
         </S.ButtonOverlay>
       </S.PageEditor>
+      {showCreateTemplateModal && (
+        <CreateTemplateModal
+          page={page}
+          isOpen={showCreateTemplateModal}
+          closeModal={() => setShowCreateTemplateModal(false)}
+        />
+      )}
     </PageEditorContext.Provider>
   );
 }

--- a/spa/src/components/pageEditor/editInterface/pageElements/ElementProperties.js
+++ b/spa/src/components/pageEditor/editInterface/pageElements/ElementProperties.js
@@ -94,13 +94,13 @@ function ElementProperties({ selectedElementType }) {
       <S.Buttons>
         <CircleButton
           icon={faCheck}
-          type="positive"
+          buttonType="positive"
           onClick={handleKeepChanges}
           data-testid="keep-element-changes-button"
         />
         <CircleButton
           icon={faTimes}
-          type="caution"
+          buttonType="caution"
           onClick={handleDiscardChanges}
           data-testid="discard-element-changes-button"
         />

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -151,13 +151,13 @@ function PageSetup({ backToProperties }) {
       <S.Buttons>
         <CircleButton
           icon={faCheck}
-          type="positive"
+          buttonType="positive"
           onClick={handleKeepChanges}
           data-testid="keep-element-changes-button"
         />
         <CircleButton
           icon={faTimes}
-          type="caution"
+          buttonType="caution"
           onClick={handleDiscardChanges}
           data-testid="discard-element-changes-button"
         />

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
@@ -41,13 +41,13 @@ function PageStyles({ backToProperties }) {
       <S.Buttons>
         <CircleButton
           icon={faCheck}
-          type="positive"
+          buttonType="positive"
           onClick={handleKeepChanges}
           data-testid="keep-element-changes-button"
         />
         <CircleButton
           icon={faTimes}
-          type="caution"
+          buttonType="caution"
           onClick={handleDiscardChanges}
           data-testid="discard-element-changes-button"
         />

--- a/spa/src/components/stylesEditor/StylesEditor.js
+++ b/spa/src/components/stylesEditor/StylesEditor.js
@@ -222,14 +222,14 @@ function StylesEditor({ styles, setStyles, handleKeepChanges, handleDiscardChang
           onClick={handleSave}
           icon={faSave}
           loading={loading}
-          type="neutral"
+          buttonType="neutral"
           data-testid="save-styles-button"
         />
         <CircleButton
           onClick={handleDiscard}
           icon={faTimes}
           loading={loading}
-          type="neutral"
+          buttonType="neutral"
           data-testid="discard-styles-button"
         />
         {isUpdate && (
@@ -237,7 +237,7 @@ function StylesEditor({ styles, setStyles, handleKeepChanges, handleDiscardChang
             onClick={handleDelete}
             icon={faTrash}
             loading={loading}
-            type="caution"
+            buttonType="caution"
             data-testid="discard-styles-button"
           />
         )}

--- a/spa/src/elements/buttons/CircleButton.js
+++ b/spa/src/elements/buttons/CircleButton.js
@@ -1,10 +1,14 @@
 import Spinner from 'elements/Spinner';
 import * as S from './CircleButton.styled';
 
-function CircleButton({ icon, color, onClick, disabled, loading, ...props }) {
+function CircleButton({ icon, type, color, onClick, disabled, loading, ...props }) {
   return (
-    <S.CircleButton {...props} disabled={disabled} onClick={disabled || loading ? () => {} : onClick}>
-      {loading ? <Spinner /> : <S.Icon icon={icon} type={props.type} color={color} disabled={disabled || loading} />}
+    <S.CircleButton {...props} type={type} disabled={disabled} onClick={disabled || loading ? () => {} : onClick}>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <S.Icon icon={icon} type={props.buttonType} color={color} disabled={disabled || loading} />
+      )}
     </S.CircleButton>
   );
 }

--- a/spa/src/elements/inputs/Select.js
+++ b/spa/src/elements/inputs/Select.js
@@ -12,6 +12,7 @@ function Select({
   dropdownPosition,
   displayAccessor,
   placeholder,
+  testId,
   ...props
 }) {
   const { isOpen, getToggleButtonProps, getLabelProps, getMenuProps, highlightedIndex, getItemProps } = useSelect({
@@ -23,7 +24,7 @@ function Select({
   return (
     <BaseField labelProps={{ ...getLabelProps() }} {...props}>
       <S.SelectWrapper>
-        <S.Select type="button" {...getToggleButtonProps()} suppressRefError>
+        <S.Select type="button" {...getToggleButtonProps()} suppressRefError data-testid={testId}>
           {(selectedItem && selectedItem[displayAccessor]) || placeholder}
         </S.Select>
         {isOpen && (

--- a/spa/src/elements/inputs/Select.styled.js
+++ b/spa/src/elements/inputs/Select.styled.js
@@ -35,10 +35,10 @@ export const List = styled.ul`
   z-index: 2;
   list-style: none;
   background: ${(props) => props.theme.colors.inputBackground};
-  box-shadow: ${(props) => props.theme.shadows[1]};
+  box-shadow: ${(props) => props.theme.shadows[2]};
   border-radius: ${(props) => props.theme.radii[0]};
   border: 1px solid;
-  border-color: ${(props) => props.theme.colors.grey[0]};
+  border-color: ${(props) => props.theme.colors.grey[2]};
 
   overflow-y: auto;
 `;


### PR DESCRIPTION
#### What's this PR do?
Implements template creation and template use from the Org Admin.

#### How should this be manually tested?
From the page edit view, notice a new button that you can use to create a template from the existing page. Try it out.
Then, from the page-create modal, notice a new optional dropdown for selecting a template from which to make your new page. Try that out too!

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
