### PR TITLE
[#11590] Move dislcaimer text to payent widget

### DIFF
--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -17,7 +17,6 @@ import useErrorFocus from 'hooks/useErrorFocus';
 import DonationPageSidebar from 'components/donationPage/DonationPageSidebar';
 
 // Children
-import DonationPageStaticText from 'components/donationPage/DonationPageStaticText';
 import DonationPageFooter from 'components/donationPage/DonationPageFooter';
 import { SALESFORCE_CAMPAIGN_ID_QUERYPARAM, FREQUENCY_QUERYPARAM, AMOUNT_QUERYPARAM } from 'settings';
 
@@ -93,7 +92,6 @@ function DonationPage({ page, live = false }) {
                     {page?.elements?.map((element) => getters.getDynamicElement(element, live))}
                   </S.PageElements>
                 </form>
-                <DonationPageStaticText page={page} frequency={frequency} amount={amount} payFee={payFee} />
               </S.DonationContent>
             </S.SideInner>
           </S.SideOuter>

--- a/spa/src/components/donationPage/DonationPageDisclaimer.js
+++ b/spa/src/components/donationPage/DonationPageDisclaimer.js
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import * as S from './DonationPageStaticText.styled';
+import * as S from './DonationPageDisclaimer.styled';
 import { format } from 'date-fns';
 
 import { getTotalAmount } from 'components/paymentProviders/stripe/stripeFns';
 
-function DonationPageStaticText({ page, amount, payFee, frequency }) {
+function DonationPageDisclaimer({ page, amount, payFee, frequency }) {
   const getFreqText = () =>
     frequency === 'one_time' ? (
       ''
@@ -29,7 +29,7 @@ function DonationPageStaticText({ page, amount, payFee, frequency }) {
   );
 
   return (
-    <S.DonationPageStaticText data-testid="donation-page-static-text">
+    <S.DonationPageDisclaimer data-testid="donation-page-static-text">
       <p>
         By proceeding with this transaction, you agree to our{' '}
         <strong>
@@ -48,8 +48,8 @@ function DonationPageStaticText({ page, amount, payFee, frequency }) {
           {totalAmount} to be processed on or adjacent to {getAmountText()}.
         </strong>
       </p>
-    </S.DonationPageStaticText>
+    </S.DonationPageDisclaimer>
   );
 }
 
-export default DonationPageStaticText;
+export default DonationPageDisclaimer;

--- a/spa/src/components/donationPage/DonationPageDisclaimer.styled.js
+++ b/spa/src/components/donationPage/DonationPageDisclaimer.styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const DonationPageStaticText = styled.div`
+export const DonationPageDisclaimer = styled.div`
   margin: 0 auto;
   max-width: 450px;
   width: 100%;

--- a/spa/src/components/donationPage/DonationPageDisclaimer.test.js
+++ b/spa/src/components/donationPage/DonationPageDisclaimer.test.js
@@ -1,14 +1,14 @@
 import { render } from 'test-utils';
 
 // Test Subject
-import DonationPageStaticText from './DonationPageStaticText';
+import DonationPageDisclaimer from './DonationPageDisclaimer';
 
 // Mock data
 import mockPage from '../../../cypress/fixtures/pages/live-page-1.json';
 
 it('should render some initial static text', () => {
   const { getByText } = render(
-    <DonationPageStaticText page={mockPage} amount={120} payFee={false} frequency={'month'} />
+    <DonationPageDisclaimer page={mockPage} amount={120} payFee={false} frequency={'month'} />
   );
 
   expect(getByText('By proceeding with this transaction, you agree to our', { exact: false })).toBeInTheDocument();
@@ -16,7 +16,7 @@ it('should render some initial static text', () => {
 
 it('should render links pointing to fundjournalism.org\'s "privacy policy" and "terms & conditions"', () => {
   const { getAllByRole } = render(
-    <DonationPageStaticText page={mockPage} amount={120} payFee={false} frequency={'month'} />
+    <DonationPageDisclaimer page={mockPage} amount={120} payFee={false} frequency={'month'} />
   );
 
   const links = getAllByRole('link');
@@ -33,7 +33,7 @@ it('should include the amount provided as a prop in the rendered text', () => {
   const expCurrencySymbol = mockPage.currency.symbol;
   const expAmount = 120;
   const { getByText } = render(
-    <DonationPageStaticText page={mockPage} amount={expAmount} payFee={false} frequency={'month'} />
+    <DonationPageDisclaimer page={mockPage} amount={expAmount} payFee={false} frequency={'month'} />
   );
 
   expect(getByText(`${expCurrencySymbol}${expAmount}`, { exact: false })).toBeInTheDocument();
@@ -42,20 +42,20 @@ it('should include the amount provided as a prop in the rendered text', () => {
 it('should show slightly different text based on the frequency prop', () => {
   const monthly = 'month';
   const { rerender, getByText, queryByText } = render(
-    <DonationPageStaticText page={mockPage} amount={120} payFee={false} frequency={monthly} />
+    <DonationPageDisclaimer page={mockPage} amount={120} payFee={false} frequency={monthly} />
   );
 
   expect(getByText('along with all future recurring payments', { exact: false })).toBeInTheDocument();
   expect(getByText('of the month until you cancel', { exact: false })).toBeInTheDocument();
 
   const yearly = 'year';
-  rerender(<DonationPageStaticText page={mockPage} amount={120} payFee={false} frequency={yearly} />);
+  rerender(<DonationPageDisclaimer page={mockPage} amount={120} payFee={false} frequency={yearly} />);
 
   expect(getByText('along with all future recurring payments', { exact: false })).toBeInTheDocument();
   expect(getByText('yearly until you cancel', { exact: false })).toBeInTheDocument();
 
   const once = 'one_time';
-  rerender(<DonationPageStaticText page={mockPage} amount={120} payFee={false} frequency={once} />);
+  rerender(<DonationPageDisclaimer page={mockPage} amount={120} payFee={false} frequency={once} />);
 
   expect(queryByText('along with all future recurring payments', { exact: false })).toBeNull();
 });

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -37,6 +37,7 @@ import BaseField from 'elements/inputs/BaseField';
 import Button from 'elements/buttons/Button';
 import { ICONS } from 'assets/icons/SvgIcon';
 import { PayFeesWidget } from 'components/donationPage/pageContent/DPayment';
+import DonationPageDisclaimer from 'components/donationPage/DonationPageDisclaimer';
 
 function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   useReCAPTCHAScript();
@@ -277,45 +278,50 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
     return `Give ${currencySymbol}${formatStringAmountForDisplay(totalAmount)} ${getFrequencyAdverb(frequency)}`;
   };
 
-  return !forceManualCard && paymentRequest ? (
+  return (
     <>
-      <S.PaymentRequestWrapper>
-        <PaymentRequestButtonElement options={{ paymentRequest, style: S.PaymentRequestButtonStyle }} />
-      </S.PaymentRequestWrapper>
-      <S.PayWithCardOption onClick={() => setForceManualCard(true)}>
-        - I prefer to manually enter my credit card -
-      </S.PayWithCardOption>
-    </>
-  ) : (
-    <S.StripePaymentForm>
-      <BaseField label="Card details" required>
-        <S.PaymentElementWrapper>
-          <CardElement
-            id="card-element"
-            options={{ style: S.CardElementStyle(theme), hidePostalCode: true }}
-            onChange={handleCardElementChange}
-          />
-        </S.PaymentElementWrapper>
-      </BaseField>
-      {stripeError && (
-        <S.PaymentError role="alert" data-testid="donation-error">
-          {stripeError}
-        </S.PaymentError>
+      {!forceManualCard && paymentRequest ? (
+        <>
+          <S.PaymentRequestWrapper>
+            <PaymentRequestButtonElement options={{ paymentRequest, style: S.PaymentRequestButtonStyle }} />
+          </S.PaymentRequestWrapper>
+          <S.PayWithCardOption onClick={() => setForceManualCard(true)}>
+            - I prefer to manually enter my credit card -
+          </S.PayWithCardOption>
+        </>
+      ) : (
+        <S.StripePaymentForm>
+          <BaseField label="Card details" required>
+            <S.PaymentElementWrapper>
+              <CardElement
+                id="card-element"
+                options={{ style: S.CardElementStyle(theme), hidePostalCode: true }}
+                onChange={handleCardElementChange}
+              />
+            </S.PaymentElementWrapper>
+          </BaseField>
+          {stripeError && (
+            <S.PaymentError role="alert" data-testid="donation-error">
+              {stripeError}
+            </S.PaymentError>
+          )}
+          {offerPayFees && <PayFeesWidget />}
+          <Button
+            onClick={handleCardSubmit}
+            disabled={!cardReady || loading || disabled || succeeded || !amountIsValid}
+            loading={loading}
+            data-testid="donation-submit"
+          >
+            {getButtonText()}
+          </Button>
+        </S.StripePaymentForm>
       )}
-      {offerPayFees && <PayFeesWidget />}
-      <Button
-        onClick={handleCardSubmit}
-        disabled={!cardReady || loading || disabled || succeeded || !amountIsValid}
-        loading={loading}
-        data-testid="donation-submit"
-      >
-        {getButtonText()}
-      </Button>
 
       <S.IconWrapper>
         <S.Icon icon={ICONS.STRIPE_POWERED} />
       </S.IconWrapper>
-    </S.StripePaymentForm>
+      <DonationPageDisclaimer page={page} amount={amount} payFee={payFee} frequency={frequency} />
+    </>
   );
 }
 

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.styled.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.styled.js
@@ -18,12 +18,14 @@ export const EnterValidAmount = styled.h5``;
 
 export const IconWrapper = styled.div`
   display: flex;
-  justify-content: center;
+  height: 25px;
+  margin: 2rem 0;
 `;
 
 export const Icon = styled(SvgIcon)`
-  width: 100px;
-  height: auto;
+  height: 100%;
+  width: auto;
+  margin: 0 auto;
 `;
 
 export const PaymentError = styled.div`


### PR DESCRIPTION
#### What's this PR do?
The initial implementation of the static disclaimer text placed it at the bottom of the page no matter where the credit card form was. That didn't make sense, so we've tied the disclaimer text to the submit button (or payment request button)

#### How should this be manually tested?
Move around your Payment element and notice that the disclaimer text moves with it.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
No
