### PR TITLE
Fix - TypeError in prod - Handle boolean conversion of string spa_env…

### DIFF
--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -431,7 +431,7 @@ SENTRY_DSN_BACKEND = os.environ.get("SENTRY_DSN_BACKEND")
 # Front End Environment Variables - Config Vars Heroku
 SPA_ENV_VARS = {
     "HUB_STRIPE_API_PUB_KEY": os.getenv("SPA_ENV_HUB_STRIPE_API_PUB_KEY"),
-    "CAPTURE_PAGE_SCREENSHOT": os.getenv("SPA_ENV_CAPTURE_PAGE_SCREENSHOT", "false"),
+    "CAPTURE_PAGE_SCREENSHOT": os.getenv("SPA_ENV_CAPTURE_PAGE_SCREENSHOT", "false").lower() == "true",
     "SALESFORCE_CAMPAIGN_ID_QUERYPARAM": os.getenv("SPA_ENV_APP_SALESFORCE_CAMPAIGN_ID_QUERYPARAM", "campaign"),
     "FREQUENCY_QUERYPARAM": os.getenv("SPA_ENV_FREQUENCY_QUERYPARAM", "frequency"),
     "AMOUNT_QUERYPARAM": os.getenv("SPA_ENV_AMOUNT_QUERYPARAM", "amount"),

--- a/spa/src/settings.js
+++ b/spa/src/settings.js
@@ -19,7 +19,7 @@ export const SALESFORCE_CAMPAIGN_ID_QUERYPARAM = resolveConstantFromEnv(
   'SALESFORCE_CAMPAIGN_ID_QUERYPARAM',
   'campaign'
 );
-export const CAPTURE_PAGE_SCREENSHOT = resolveConstantFromEnv('CAPTURE_PAGE_SCREENSHOT') === 'true';
+export const CAPTURE_PAGE_SCREENSHOT = resolveConstantFromEnv('CAPTURE_PAGE_SCREENSHOT');
 
 // Analytics
 export const HUB_ANALYTICS_APP_NAME = 'rev-engine-analytics';
@@ -43,8 +43,7 @@ export const GRECAPTCHA_SITE_KEY = '6Lfuse8UAAAAAD9E6tCxKYrxO1IbnXp8IBa4u5Ri';
 export const HUB_GOOGLE_MAPS_API_KEY = resolveConstantFromEnv('HUB_GOOGLE_MAPS_API_KEY');
 
 // Sentry
-export const SENTRY_ENABLE_FRONTEND =
-  resolveConstantFromEnv('SENTRY_ENABLE_FRONTEND', 'false').toLowerCase() === 'true';
+export const SENTRY_ENABLE_FRONTEND = resolveConstantFromEnv('SENTRY_ENABLE_FRONTEND', false);
 export const SENTRY_DSN_FRONTEND = resolveConstantFromEnv('SENTRY_DSN_FRONTEND');
 
 // Stripe


### PR DESCRIPTION
…_vars in django base settings instead of react settings

Ticket Ref: https://app.shortcut.com/caktusgroup/story/10825/resolve-confusion-around-booleans-strings-from-env-in-js-settings

#### What's this PR do?
This PR resolves a `TypeError` being thrown in the production environment.  The reason for this error is that when config vars containing Booleans are set in Heroku, they are stored as string versions of a python boolean (uppercase "True" or "False").  When the `spa_env` json is served from django to the html and is parsed in a JS script, the value of the `SENTRY_ENABLE_FRONTEND` config var in production (which had already been being lower-cased in base.py) was interpreted as a Boolean.  In `settings.js` there was another attempt to lowercase the string, but it found a Boolean instead, causing the `TypeError`.

This PR ensures that these booleans are being lowercased (and given a default value) in python base settings.  The repeated logic is removed from the `settings.js` file in the `spa`.

#### How should this be manually tested?
In staging, navigate to any nrh page and open the devtools.  In the console, type `window.ENV`, you should find that any variables with the value of `true` or `false` are represented as Booleans, not strings.  The page should render and there should be no `TypeError`.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?

In order to test this in staging, I set `SENTRY_ENABLE_FRONTEND` to `"True"`.  This isn't a necessary variable for staging and is for testing purposes only.  It could be removed following this test.  No changes to Prod are necessary.
