### PR TITLE
Create componentLoader util and ChunkErrorBoundary component + styles

### DIFF
--- a/spa/src/components/DashboardRouter.js
+++ b/spa/src/components/DashboardRouter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
 // Routing
 import { Route, BrowserRouter, Switch, Redirect } from 'react-router-dom';
@@ -10,45 +10,51 @@ import * as ROUTES from 'routes';
 // Components/Children
 import GlobalLoading from 'elements/GlobalLoading';
 import TrackPageView from 'components/analytics/TrackPageView';
+import ChunkErrorBoundary from 'components/errors/ChunkErrorBoundary';
+
+// Utilities
+import componentLoader from 'utilities/componentLoader';
 
 // Split bundles
-const Login = React.lazy(() => import('components/authentication/Login'));
-const Main = React.lazy(() => import('components/Main'));
-const ContributorEntry = React.lazy(() => import('components/contributor/ContributorEntry'));
-const ContributorVerify = React.lazy(() => import('components/contributor/ContributorVerify'));
-const ContributorDashboard = React.lazy(() =>
-  import('components/contributor/contributorDashboard/ContributorDashboard')
+const Login = lazy(() => componentLoader(() => import(`components/authentication/Login`)));
+const Main = lazy(() => componentLoader(() => import(`components/Main`)));
+const ContributorEntry = lazy(() => componentLoader(() => import(`components/contributor/ContributorEntry`)));
+const ContributorVerify = lazy(() => componentLoader(() => import(`components/contributor/ContributorVerify`)));
+const ContributorDashboard = lazy(() =>
+  componentLoader(() => import(`components/contributor/contributorDashboard/ContributorDashboard`))
 );
-const PageEditor = React.lazy(() => import('components/pageEditor/PageEditor'));
+const PageEditor = lazy(() => componentLoader(() => import(`components/pageEditor/PageEditor`)));
 
 function DashboardRouter() {
   return (
     <BrowserRouter>
-      <React.Suspense fallback={<GlobalLoading />}>
-        <Switch>
-          {/* Login URL */}
-          <Route exact path={ROUTES.LOGIN} render={() => <TrackPageView component={Login} />} />
+      <ChunkErrorBoundary>
+        <React.Suspense fallback={<GlobalLoading />}>
+          <Switch>
+            {/* Login URL */}
+            <Route exact path={ROUTES.LOGIN} render={() => <TrackPageView component={Login} />} />
 
-          {/* Nothing lives at "/" -- redirect to dashboard  */}
-          <Route exact path="/">
-            <Redirect to={ROUTES.CONTENT_SLUG} />
-          </Route>
+            {/* Nothing lives at "/" -- redirect to dashboard  */}
+            <Route exact path="/">
+              <Redirect to={ROUTES.CONTENT_SLUG} />
+            </Route>
 
-          {/* Organization Dashboard */}
-          <ProtectedRoute path={ROUTES.DASHBOARD_SLUG} render={() => <TrackPageView component={Main} />} />
-          <ProtectedRoute path={ROUTES.EDITOR_ROUTE_PAGE} render={() => <TrackPageView component={PageEditor} />} />
-          <ProtectedRoute path={ROUTES.EDITOR_ROUTE_REV} render={() => <TrackPageView component={PageEditor} />} />
+            {/* Organization Dashboard */}
+            <ProtectedRoute path={ROUTES.DASHBOARD_SLUG} render={() => <TrackPageView component={Main} />} />
+            <ProtectedRoute path={ROUTES.EDITOR_ROUTE_PAGE} render={() => <TrackPageView component={PageEditor} />} />
+            <ProtectedRoute path={ROUTES.EDITOR_ROUTE_REV} render={() => <TrackPageView component={PageEditor} />} />
 
-          {/* Contributor Dashboard */}
-          <ProtectedRoute
-            path={ROUTES.CONTRIBUTOR_DASHBOARD}
-            render={() => <TrackPageView component={ContributorDashboard} />}
-            contributor
-          />
-          <Route path={ROUTES.CONTRIBUTOR_ENTRY} render={() => <TrackPageView component={ContributorEntry} />} />
-          <Route path={ROUTES.CONTRIBUTOR_VERIFY} render={() => <TrackPageView component={ContributorVerify} />} />
-        </Switch>
-      </React.Suspense>
+            {/* Contributor Dashboard */}
+            <ProtectedRoute
+              path={ROUTES.CONTRIBUTOR_DASHBOARD}
+              render={() => <TrackPageView component={ContributorDashboard} />}
+              contributor
+            />
+            <Route path={ROUTES.CONTRIBUTOR_ENTRY} render={() => <TrackPageView component={ContributorEntry} />} />
+            <Route path={ROUTES.CONTRIBUTOR_VERIFY} render={() => <TrackPageView component={ContributorVerify} />} />
+          </Switch>
+        </React.Suspense>
+      </ChunkErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/spa/src/components/DonationPageRouter.js
+++ b/spa/src/components/DonationPageRouter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
 // Router
 import { Route, BrowserRouter, Switch } from 'react-router-dom';
@@ -10,11 +10,18 @@ import TrackPageView from 'components/analytics/TrackPageView';
 // Elements
 import GlobalLoading from 'elements/GlobalLoading';
 
+// Utilities
+import componentLoader from 'utilities/componentLoader';
+
 /**
  * Split Bundles
  */
-const GenericThankYou = React.lazy(() => import('components/donationPage/live/thankYou/GenericThankYou'));
-const LiveDonationPageContainer = React.lazy(() => import('components/donationPage/LiveDonationPageContainer'));
+const GenericThankYou = lazy(() =>
+  componentLoader(() => import(`components/donationPage/live/thankYou/GenericThankYou`))
+);
+const LiveDonationPageContainer = lazy(() =>
+  componentLoader(() => import(`components/donationPage/LiveDonationPageContainer`))
+);
 
 function DonationPageRouter() {
   return (

--- a/spa/src/components/DonationPageRouter.js
+++ b/spa/src/components/DonationPageRouter.js
@@ -9,6 +9,7 @@ import TrackPageView from 'components/analytics/TrackPageView';
 
 // Elements
 import GlobalLoading from 'elements/GlobalLoading';
+import ChunkErrorBoundary from 'components/errors/ChunkErrorBoundary';
 
 // Utilities
 import componentLoader from 'utilities/componentLoader';
@@ -26,20 +27,22 @@ const LiveDonationPageContainer = lazy(() =>
 function DonationPageRouter() {
   return (
     <BrowserRouter>
-      <React.Suspense fallback={<GlobalLoading />}>
-        <Switch>
-          <Route
-            path={ROUTES.DONATION_PAGE_SLUG + ROUTES.THANK_YOU_SLUG}
-            render={() => <TrackPageView component={GenericThankYou} />}
-          />
-          <Route path={ROUTES.THANK_YOU_SLUG} render={() => <TrackPageView component={GenericThankYou} />} />
-          <Route
-            path={ROUTES.DONATION_PAGE_SLUG}
-            render={() => <TrackPageView component={LiveDonationPageContainer} />}
-          />
-          <Route path={'/'} render={() => <TrackPageView component={LiveDonationPageContainer} />} />
-        </Switch>
-      </React.Suspense>
+      <ChunkErrorBoundary>
+        <React.Suspense fallback={<GlobalLoading />}>
+          <Switch>
+            <Route
+              path={ROUTES.DONATION_PAGE_SLUG + ROUTES.THANK_YOU_SLUG}
+              render={() => <TrackPageView component={GenericThankYou} />}
+            />
+            <Route path={ROUTES.THANK_YOU_SLUG} render={() => <TrackPageView component={GenericThankYou} />} />
+            <Route
+              path={ROUTES.DONATION_PAGE_SLUG}
+              render={() => <TrackPageView component={LiveDonationPageContainer} />}
+            />
+            <Route path={'/'} render={() => <TrackPageView component={LiveDonationPageContainer} />} />
+          </Switch>
+        </React.Suspense>
+      </ChunkErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/spa/src/components/errors/ChunkErrorBoundary.js
+++ b/spa/src/components/errors/ChunkErrorBoundary.js
@@ -1,21 +1,23 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React from 'react';
 import * as Sentry from '@sentry/react';
 
-import Button from 'elements/buttons/Button';
 import * as S from '../../elements/buttons/Button.styled';
 import * as ErrorS from './ErrorFallback.styled';
 
-const ChunkErrorFallback = (error, componentStack, handleReset, resetError) => {
+const ChunkErrorFallback = (error, componentStack, resetError) => {
+  console.log(error, componentStack, resetError);
   const chunkFailedMessage = /Loading chunk [\d]+ failed/;
 
   if (error?.message && chunkFailedMessage.test(error.message)) {
+    // Leaving this here for testing purposes, should retry only for chunk loading errors
+    console.error(error);
     resetError();
   } else {
     return (
-      <Fragment>
+      <>
         <ErrorS.ErrorWrapper>
           <ErrorS.ErrorHeading layout>
-            <h2>You have encountered an error</h2>
+            <h2>😰 We've encountered a problem. Click below to reload the page</h2>
           </ErrorS.ErrorHeading>
           <ErrorS.ErrorMessage>
             <div>{error.toString()}</div>
@@ -23,34 +25,24 @@ const ChunkErrorFallback = (error, componentStack, handleReset, resetError) => {
           <ErrorS.ErrorStack>
             <div>{componentStack}</div>
           </ErrorS.ErrorStack>
-          <S.Button>
-            <Button
-              onClick={() => {
-                handleReset('An error has occurred');
-                resetError();
-              }}
-            >
-              Click here to reload this page
-            </Button>
+          <S.Button
+            onClick={() => {
+              resetError();
+            }}
+          >
+            Reload Page
           </S.Button>
         </ErrorS.ErrorWrapper>
-      </Fragment>
+      </>
     );
   }
 };
 
 const ChunkErrorBoundary = (props) => {
-  const [message, setMessage] = useState();
-
-  const handleReset = (newMessage) => {
-    setMessage(newMessage);
-  };
-
+  console.log(props);
   return (
     <Sentry.ErrorBoundary
-      fallback={({ error, componentStack, resetError }) =>
-        ChunkErrorFallback(error, componentStack, handleReset, resetError)
-      }
+      fallback={({ error, componentStack, resetError }) => ChunkErrorFallback(error, componentStack, resetError)}
     >
       {props.children}
     </Sentry.ErrorBoundary>

--- a/spa/src/components/errors/ChunkErrorBoundary.js
+++ b/spa/src/components/errors/ChunkErrorBoundary.js
@@ -4,12 +4,12 @@ import * as Sentry from '@sentry/react';
 import * as S from '../../elements/buttons/Button.styled';
 import * as ErrorS from './ErrorFallback.styled';
 
-const ChunkErrorFallback = (error) => {
+const ChunkErrorFallback = () => {
   return (
     <>
       <ErrorS.ErrorWrapper>
         <ErrorS.ErrorHeading layout>
-          <h2>😰 We've encountered a problem!</h2>
+          <h2>We've encountered a problem!</h2>
           <h4>Click below to reload the page</h4>
         </ErrorS.ErrorHeading>
         <S.Button
@@ -25,9 +25,7 @@ const ChunkErrorFallback = (error) => {
 };
 
 const ChunkErrorBoundary = (props) => {
-  return (
-    <Sentry.ErrorBoundary fallback={({ error }) => ChunkErrorFallback(error)}>{props.children}</Sentry.ErrorBoundary>
-  );
+  return <Sentry.ErrorBoundary fallback={ChunkErrorFallback}>{props.children}</Sentry.ErrorBoundary>;
 };
 
 export default ChunkErrorBoundary;

--- a/spa/src/components/errors/ChunkErrorBoundary.js
+++ b/spa/src/components/errors/ChunkErrorBoundary.js
@@ -4,48 +4,29 @@ import * as Sentry from '@sentry/react';
 import * as S from '../../elements/buttons/Button.styled';
 import * as ErrorS from './ErrorFallback.styled';
 
-const ChunkErrorFallback = (error, componentStack, resetError) => {
-  console.log(error, componentStack, resetError);
-  const chunkFailedMessage = /Loading chunk [\d]+ failed/;
-
-  if (error?.message && chunkFailedMessage.test(error.message)) {
-    // Leaving this here for testing purposes, should retry only for chunk loading errors
-    console.error(error);
-    resetError();
-  } else {
-    return (
-      <>
-        <ErrorS.ErrorWrapper>
-          <ErrorS.ErrorHeading layout>
-            <h2>😰 We've encountered a problem. Click below to reload the page</h2>
-          </ErrorS.ErrorHeading>
-          <ErrorS.ErrorMessage>
-            <div>{error.toString()}</div>
-          </ErrorS.ErrorMessage>
-          <ErrorS.ErrorStack>
-            <div>{componentStack}</div>
-          </ErrorS.ErrorStack>
-          <S.Button
-            onClick={() => {
-              resetError();
-            }}
-          >
-            Reload Page
-          </S.Button>
-        </ErrorS.ErrorWrapper>
-      </>
-    );
-  }
+const ChunkErrorFallback = (error) => {
+  return (
+    <>
+      <ErrorS.ErrorWrapper>
+        <ErrorS.ErrorHeading layout>
+          <h2>😰 We've encountered a problem!</h2>
+          <h4>Click below to reload the page</h4>
+        </ErrorS.ErrorHeading>
+        <S.Button
+          onClick={() => {
+            window.location.reload();
+          }}
+        >
+          Refresh
+        </S.Button>
+      </ErrorS.ErrorWrapper>
+    </>
+  );
 };
 
 const ChunkErrorBoundary = (props) => {
-  console.log(props);
   return (
-    <Sentry.ErrorBoundary
-      fallback={({ error, componentStack, resetError }) => ChunkErrorFallback(error, componentStack, resetError)}
-    >
-      {props.children}
-    </Sentry.ErrorBoundary>
+    <Sentry.ErrorBoundary fallback={({ error }) => ChunkErrorFallback(error)}>{props.children}</Sentry.ErrorBoundary>
   );
 };
 

--- a/spa/src/components/errors/ChunkErrorBoundary.js
+++ b/spa/src/components/errors/ChunkErrorBoundary.js
@@ -1,0 +1,60 @@
+import React, { Fragment, useState, useEffect } from 'react';
+import * as Sentry from '@sentry/react';
+
+import Button from 'elements/buttons/Button';
+import * as S from '../../elements/buttons/Button.styled';
+import * as ErrorS from './ErrorFallback.styled';
+
+const ChunkErrorFallback = (error, componentStack, handleReset, resetError) => {
+  const chunkFailedMessage = /Loading chunk [\d]+ failed/;
+
+  if (error?.message && chunkFailedMessage.test(error.message)) {
+    resetError();
+  } else {
+    return (
+      <Fragment>
+        <ErrorS.ErrorWrapper>
+          <ErrorS.ErrorHeading layout>
+            <h2>You have encountered an error</h2>
+          </ErrorS.ErrorHeading>
+          <ErrorS.ErrorMessage>
+            <div>{error.toString()}</div>
+          </ErrorS.ErrorMessage>
+          <ErrorS.ErrorStack>
+            <div>{componentStack}</div>
+          </ErrorS.ErrorStack>
+          <S.Button>
+            <Button
+              onClick={() => {
+                handleReset('An error has occurred');
+                resetError();
+              }}
+            >
+              Click here to reload this page
+            </Button>
+          </S.Button>
+        </ErrorS.ErrorWrapper>
+      </Fragment>
+    );
+  }
+};
+
+const ChunkErrorBoundary = (props) => {
+  const [message, setMessage] = useState();
+
+  const handleReset = (newMessage) => {
+    setMessage(newMessage);
+  };
+
+  return (
+    <Sentry.ErrorBoundary
+      fallback={({ error, componentStack, resetError }) =>
+        ChunkErrorFallback(error, componentStack, handleReset, resetError)
+      }
+    >
+      {props.children}
+    </Sentry.ErrorBoundary>
+  );
+};
+
+export default ChunkErrorBoundary;

--- a/spa/src/components/errors/ErrorFallback.styled.js
+++ b/spa/src/components/errors/ErrorFallback.styled.js
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
+
+export const ErrorHeading = styled(motion.div)`
+  display: flex;
+  justify-content: center;
+  height: 60px;
+  position: relative;
+
+  h2 {
+    margin: 0;
+    font-size: ${(props) => props.theme.fontSizes[2]};
+    color: ${(props) => props.theme.colors.black};
+  }
+`;
+
+export const ErrorWrapper = styled(motion.div)`
+  padding: 2rem;
+`;
+
+export const ErrorMessage = styled(motion.div)`
+  font-weight: 600;
+  padding-bottom: 2rem;
+`;
+
+export const ErrorStack = styled(motion.div)`
+  padding-bottom: 4rem;
+`;

--- a/spa/src/components/errors/ErrorFallback.styled.js
+++ b/spa/src/components/errors/ErrorFallback.styled.js
@@ -3,26 +3,29 @@ import { motion } from 'framer-motion';
 
 export const ErrorHeading = styled(motion.div)`
   display: flex;
-  justify-content: center;
-  height: 60px;
-  position: relative;
-
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  height: 40%;
   h2 {
     margin: 0;
     font-size: ${(props) => props.theme.fontSizes[2]};
     color: ${(props) => props.theme.colors.black};
   }
+  h4 {
+    margin: 0;
+    font-size: ${(props) => props.theme.fontSizes[1]};
+    color: ${(props) => props.theme.colors.black};
+  }
 `;
 
 export const ErrorWrapper = styled(motion.div)`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  margin: 0px auto;
   padding: 2rem;
-`;
-
-export const ErrorMessage = styled(motion.div)`
-  font-weight: 600;
-  padding-bottom: 2rem;
-`;
-
-export const ErrorStack = styled(motion.div)`
-  padding-bottom: 4rem;
+  max-width: 700px;
+  height: 50%;
 `;

--- a/spa/src/utilities/componentLoader.js
+++ b/spa/src/utilities/componentLoader.js
@@ -1,0 +1,17 @@
+const componentLoader = (lazyComponent, attemptsLeft = 3, interval = 1000) => {
+  return new Promise((resolve, reject) => {
+    lazyComponent()
+      .then(resolve)
+      .catch((error) => {
+        setTimeout(() => {
+          if (attemptsLeft === 1) {
+            reject(error);
+            return;
+          }
+          componentLoader(lazyComponent, attemptsLeft - 1, interval).then(resolve, reject);
+        }, interval);
+      });
+  });
+};
+
+export default componentLoader;

--- a/spa/src/utilities/componentLoader.js
+++ b/spa/src/utilities/componentLoader.js
@@ -1,4 +1,4 @@
-const componentLoader = (lazyComponent, attemptsLeft = 3, interval = 1000) => {
+const componentLoader = (lazyComponent, attemptsLeft = 10, interval = 1500) => {
   return new Promise((resolve, reject) => {
     lazyComponent()
       .then(resolve)


### PR DESCRIPTION
#### What's this PR do?
Creates a custom component loader to handle chunk loading errors from code splitting as well as an error boundary that shows the error and reloads the page.

#### How should this be manually tested?
You can try to test locally, I can provide the settings for throttling, though I was never able to trigger it.  My guess is that it must be tested in a deployed environment.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
