### PR TITLE
Add default colors with cstm_ namespace so there are preset colors wh…

### DIFF
--- a/spa/src/styles/themes.js
+++ b/spa/src/styles/themes.js
@@ -14,7 +14,7 @@ export const revEngineTheme = {
 
     black: '#080708',
 
-    white: '#fff',
+    white: '#ffffff',
 
     grey: ['#eee', '#ccc', '#999', '#666', '#333'],
 
@@ -59,7 +59,14 @@ export const donationPageBase = merge({}, revEngineTheme, {
     lg: '1100px',
     xl: '1300px'
   },
-  font: { body: "'Montserrat', sans-serif", heading: "'Montserrat', sans-serif" }
+  font: { body: "'Montserrat', sans-serif", heading: "'Montserrat', sans-serif" },
+  colors: {
+    cstm_mainHeader: revEngineTheme.colors.white,
+    cstm_mainBackground: '#faf8f8',
+    cstm_formPanelBackground: revEngineTheme.colors.white,
+    cstm_CTAs: revEngineTheme.colors.primary,
+    cstm_ornaments: '#2b2869'
+  }
 });
 
 export const muiThemeOverrides = createMuiTheme({


### PR DESCRIPTION
…en user adds first style

Ticket: https://app.shortcut.com/caktusgroup/story/11733/new-stylesheets-not-showing-default-revengine-styles

#### What's this PR do?
Sets default colors in donationPageBase theme so they're displayed when a user creates a new set of custom styles.

#### How should this be manually tested?
Add a new color and confirm that the default colors match those in the screenshot in the ticket.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
