### PR TITLE
Sentry logging

### DIFF
--- a/revengine/settings/deploy.py
+++ b/revengine/settings/deploy.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -111,10 +112,15 @@ CELERY_HIJACK_ROOT_LOGGER = False
 if SENTRY_ENABLE_BACKEND and SENTRY_DSN_BACKEND:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.logging import LoggingIntegration
 
+    sentry_logging = LoggingIntegration(
+        level=logging.DEBUG,
+        event_level=logging.WARNING,
+    )  # Capture debug and above as breadcrumbs
     sentry_sdk.init(
         dsn=SENTRY_DSN_BACKEND,
-        integrations=[DjangoIntegration()],
+        integrations=[sentry_logging, DjangoIntegration()],
         environment=ENVIRONMENT,
     )
 


### PR DESCRIPTION
#### What's this PR do?

Adds the logging integration for Sentry. So that `logger.warning` will show up in Sentry.

#### How should this be manually tested?

Configure Sentry; generate a log warning; confirm it shows up in Sentry.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?

No.
