### PR TITLE
[#9726] Apple/Google Pay Label is RevProgram

### DIFF
--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -39,8 +39,6 @@ import Button from 'elements/buttons/Button';
 import { ICONS } from 'assets/icons/SvgIcon';
 import { PayFeesWidget } from 'components/donationPage/pageContent/DPayment';
 
-const STRIPE_PAYMENT_REQUEST_LABEL = 'RevEngine Donation';
-
 function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   useReCAPTCHAScript();
   const subdomain = useSubdomain();
@@ -217,7 +215,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
         country: page?.organization_country,
         currency: page?.currency?.code?.toLowerCase(),
         total: {
-          label: STRIPE_PAYMENT_REQUEST_LABEL,
+          label: page.revenue_program.name,
           amount: amnt
         }
       });
@@ -259,7 +257,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
     if (paymentRequest && amntIsValid) {
       paymentRequest.update({
         total: {
-          label: STRIPE_PAYMENT_REQUEST_LABEL,
+          label: page.revenue_program.name,
           amount: amnt
         }
       });


### PR DESCRIPTION
#### What's this PR do?
Makes the payment request label the rp name, not the generic "revengine donation"

#### How should this be manually tested?
Start an apple or google pay payment

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No