### PR TITLE
[NRH-5020] Fix default social image for pages with page slugs

### DIFF
--- a/apps/common/serializers.py
+++ b/apps/common/serializers.py
@@ -30,9 +30,8 @@ class SocialMetaInlineSerializer(serializers.ModelSerializer):
 
     def get_card(self, obj):
         request = self.context.get("request")
-        request_uri = request.build_absolute_uri()
-        card_uri = request_uri[:-1]
-        card_uri = obj.card.url if obj.card else card_uri + static("hub-og-card.png")
+        site_url = f"{request.scheme}://{request.get_host()}"
+        card_uri = obj.card.url if obj.card else site_url + static("hub-og-card.png")
         return card_uri
 
     def get_twitter_handle(self, obj):


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug in which the default hub social share image wasn't being used if the page was accessed via a page-url. 
The method building the fully qualified absolute url for the default image was itself using the absolute url of the incoming request, which obviously wouldn't work if there was additional path information in the url.

#### How should this be manually tested?
Visit a donation page via page slug and check the head of og:image, verify that the url there takes you to an actual image. You can also use the facebook share debugger to verify that facebook gets the correct image.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No