### PR TITLE
[NRH-5017] Fix RP Pagination

### DIFF
--- a/apps/organizations/tests/test_org_views.py
+++ b/apps/organizations/tests/test_org_views.py
@@ -78,7 +78,7 @@ class RevenueProgramViewSetTest(AbstractTestCase):
         response = self.client.get(self.list_url)
         self.assertEqual(response.status_code, 200)
         expected_count = RevenueProgram.objects.filter(organization=self.user.get_organization()).count()
-        self.assertEqual(response.json()["count"], expected_count)
+        self.assertEqual(len(response.json()), expected_count)
 
     def test_created_and_list_are_equivalent(self):
         revp = self.resources[0]
@@ -87,7 +87,7 @@ class RevenueProgramViewSetTest(AbstractTestCase):
         response = self.client.get(self.list_url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            [x["id"] for x in response.json()["results"]],
+            [x["id"] for x in response.json()],
             [
                 x
                 for x in RevenueProgram.objects.filter(organization=self.user.get_organization()).values_list(
@@ -112,6 +112,16 @@ class RevenueProgramViewSetTest(AbstractTestCase):
         # Method POST Not Allowed
         response = self.client.post(self.list_url, {"name": "New RevenueProgram", "organization": self.orgs[0].pk})
         self.assertEqual(response.status_code, 405)
+
+    def test_pagination_disabled(self):
+        revp = self.resources[0]
+        self.authenticate_user_for_resource(revp)
+        self.login()
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, 200)
+        # 'count' and 'results' keys are only present in paginated responses
+        self.assertNotIn("count", response.json())
+        self.assertNotIn("results", response.json())
 
 
 class PlanViewSetTest(APITestCase):

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -65,3 +65,4 @@ class RevenueProgramViewSet(OrganizationLimitedListView, viewsets.ReadOnlyModelV
     model = RevenueProgram
     queryset = RevenueProgram.objects.all()
     serializer_class = serializers.RevenueProgramSerializer
+    pagination_class = None

--- a/spa/cypress/fixtures/org/revenue-programs-1.json
+++ b/spa/cypress/fixtures/org/revenue-programs-1.json
@@ -1,16 +1,14 @@
-{
-  "results": [
-    {
-      "id": 1,
-      "name": "Revenue Program 1"
-    },
-    {
-      "id": 2,
-      "name": "Revenue Program 2"
-    },
-    {
-      "id": 3,
-      "name": "Revenue Program 3"
-    }
-  ]
-}
+[
+  {
+    "id": 1,
+    "name": "Revenue Program 1"
+  },
+  {
+    "id": 2,
+    "name": "Revenue Program 2"
+  },
+  {
+    "id": 3,
+    "name": "Revenue Program 3"
+  }
+]

--- a/spa/cypress/integration/03 - donation-page-list.spec.js
+++ b/spa/cypress/integration/03 - donation-page-list.spec.js
@@ -32,10 +32,7 @@ describe('Donation page list', () => {
 
     it('should show message if there are no revenue programs', () => {
       // override intercept set in beforeEach cause for this case we don't want any programs present
-      cy.intercept(
-        { method: 'GET', pathname: getEndpoint(REVENUE_PROGRAMS) },
-        { body: { results: [] }, statusCode: 200 }
-      );
+      cy.intercept({ method: 'GET', pathname: getEndpoint(REVENUE_PROGRAMS) }, { body: [], statusCode: 200 });
       cy.getByTestId('page-create-button').click();
       cy.contains('You need to set up a revenue program to create a page.');
     });

--- a/spa/src/components/content/pages/AddPageModal.js
+++ b/spa/src/components/content/pages/AddPageModal.js
@@ -57,7 +57,7 @@ function AddPageModal({ isOpen, closeModal }) {
           method: 'GET',
           url: REVENUE_PROGRAMS
         },
-        { onSuccess: ({ data }) => setRevenuePrograms(data.results), onFailure: handleRequestFailure }
+        { onSuccess: ({ data }) => setRevenuePrograms(data), onFailure: handleRequestFailure }
       );
     }
     getRevProgams();


### PR DESCRIPTION
#### What's this PR do?
The bug "cannot see more than 10 revenue programs" is fixed here. It was default pagination.

#### How should this be manually tested?
View more than 10 of em.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No