### PR TITLE
[NRH-410] ThankYou page redirect failure

### DIFF
--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -112,7 +112,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
       const email = extractEmailFromFormRef(formRef.current);
       const donationPageUrl = window.location.href;
       history.push({
-        pathname: url + THANK_YOU_SLUG,
+        pathname: url === '/' ? THANK_YOU_SLUG : url + THANK_YOU_SLUG,
         state: { page, amount, email, donationPageUrl }
       });
     }


### PR DESCRIPTION
#### What's this PR do?
Thank you page urls were malformed after subdomain work.

#### How should this be manually tested?
Make a donation page. Should successfully go to thank you page

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No