### PR TITLE
[NRH-5051] DonationPage header-logo cutoff

### DIFF
--- a/spa/src/components/donationPage/DonationPageNavbar.styled.js
+++ b/spa/src/components/donationPage/DonationPageNavbar.styled.js
@@ -8,11 +8,15 @@ export const DonationPageNavbar = styled.header`
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 0 3rem;
 
   box-shadow: ${(props) => props.theme.shadows[0]};
 `;
 
 export const DonationPageNavbarLogo = styled.img`
+  display: block;
   max-height: 50px;
   width: auto;
+  max-width: 100%;
+  margin: 0 auto;
 `;


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug in which the header-logo can potentially but cut off on the x-axis on smaller devices.

#### How should this be manually tested?
Test [this page](https://vosd.revengine-test.org/voice-of-san-diego-donation-page) at smaller viewport widths (assuming nobody has changed the header image)

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
