### PR TITLE
#9701 Move /admin to r"nrhadmin/?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ following shell environment variables or add them to your `.envrc` file:
     (revengine)$ make run-dev
 ```
 
-The react app will be available at `https://localhost:3000/`, and the django admin will be available at `http://localhost:8000/admin/`
+The react app will be available at `https://localhost:3000/`, and the django admin will be available at `http://localhost:8000/nrhadmin/`
 
 **11. Access the server**
 
-The Django admin is at `/admin/`.
+The Django admin is at `/nrhadmin/`.
 
 **12. Test Email Setup**
 

--- a/apps/organizations/tests/test_admin.py
+++ b/apps/organizations/tests/test_admin.py
@@ -21,7 +21,7 @@ def test_feature_add_boolean(admin_client):
     assert Feature.objects.all().count() == 0
     for t in boolean_types:
         feature["feature_value"] = t
-        response = admin_client.post(f"/admin/organizations/feature/{action}/", feature)
+        response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
         assert response.status_code == 302
     assert Feature.objects.all().count() == 4
 
@@ -31,7 +31,7 @@ def test_feature_add_limit(admin_client):
     feature["feature_type"] = Feature.FeatureType.PAGE_LIMIT.value
     feature["feature_value"] = 3
     assert Feature.objects.all().count() == 0
-    response = admin_client.post(f"/admin/organizations/feature/{action}/", feature)
+    response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
     assert response.status_code == 302
     assert Feature.objects.all().count() == 1
 
@@ -40,7 +40,7 @@ def test_feature_add_boolean_fail(admin_client):
     action = "add"
     assert Feature.objects.all().count() == 0
     feature["feature_value"] = "z"
-    response = admin_client.post(f"/admin/organizations/feature/{action}/", feature)
+    response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
     assert response.status_code == 200
     assert Feature.objects.all().count() == 0
     soup = bs4(response.content)
@@ -54,7 +54,7 @@ def test_feature_add_limit_fail(admin_client):
     feature["feature_type"] = Feature.FeatureType.PAGE_LIMIT.value
     for il in invalid_limits:
         feature["feature_value"] = il
-        response = admin_client.post(f"/admin/organizations/feature/{action}/", feature)
+        response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
         assert response.status_code == 200
         soup = bs4(response.content)
         assert soup.find(class_="errorlist nonfield")

--- a/apps/organizations/tests/test_admin.py
+++ b/apps/organizations/tests/test_admin.py
@@ -1,3 +1,5 @@
+from django.urls import reverse
+
 import pytest
 from bs4 import BeautifulSoup as bs4
 
@@ -17,30 +19,28 @@ feature = {
 
 
 def test_feature_add_boolean(admin_client):
-    action = "add"
     assert Feature.objects.all().count() == 0
     for t in boolean_types:
         feature["feature_value"] = t
-        response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
+
+        response = admin_client.post(reverse("admin:organizations_feature_add"), feature)
         assert response.status_code == 302
     assert Feature.objects.all().count() == 4
 
 
 def test_feature_add_limit(admin_client):
-    action = "add"
     feature["feature_type"] = Feature.FeatureType.PAGE_LIMIT.value
     feature["feature_value"] = 3
     assert Feature.objects.all().count() == 0
-    response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
+    response = admin_client.post(reverse("admin:organizations_feature_add"), feature)
     assert response.status_code == 302
     assert Feature.objects.all().count() == 1
 
 
 def test_feature_add_boolean_fail(admin_client):
-    action = "add"
     assert Feature.objects.all().count() == 0
     feature["feature_value"] = "z"
-    response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
+    response = admin_client.post(reverse("admin:organizations_feature_add"), feature)
     assert response.status_code == 200
     assert Feature.objects.all().count() == 0
     soup = bs4(response.content)
@@ -48,13 +48,12 @@ def test_feature_add_boolean_fail(admin_client):
 
 
 def test_feature_add_limit_fail(admin_client):
-    action = "add"
     invalid_limits = [-1, "k", -100, 0]
     assert Feature.objects.all().count() == 0
     feature["feature_type"] = Feature.FeatureType.PAGE_LIMIT.value
     for il in invalid_limits:
         feature["feature_value"] = il
-        response = admin_client.post(f"/nrhadmin/organizations/feature/{action}/", feature)
+        response = admin_client.post(reverse("admin:organizations_feature_add"), feature)
         assert response.status_code == 200
         soup = bs4(response.content)
         assert soup.find(class_="errorlist nonfield")

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -324,7 +324,7 @@ EMAIL_TEMPLATE_IDENTIFIER_MAGIC_LINK_DONOR = os.environ.get(
 
 # this is only used by HubAdmins, not OrgAdmins, but needs to be named generically as LOGIN_URL
 # so our implementation of password reset flow for HubAdmins works as expected
-LOGIN_URL = "/admin/"
+LOGIN_URL = "/nrhadmin/"
 
 # Set USE_DEBUG_INTERVALS to True if you want recurring payment intervals to be truncated for testing (as much as possible, currently)
 USE_DEBUG_INTERVALS = os.getenv("USE_DEBUG_INTERVALS", False)

--- a/revengine/urls.py
+++ b/revengine/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import include
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.urls import path, re_path
+from django.views.generic.base import RedirectView
 
 from apps.api.urls import urlpatterns as api_urlpatterns
 from apps.users.urls import orgadmin_user_management_urls
@@ -12,12 +13,12 @@ from .views import index, read_apple_developer_merchant_id
 
 urlpatterns = [
     path(
-        "admin/password_reset/",
+        "nrhadmin/password_reset/",
         auth_views.PasswordResetView.as_view(),
         name="admin_password_reset",
     ),
     path(
-        "admin/password_reset/done/",
+        "nrhadmin/password_reset/done/",
         auth_views.PasswordResetDoneView.as_view(),
         name="password_reset_done",
     ),
@@ -31,7 +32,8 @@ urlpatterns = [
         auth_views.PasswordResetCompleteView.as_view(),
         name="password_reset_complete",
     ),
-    path("admin/", admin.site.urls),
+    path("nrhadmin", RedirectView.as_view(url="/nrhadmin/")),
+    path("nrhadmin/", admin.site.urls),
     path("users/", include(orgadmin_user_management_urls)),
     path("api/", include(api_urlpatterns)),
     path(".well-known/apple-developer-merchantid-domain-association", read_apple_developer_merchant_id),


### PR DESCRIPTION
#### What's this PR do?
Changes /admin to /nrhadmin.
Removes need for trailing slash on admin route as well

#### How should this be manually tested?
Visit /nrhadmin and observe that the admin is displayed. Visit /admin and observe that nothing happens.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No