### PR TITLE
[NRH-415] Validation theft

### DIFF
--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -53,6 +53,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const [disabled, setDisabled] = useState(true);
   const [paymentRequest, setPaymentRequest] = useState(null);
   const [forceManualCard, setForceManualCard] = useState(false);
+  const [stripeError, setStripeError] = useState();
 
   const theme = useTheme();
   const history = useHistory();
@@ -81,9 +82,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const handleCardElementChange = async (event) => {
     setCardReady(event.complete);
     setDisabled(event.empty);
-    const errs = { ...errors };
-    if (event?.error?.message) errs.stripe = event.error.message;
-    setErrors(errs);
+    setStripeError(event?.error?.message);
   };
 
   /**
@@ -103,6 +102,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const handlePaymentSuccess = (pr) => {
     if (pr) pr.complete('success');
     setErrors({});
+    setStripeError(null);
     setLoading(false);
     setSucceeded(true);
     trackConversion(amount);
@@ -120,7 +120,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
 
   const handlePaymentFailure = (error, pr) => {
     if (error instanceof StripeError) {
-      setErrors({ stripe: `Payment failed: ${error}` });
+      setStripeError(`Payment failed: ${error}`);
       alert.error(`Payment failed: ${error}`);
     } else {
       const internalErrors = error?.response?.data;
@@ -311,9 +311,9 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
           />
         </S.PaymentElementWrapper>
       </BaseField>
-      {errors?.stripe && (
+      {stripeError && (
         <S.PaymentError role="alert" data-testid="donation-error">
-          {errors.stripe}
+          {stripeError}
         </S.PaymentError>
       )}
       {offerPayFees && <PayFeesWidget />}

--- a/spa/src/hooks/useErrorFocus.js
+++ b/spa/src/hooks/useErrorFocus.js
@@ -11,6 +11,7 @@ import isEmpty from 'lodash.isempty';
  */
 function useErrorFocus(formRef, errors) {
   useEffect(() => {
+    console.log('those errors tho', errors);
     if (!isEmpty(errors)) {
       const errorNames = Object.keys(errors);
       const inputNames = [...formRef.current.elements].map((el) => el.name);

--- a/spa/src/hooks/useErrorFocus.js
+++ b/spa/src/hooks/useErrorFocus.js
@@ -11,7 +11,6 @@ import isEmpty from 'lodash.isempty';
  */
 function useErrorFocus(formRef, errors) {
   useEffect(() => {
-    console.log('those errors tho', errors);
     if (!isEmpty(errors)) {
       const errorNames = Object.keys(errors);
       const inputNames = [...formRef.current.elements].map((el) => el.name);


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug in which modifying the credit card field of a previously submitted form with validation errors causes those previous validation errors to "steal" the focus from the credit card element.

#### How should this be manually tested?
Submit a payment with missing first_name. After validation errors come back, return to the credit card input without fixing the validation errors. If you start editing the credit card input, the first_name should not steal focus.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No