### PR TITLE
adjust t-shirt dropdown help text

### DIFF
--- a/spa/src/components/donationPage/pageContent/DSwag.js
+++ b/spa/src/components/donationPage/pageContent/DSwag.js
@@ -149,7 +149,7 @@ function SwagItem({ swag, isOnlySwag, ...props }) {
           selectedItem={selectedSwagOption}
           onSelectedItemChange={({ selectedItem }) => setSelectedSwagOption(selectedItem)}
           items={swagOptions}
-          helpText="Your donation comes with member merchandise. Please choose an option."
+          helpText="Your contribution comes with member merchandise. Please choose an option."
           maxWidth="300px"
         />
       </S.SwagOptions>


### PR DESCRIPTION
#### What's this PR do?
Minor adjustment to help text for t-shirt dropdown

#### How should this be manually tested?
View a donation page and verify the text says "Your contribution comes with member merchandise. Please choose an option" and not "Your contribution comes with…"

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
n/a
