### PR TITLE
[NRH-4865] No android-keyboard on select widget

### DIFF
--- a/spa/src/elements/inputs/Select.js
+++ b/spa/src/elements/inputs/Select.js
@@ -34,6 +34,7 @@ function Select({
           data-testid={testId}
           value={selectedItem && displayAccessor ? selectedItem[displayAccessor] : selectedItem}
           readonly
+          inputmode="none"
         />
         <S.CaretWrapper animate={isOpen ? 'open' : 'closed'} variants={caretVariants}>
           <S.Caret icon={faAngleDown} />


### PR DESCRIPTION
#### What's this PR do?
Hopefully disables the caret and keyboard for the select widget on Android devices.

#### How should this be manually tested?
Find a select widget (dropdown/picklist) on an Android phone.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No