### PR TITLE
[NRH-4998] Broken address autofocus

### DIFF
--- a/spa/src/hooks/useErrorFocus.js
+++ b/spa/src/hooks/useErrorFocus.js
@@ -20,12 +20,21 @@ function useErrorFocus(formRef, errors) {
       const firstErrorName = inputNames.find((name) => errorNames.indexOf(name) !== -1);
       const targetElement = formRef.current.elements[firstErrorName];
       if (targetElement) {
+        let scrollableElement = targetElement;
+        if (targetElement.length) {
+          // targetElement, in some cases, is a NodeList with multiples, only one of which is visible in the DOM.
+          scrollableElement = findFirstVisibleChild(targetElement);
+        }
         // use this lib as polyfill for Safari iOS.
         // Focus in callback so we see the smooth scroll on other browsers (the ones that treat "focus" as an implied "scroll into view")
-        scrollIntoView(targetElement, scrollOptions, () => targetElement.focus());
+        scrollIntoView(scrollableElement, scrollOptions, () => scrollableElement.focus());
       }
     }
   }, [errors, formRef]);
 }
 
 export default useErrorFocus;
+
+function findFirstVisibleChild(nodeList) {
+  return [...nodeList].find((el) => el.offsetParent);
+}


### PR DESCRIPTION
#### What's this PR do?
Autofocus on mailing_street field was broken by the addition of a hidden field with the same `name` property. If this was the first errored field on the page, it would break autoscrolling altogether. This PR accounts for the possibility of a nodelist instead of a single element.

#### How should this be manually tested?
View a page in which the Donor Address block appears _above the Donor Info block_. Make a donation without filling in any information. This should now autoscroll and autofocus to the mailing_street field.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No