### PR TITLE
Fix header fallback

### DIFF
--- a/spa/src/components/donationPage/DonationPageNavbar.js
+++ b/spa/src/components/donationPage/DonationPageNavbar.js
@@ -8,7 +8,7 @@ function DonationPageNavbar({ page }) {
   };
 
   return (
-    <S.DonationPageNavbar data-testid="s-header-bar">
+    <S.DonationPageNavbar bgImg={getImageUrl(page?.header_bg_image)} data-testid="s-header-bar">
       <a href={page?.header_link} target="_blank" rel="noreferrer noopener">
         <S.DonationPageNavbarLogo src={getImageUrl(page?.header_logo)} />
       </a>

--- a/spa/src/components/donationPage/DonationPageNavbar.styled.js
+++ b/spa/src/components/donationPage/DonationPageNavbar.styled.js
@@ -2,7 +2,8 @@ import styled from 'styled-components';
 
 export const DonationPageNavbar = styled.header`
   width: 100%;
-  background: ${(props) => props.theme.colors.cstm_mainHeader};
+  background: ${(props) =>
+    props.bgImg ? `url(${props.bgImg})` : props.theme.colors.cstm_mainHeader || props.theme.colors.white};
   background-size: cover;
   height: 60px;
   display: flex;


### PR DESCRIPTION
Restores the option to use a header background image. If not present, defaults to stylesheet provided color