### PR TITLE
[NRH-5541] Missing BadActor Fields

### DIFF
--- a/apps/contributions/bad_actor.py
+++ b/apps/contributions/bad_actor.py
@@ -5,8 +5,6 @@ from django.conf import settings
 
 import requests
 
-from apps.contributions.serializers import AbstractPaymentSerializer
-
 
 logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
@@ -24,7 +22,6 @@ def make_bad_actor_request(validated_data):
         "Authorization": f"Bearer {settings.BAD_ACTOR_API_KEY}",
     }
     json_data = validated_data.copy()
-    json_data["amount"] = AbstractPaymentSerializer.convert_cents_to_amount(json_data["amount"])
     response = requests.post(url=settings.BAD_ACTOR_API_URL, headers=headers, json=json_data)
     if int(str(response.status_code)[:1]) != 2:
         try:

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -301,7 +301,6 @@ class ContributionMetadataSerializer(serializers.Serializer):
         return not bool(self._errors) and is_valid
 
     def validate_secondary_metadata(self, secondary_metadata):
-        # ? TEST: Secondary metadata validation fails if missing contributor_id
         """
         Validation for values not present at the time of original validation. Generally, these values must be derived from
         values created after that initial validation. contributor_id is the only example of this so far.
@@ -330,6 +329,40 @@ class ContributionMetadataSerializer(serializers.Serializer):
         }
 
 
+class BadActorSerializer(serializers.Serializer):
+    # Donation info
+    amount = serializers.CharField(max_length=12)
+
+    # Donor info
+    first_name = serializers.CharField(max_length=40)
+    last_name = serializers.CharField(max_length=80)
+    email = serializers.EmailField(max_length=80)
+    street = serializers.CharField(max_length=255)
+    city = serializers.CharField(max_length=40)
+    state = serializers.CharField(max_length=80)
+    country = serializers.CharField(max_length=80)
+    zipcode = serializers.CharField(max_length=20)
+
+    # Third-party risk assessment
+    captcha_token = serializers.CharField(max_length=2550, required=False, allow_blank=True)
+
+    # Request metadata
+    ip = serializers.IPAddressField()
+    referer = serializers.URLField()
+
+    # Donation additional
+    reason_for_giving = serializers.CharField(max_length=255, required=False, allow_blank=True)
+
+    def to_internal_value(self, data):
+        data["street"] = data.get("mailing_street")
+        data["city"] = data.get("mailing_city")
+        data["state"] = data.get("mailing_state")
+        data["zipcode"] = data.get("mailing_postal_code")
+        data["country"] = data.get("mailing_country")
+        data["reason"] = data.get("reason_for_giving")
+        return super().to_internal_value(data)
+
+
 class AbstractPaymentSerializer(serializers.Serializer):
     # Payment details
     amount = serializers.IntegerField(
@@ -341,7 +374,6 @@ class AbstractPaymentSerializer(serializers.Serializer):
         },
     )
     interval = serializers.ChoiceField(choices=ContributionInterval.choices, default=ContributionInterval.ONE_TIME)
-
     # organization_country tand currency are a different pattern, but important here.
     # They could be derived from the organization that this contribution is tied to,
     # but instead we send that info to each donation page load and pass it back as params;
@@ -352,13 +384,6 @@ class AbstractPaymentSerializer(serializers.Serializer):
 
     # DonorInfo
     email = serializers.EmailField(max_length=80)
-
-    # Params/Pass-through
-    captcha_token = serializers.CharField(max_length=2550, required=False, allow_blank=True)
-
-    # Request metadata
-    ip = serializers.IPAddressField()
-    referer = serializers.URLField()
 
     # These are used to attach the contribution to the right organization,
     # and associate it with the page it came from.


### PR DESCRIPTION
#### What's this PR do?
Pulls BadActor validation out of the `AbstractPaymentSerializer` into its own `BadActorSerializer`. This original bug was caused by removing some values from the `AbstractPaymentSerializer` and moving them to the `ContributionMetadataSerializer`. A good move, semantically, but had the unintended side-effect of removing values that were required for BadActor. So declaring an independent serializer for BadActor makes sense here. It's worth noting that failed validation for this serializer should not prevent the payment from going through. Instead, failed validation sends a sentry warning.

#### How should this be manually tested?
Verify that all required information is passed through to BadActor, or if not, we get a sentry warning.


#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No