### PR TITLE
#10666 Configure Sentry via Env

### DIFF
--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -420,7 +420,13 @@ SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 # Stripe API Target Version
 STRIPE_API_VERSION = "2020-08-27"
 
-SENTRY_ENABLE = os.environ.get("SENTRY_ENABLE", "false").lower() == "true"
+
+# Sentry Configuration
+SENTRY_ENABLE_FRONTEND = os.environ.get("SENTRY_ENABLE_FRONTEND", "false").lower() == "true"
+SENTRY_DSN_FRONTEND = os.environ.get("SENTRY_DSN_FRONTEND")
+
+SENTRY_ENABLE_BACKEND = os.environ.get("SENTRY_ENABLE_BACKEND", "false").lower() == "true"
+SENTRY_DSN_BACKEND = os.environ.get("SENTRY_DSN_BACKEND")
 
 # Front End Environment Variables - Config Vars Heroku
 SPA_ENV_VARS = {
@@ -432,7 +438,8 @@ SPA_ENV_VARS = {
     "REVENGINE_API_VERSION": os.getenv("SPA_ENV_REVENGINE_API_VERSION", "v1"),
     "STRIPE_API_VERSION": STRIPE_API_VERSION,
     "STRIPE_OAUTH_SCOPE": STRIPE_OAUTH_SCOPE,
-    "SENTRY_ENABLE": SENTRY_ENABLE,
+    "SENTRY_ENABLE_FRONTEND": SENTRY_ENABLE_FRONTEND,
+    "SENTRY_DSN_FRONTEND": SENTRY_DSN_FRONTEND,
     "STRIPE_CLIENT_ID": os.getenv("SPA_ENV_STRIPE_CLIENT_ID"),
     "HUB_GOOGLE_MAPS_API_KEY": os.getenv("SPA_ENV_HUB_GOOGLE_MAPS_API_KEY"),
     "HUB_V3_GOOGLE_ANALYTICS_ID": os.getenv("SPA_ENV_HUB_V3_GOOGLE_ANALYTICS_ID"),

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -361,9 +361,7 @@ SENTRY_DSN = os.getenv("SENTRY_DSN", "dsn-unavailable")
 # )
 CSP_REPORT_ONLY = os.getenv("CSP_REPORT_ONLY", True)
 
-CSP_REPORT_URI = (
-    f"https://o320544.ingest.sentry.io/api/6046263/security/?sentry_key={SENTRY_DSN}&sentry_environment={ENVIRONMENT}"
-)
+CSP_REPORT_URI = os.getenv("CSP_REPORT_URI")
 CSP_DEFAULT_SRC = (
     "'self'",
     "*.fundjournalism.org",

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -348,8 +348,8 @@ CURRENCIES = {"USD": "$", "CAD": "$"}
 NON_DONATION_PAGE_SUBDOMAINS = os.getenv("NON_DONATION_PAGE_SUBDOMAINS", ["support", "www"])
 DOMAIN_APEX = os.getenv("DOMAIN_APEX")
 
-SENTRY_DSN = os.getenv("SENTRY_DSN", "dsn-unavailable")
 
+CSP_REPORTING_ENABLE = os.environ.get("CSP_REPORTING_ENABLE", "false").lower() == "true"
 # Django-CSP configuration
 # For now, report only.
 
@@ -361,7 +361,9 @@ SENTRY_DSN = os.getenv("SENTRY_DSN", "dsn-unavailable")
 # )
 CSP_REPORT_ONLY = os.getenv("CSP_REPORT_ONLY", True)
 
-CSP_REPORT_URI = os.getenv("CSP_REPORT_URI")
+if CSP_REPORTING_ENABLE:
+    CSP_REPORT_URI = os.getenv("CSP_REPORT_URI")
+
 CSP_DEFAULT_SRC = (
     "'self'",
     "*.fundjournalism.org",
@@ -418,6 +420,8 @@ SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 # Stripe API Target Version
 STRIPE_API_VERSION = "2020-08-27"
 
+SENTRY_ENABLE = os.environ.get("SENTRY_ENABLE", "false").lower() == "true"
+
 # Front End Environment Variables - Config Vars Heroku
 SPA_ENV_VARS = {
     "HUB_STRIPE_API_PUB_KEY": os.getenv("SPA_ENV_HUB_STRIPE_API_PUB_KEY"),
@@ -428,6 +432,7 @@ SPA_ENV_VARS = {
     "REVENGINE_API_VERSION": os.getenv("SPA_ENV_REVENGINE_API_VERSION", "v1"),
     "STRIPE_API_VERSION": STRIPE_API_VERSION,
     "STRIPE_OAUTH_SCOPE": STRIPE_OAUTH_SCOPE,
+    "SENTRY_ENABLE": SENTRY_ENABLE,
     "STRIPE_CLIENT_ID": os.getenv("SPA_ENV_STRIPE_CLIENT_ID"),
     "HUB_GOOGLE_MAPS_API_KEY": os.getenv("SPA_ENV_HUB_GOOGLE_MAPS_API_KEY"),
     "HUB_V3_GOOGLE_ANALYTICS_ID": os.getenv("SPA_ENV_HUB_V3_GOOGLE_ANALYTICS_ID"),

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -348,6 +348,8 @@ CURRENCIES = {"USD": "$", "CAD": "$"}
 NON_DONATION_PAGE_SUBDOMAINS = os.getenv("NON_DONATION_PAGE_SUBDOMAINS", ["support", "www"])
 DOMAIN_APEX = os.getenv("DOMAIN_APEX")
 
+SENTRY_DSN = os.getenv("SENTRY_DSN", "dsn-unavailable")
+
 # Django-CSP configuration
 # For now, report only.
 
@@ -358,7 +360,10 @@ DOMAIN_APEX = os.getenv("DOMAIN_APEX")
 #     "script-src",
 # )
 CSP_REPORT_ONLY = os.getenv("CSP_REPORT_ONLY", True)
-CSP_REPORT_URI = f"https://o320544.ingest.sentry.io/api/6046263/security/?sentry_key=d576a6738e41453db36130d03e4e95be&sentry_environment={ENVIRONMENT}"
+
+CSP_REPORT_URI = (
+    f"https://o320544.ingest.sentry.io/api/6046263/security/?sentry_key={SENTRY_DSN}&sentry_environment={ENVIRONMENT}"
+)
 CSP_DEFAULT_SRC = (
     "'self'",
     "*.fundjournalism.org",

--- a/revengine/settings/deploy.py
+++ b/revengine/settings/deploy.py
@@ -108,18 +108,15 @@ CELERYBEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_HIJACK_ROOT_LOGGER = False
 
 ### 3rd-party appplications
-SENTRY_DSN = os.getenv("SENTRY_DSN")
-if SENTRY_ENABLE and SENTRY_DSN:
+if SENTRY_ENABLE_BACKEND and SENTRY_DSN_BACKEND:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
 
     sentry_sdk.init(
-        dsn=SENTRY_DSN,
+        dsn=SENTRY_DSN_BACKEND,
         integrations=[DjangoIntegration()],
         environment=ENVIRONMENT,
     )
-
-    SPA_ENV_VARS["SENTRY_DSN"] = SENTRY_DSN
 
 
 # BadActor API

--- a/revengine/settings/deploy.py
+++ b/revengine/settings/deploy.py
@@ -120,6 +120,8 @@ if SENTRY_DSN:
         environment=ENVIRONMENT,
     )
 
+    SPA_ENV_VARS["SENTRY_DSN"] = SENTRY_DSN
+
 
 # BadActor API
 BAD_ACTOR_API_URL = "https://bad-actor.fundjournalism.org/v1/bad_actor/"

--- a/revengine/settings/deploy.py
+++ b/revengine/settings/deploy.py
@@ -108,9 +108,8 @@ CELERYBEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_HIJACK_ROOT_LOGGER = False
 
 ### 3rd-party appplications
-
 SENTRY_DSN = os.getenv("SENTRY_DSN")
-if SENTRY_DSN:
+if SENTRY_ENABLE and SENTRY_DSN:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
 

--- a/spa/src/App.js
+++ b/spa/src/App.js
@@ -9,6 +9,9 @@ import 'semantic-ui-css/semantic.min.css';
 import SvgIcons from 'assets/icons/SvgIcons';
 import hubFavicon from 'assets/icons/favicon.ico';
 
+// Hooks
+import useSentry from 'hooks/useSentry';
+
 // Deps
 import Helmet from 'react-helmet';
 import { Provider as AlertProvider } from 'react-alert';
@@ -18,6 +21,8 @@ import Alert, { alertOptions } from 'elements/alert/Alert';
 import MainLayout from 'components/MainLayout';
 
 function App() {
+  useSentry();
+
   return (
     <ThemeProvider theme={revEngineTheme}>
       <MuiThemeProvider theme={muiThemeOverrides}>

--- a/spa/src/hooks/useSentry.js
+++ b/spa/src/hooks/useSentry.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+// Sentry
+import * as Sentry from '@sentry/react';
+import { Integrations } from '@sentry/tracing';
+
+// Const
+import { SENTRY_DSN } from 'settings';
+
+/**
+ * Typically, just loading sentry at build time is sufficient.
+ * However, due to our front-end environment variable pattern,
+ * we need to wait till runtime to get the Sentry DSN.
+ */
+function useSentry() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') {
+      Sentry.init({
+        dsn: SENTRY_DSN,
+        integrations: [new Integrations.BrowserTracing()],
+        tracesSampleRate: 1.0,
+        environment: document.location.hostname
+      });
+    }
+  });
+}
+
+export default useSentry;

--- a/spa/src/hooks/useSentry.js
+++ b/spa/src/hooks/useSentry.js
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 
 // Const
-import { SENTRY_DSN } from 'settings';
+import { SENTRY_DSN, SENTRY_ENABLE } from 'settings';
 
 /**
  * Typically, just loading sentry at build time is sufficient.
@@ -14,7 +14,7 @@ import { SENTRY_DSN } from 'settings';
  */
 function useSentry() {
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') {
+    if (process.env.NODE_ENV !== 'development' && SENTRY_ENABLE) {
       Sentry.init({
         dsn: SENTRY_DSN,
         integrations: [new Integrations.BrowserTracing()],

--- a/spa/src/hooks/useSentry.js
+++ b/spa/src/hooks/useSentry.js
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 
 // Const
-import { SENTRY_DSN, SENTRY_ENABLE } from 'settings';
+import { SENTRY_DSN_FRONTEND, SENTRY_ENABLE_FRONTEND } from 'settings';
 
 /**
  * Typically, just loading sentry at build time is sufficient.
@@ -14,9 +14,9 @@ import { SENTRY_DSN, SENTRY_ENABLE } from 'settings';
  */
 function useSentry() {
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'development' && SENTRY_ENABLE) {
+    if (process.env.NODE_ENV !== 'development' && SENTRY_ENABLE_FRONTEND) {
       Sentry.init({
-        dsn: SENTRY_DSN,
+        dsn: SENTRY_DSN_FRONTEND,
         integrations: [new Integrations.BrowserTracing()],
         tracesSampleRate: 1.0,
         environment: document.location.hostname

--- a/spa/src/index.js
+++ b/spa/src/index.js
@@ -2,25 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 
-// Sentry
-import * as Sentry from '@sentry/react';
-import { Integrations } from '@sentry/tracing';
-
 // Fontawesome config for CSP`
 import { config as fontawesomeConfig } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 // import 'node_modules/@fortawesome/fontawesome-svg-core/styles.css';
 // Load css via webpack, not via inline styles (fontawesome default)
 fontawesomeConfig.autoAddCss = false;
-
-if (process.env.NODE_ENV !== 'development') {
-  Sentry.init({
-    dsn: 'https://e7c3a0467b6e4474a99922d00cec182e@o168020.ingest.sentry.io/5774473',
-    integrations: [new Integrations.BrowserTracing()],
-    tracesSampleRate: 1.0,
-    environment: document.location.hostname
-  });
-}
 
 // webpack CSP nonce concession
 /* eslint-disable-next-line */

--- a/spa/src/settings.js
+++ b/spa/src/settings.js
@@ -43,8 +43,9 @@ export const GRECAPTCHA_SITE_KEY = '6Lfuse8UAAAAAD9E6tCxKYrxO1IbnXp8IBa4u5Ri';
 export const HUB_GOOGLE_MAPS_API_KEY = resolveConstantFromEnv('HUB_GOOGLE_MAPS_API_KEY');
 
 // Sentry
-export const SENTRY_ENABLE = resolveConstantFromEnv('SENTRY_ENABLE', '').toLowerCase() === 'true';
-export const SENTRY_DSN = resolveConstantFromEnv('SENTRY_DSN');
+export const SENTRY_ENABLE_FRONTEND =
+  resolveConstantFromEnv('SENTRY_ENABLE_FRONTEND', 'false').toLowerCase() === 'true';
+export const SENTRY_DSN_FRONTEND = resolveConstantFromEnv('SENTRY_DSN_FRONTEND');
 
 // Stripe
 export const HUB_STRIPE_API_PUB_KEY = resolveConstantFromEnv('HUB_STRIPE_API_PUB_KEY');

--- a/spa/src/settings.js
+++ b/spa/src/settings.js
@@ -43,6 +43,7 @@ export const GRECAPTCHA_SITE_KEY = '6Lfuse8UAAAAAD9E6tCxKYrxO1IbnXp8IBa4u5Ri';
 export const HUB_GOOGLE_MAPS_API_KEY = resolveConstantFromEnv('HUB_GOOGLE_MAPS_API_KEY');
 
 // Sentry
+export const SENTRY_ENABLE = resolveConstantFromEnv('SENTRY_ENABLE', '').toLowerCase() === 'true';
 export const SENTRY_DSN = resolveConstantFromEnv('SENTRY_DSN');
 
 // Stripe

--- a/spa/src/settings.js
+++ b/spa/src/settings.js
@@ -42,6 +42,9 @@ export const GRECAPTCHA_SITE_KEY = '6Lfuse8UAAAAAD9E6tCxKYrxO1IbnXp8IBa4u5Ri';
 // Google Maps
 export const HUB_GOOGLE_MAPS_API_KEY = resolveConstantFromEnv('HUB_GOOGLE_MAPS_API_KEY');
 
+// Sentry
+export const SENTRY_DSN = resolveConstantFromEnv('SENTRY_DSN');
+
 // Stripe
 export const HUB_STRIPE_API_PUB_KEY = resolveConstantFromEnv('HUB_STRIPE_API_PUB_KEY');
 export const STRIPE_API_VERSION = resolveConstantFromEnv('STRIPE_API_VERSION', '2020-08-27');


### PR DESCRIPTION
#### What's this PR do?
Ensures that all uses of the Sentry DSN reference the SENTRY_DSN env var. Also makes the CSP_REPORT_URI a config var so that it's flexible like the SENTRY_DSN now is.

#### How should this be manually tested?
Set the env vars on staging to the desired DSN and-- maybe trigger some error? Not sure about that one.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
Add the desired DSN to Heroku config vars as SENTRY_DSN to each environment. Also make sure to set the CSP_REPORT_URI env var in each env.
