### PR TITLE
[NRH-5057] CSP Report Only

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -369,6 +369,21 @@ rjsmin = "1.1.0"
 six = ">=1.12.0"
 
 [[package]]
+name = "django-csp"
+version = "3.7"
+description = "Django Content Security Policy support."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Django = ">=1.8"
+
+[package.extras]
+jinja2 = ["jinja2 (>=2.9.6)"]
+tests = ["pytest (<4.0)", "pytest-django", "pytest-flakes (==1.0.1)", "pytest-pep8 (==1.0.6)", "pep8 (==1.4.6)", "mock (==1.0.1)", "six (==1.12.0)", "jinja2 (>=2.9.6)"]
+
+[[package]]
 name = "django-debug-toolbar"
 version = "3.2.1"
 description = "A configurable set of panels that display various debug information about the current request/response."
@@ -1548,7 +1563,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "f998fee93d7b42348d4ae03adc5a96deeee8edaea10e7c9bba214740d5b76849"
+content-hash = "fe907f88130c08da0479e97d14bafe92c738f7a012a8bd45fce94f7cad8a1d70"
 
 [metadata.files]
 amqp = [
@@ -1766,6 +1781,10 @@ django-celery-beat = [
 django-compressor = [
     {file = "django_compressor-2.4-py2.py3-none-any.whl", hash = "sha256:57ac0a696d061e5fc6fbc55381d2050f353b973fb97eee5593f39247bc0f30af"},
     {file = "django_compressor-2.4.tar.gz", hash = "sha256:d2ed1c6137ddaac5536233ec0a819e14009553fee0a869bea65d03e5285ba74f"},
+]
+django-csp = [
+    {file = "django_csp-3.7-py2.py3-none-any.whl", hash = "sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a"},
+    {file = "django_csp-3.7.tar.gz", hash = "sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727"},
 ]
 django-debug-toolbar = [
     {file = "django-debug-toolbar-3.2.1.tar.gz", hash = "sha256:a5ff2a54f24bf88286f9872836081078f4baa843dc3735ee88524e89f8821e33"},
@@ -2079,6 +2098,13 @@ protobuf = [
 ]
 psycopg2-binary = [
     {file = "psycopg2-binary-2.9.1.tar.gz", hash = "sha256:b0221ca5a9837e040ebf61f48899926b5783668b7807419e4adae8175a31f773"},
+    {file = "psycopg2_binary-2.9.1-cp310-cp310-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:24b0b6688b9f31a911f2361fe818492650795c9e5d3a1bc647acbd7440142a4f"},
+    {file = "psycopg2_binary-2.9.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:542875f62bc56e91c6eac05a0deadeae20e1730be4c6334d8f04c944fcd99759"},
+    {file = "psycopg2_binary-2.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:661509f51531ec125e52357a489ea3806640d0ca37d9dada461ffc69ee1e7b6e"},
+    {file = "psycopg2_binary-2.9.1-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:d92272c7c16e105788efe2cfa5d680f07e34e0c29b03c1908f8636f55d5f915a"},
+    {file = "psycopg2_binary-2.9.1-cp310-cp310-manylinux_2_24_ppc64le.whl", hash = "sha256:736b8797b58febabb85494142c627bd182b50d2a7ec65322983e71065ad3034c"},
+    {file = "psycopg2_binary-2.9.1-cp310-cp310-win32.whl", hash = "sha256:ebccf1123e7ef66efc615a68295bf6fdba875a75d5bba10a05073202598085fc"},
+    {file = "psycopg2_binary-2.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:1f6ca4a9068f5c5c57e744b4baa79f40e83e3746875cac3c45467b16326bab45"},
     {file = "psycopg2_binary-2.9.1-cp36-cp36m-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:c250a7ec489b652c892e4f0a5d122cc14c3780f9f643e1a326754aedf82d9a76"},
     {file = "psycopg2_binary-2.9.1-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aef9aee84ec78af51107181d02fe8773b100b01c5dfde351184ad9223eab3698"},
     {file = "psycopg2_binary-2.9.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:123c3fb684e9abfc47218d3784c7b4c47c8587951ea4dd5bc38b6636ac57f616"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ django-safedelete = "^1.0.0"
 django-reverse-admin = "^2.9.6"
 django-health-check = "^3.16.4"
 pycountry = "^20.7.3"
+django-csp = "^3.7"
 
 [tool.poetry.dev-dependencies]
 appnope = "0.1.2"

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -72,6 +72,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "apps.common.middleware.LogFourHundredsMiddleware",
+    "csp.middleware.CSPMiddleware",
 ]
 
 ROOT_URLCONF = "revengine.urls"
@@ -346,3 +347,27 @@ CURRENCIES = {"USD": "$", "CAD": "$"}
 
 # Application subdomains (that are NOT revenue program slugs)
 NON_DONATION_PAGE_SUBDOMAINS = os.getenv("NON_DONATION_PAGE_SUBDOMAINS", ["support", "www"])
+
+
+# Django-CSP configuration
+# For now, report only.
+CSP_REPORT_ONLY = os.getenv("CSP_REPORT_ONLY", True)
+CSP_REPORT_URI = f"https://o320544.ingest.sentry.io/api/6046263/security/?sentry_key=d576a6738e41453db36130d03e4e95be&sentry_environment={ENVIRONMENT}"
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_IMG_SRC = ("*",)
+CSP_SCRIPT_SRC = (
+    "https://js.stripe.com",
+    "https://risk.clearbit.com",
+    "https://www.google-analytics.com",
+    "https://maps.googleapis.com",
+    "https://www.google.com/recaptcha/",
+    "https://www.gstatic.com/recaptcha/",
+    "https://pay.google.com",
+)
+CSP_FRAME_SRC = (
+    "https://js.stripe.com",
+    "https://hooks.stripe.com",
+    "https://www.google.com/recaptcha/",
+    "https://recaptcha.google.com/recaptcha/",
+    "https://pay.google.com",
+)

--- a/revengine/views.py
+++ b/revengine/views.py
@@ -23,7 +23,13 @@ class ReactAppView(TemplateView):
         self._add_social_media_context(context)
         return context
 
+    # def _request_is_donation_page(self):
+    #     return bool(get_subdomain_from_request(self.request))
+
     def _add_social_media_context(self, context):
+        """
+        Add Open Graph protocol and Twitter social sharing meta tags to index.html context, only when there's a subdomain.
+        """
         if subdomain := get_subdomain_from_request(self.request):
             revenue_program = None
             try:
@@ -34,6 +40,18 @@ class ReactAppView(TemplateView):
             if revenue_program:
                 serializer = SocialMetaInlineSerializer(revenue_program.social_meta, context={"request": self.request})
                 context["social_meta"] = serializer.data
+
+    # def _add_security_headers(self, context):
+    #     """
+    #     Add security
+    #     """
+
+    # def _add_donation_page_security_headers(self, context):
+    #     """
+    #     Add security headers that should only be present on public DonationPages
+    #     """
+    #     if self._request_is_donation_page():
+    #         pass
 
 
 index = never_cache(ReactAppView.as_view())

--- a/revengine/views.py
+++ b/revengine/views.py
@@ -23,13 +23,7 @@ class ReactAppView(TemplateView):
         self._add_social_media_context(context)
         return context
 
-    # def _request_is_donation_page(self):
-    #     return bool(get_subdomain_from_request(self.request))
-
     def _add_social_media_context(self, context):
-        """
-        Add Open Graph protocol and Twitter social sharing meta tags to index.html context, only when there's a subdomain.
-        """
         if subdomain := get_subdomain_from_request(self.request):
             revenue_program = None
             try:
@@ -40,18 +34,6 @@ class ReactAppView(TemplateView):
             if revenue_program:
                 serializer = SocialMetaInlineSerializer(revenue_program.social_meta, context={"request": self.request})
                 context["social_meta"] = serializer.data
-
-    # def _add_security_headers(self, context):
-    #     """
-    #     Add security
-    #     """
-
-    # def _add_donation_page_security_headers(self, context):
-    #     """
-    #     Add security headers that should only be present on public DonationPages
-    #     """
-    #     if self._request_is_donation_page():
-    #         pass
 
 
 index = never_cache(ReactAppView.as_view())

--- a/spa/public/index.html
+++ b/spa/public/index.html
@@ -3,25 +3,27 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    
+
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="RevEngine" />
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,300;0,400;0,700;1,100;1,200;1,400;1,700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,300;0,400;0,700;1,100;1,200;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
 
-    
     {% if social_meta %}
-      <meta name="og:type" content="website">
-      <meta name="og:url" content="{{ social_meta.url }}" />
-      <meta name="og:title" content="{{ social_meta.title }}">
-      <meta name="og:description" content="{{ social_meta.description }}">
-      <meta name="og:image:alt" content="{{ social_meta.image_alt }}">
-      <meta name="og:image" content="{{ social_meta.card }}" />
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:site" content="{{ social_meta.twitter_handle }}" />
-      <meta name="twitter:creator" content="{{ social_meta.twitter_handle }}" />
+    <meta name="og:type" content="website" />
+    <meta name="og:url" content="{{ social_meta.url }}" />
+    <meta name="og:title" content="{{ social_meta.title }}" />
+    <meta name="og:description" content="{{ social_meta.description }}" />
+    <meta name="og:image:alt" content="{{ social_meta.image_alt }}" />
+    <meta name="og:image" content="{{ social_meta.card }}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="{{ social_meta.twitter_handle }}" />
+    <meta name="twitter:creator" content="{{ social_meta.twitter_handle }}" />
     {% endif %}
 
     <title>RevEngine</title>


### PR DESCRIPTION
#### What's this PR do?
Adds a library, `django-csp`, to easily handle content security policy directives. 

The policy is something like this:

```
Content-Security-Policy-Report-Only: 
default-src 'self'; 
img-src *; 
script-src https://js.stripe.com https://risk.clearbit.com https://www.google-analytics.com https://maps.googleapis.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://pay.google.com;
frame-src https://js.stripe.com https://hooks.stripe.com https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/ https://pay.google.com; 
report-uri https://o320544.ingest.sentry.io/api/6046263/security/?sentry_key=<sentry_key>&sentry_environment=<environment>
```

#### How should this be manually tested?
View the request headers for the page request.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No. Though there is an environment variable, `CSP_REPORT_ONLY`, that defaults to True. When we want to start enforcing the policy, we can toggle this.