### PR TITLE
new copy for button CTA on thank you page

### DIFF
--- a/spa/src/components/donationPage/live/thankYou/GenericThankYou.js
+++ b/spa/src/components/donationPage/live/thankYou/GenericThankYou.js
@@ -98,7 +98,7 @@ function GenericThankYou() {
               </S.SocialShareList>
             </S.SocialShareSection>
             {routedState?.page?.post_thank_you_redirect && (
-              <S.Redirect onClick={handleRedirect}>Take me back to the news</S.Redirect>
+              <S.Redirect onClick={handleRedirect}>Return to website</S.Redirect>
             )}
           </S.InnerContent>
         </S.Wrapper>


### PR DESCRIPTION
#### What's this PR do?
rewords "take me back to the news" on thank you page

#### How should this be manually tested?
try processing a test donation and verify "return" button says "return to website" instead of "take me back to the news"

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
n/a
