### PR TITLE
fix - switches various labels, inputs, and help texts from custom to …

### DIFF
--- a/spa/src/components/donationPage/live/thankYou/GenericThankYou.styled.js
+++ b/spa/src/components/donationPage/live/thankYou/GenericThankYou.styled.js
@@ -31,7 +31,7 @@ export const InnerContent = styled.div`
 `;
 
 export const ThankYou = styled.h2`
-  font-family: ${(props) => props.theme.systemFont};
+  font-family: ${(props) => props.theme.font.heading?.font_name};
   font-size: ${(props) => props.theme.fontSizes[4]};
   font-weight: 900;
   text-align: center;

--- a/spa/src/components/donationPage/pageContent/DElement.styled.js
+++ b/spa/src/components/donationPage/pageContent/DElement.styled.js
@@ -9,6 +9,7 @@ export const Label = styled.h2`
 `;
 
 export const Description = styled.p`
+  font-family: ${(props) => props.theme.systemFont};
   font-size: ${(props) => props.theme.fontSizes[1]};
   font-weight: 500;
   color: ${(props) => props.theme.colors.black};

--- a/spa/src/components/donationPage/pageContent/DPayment.styled.js
+++ b/spa/src/components/donationPage/pageContent/DPayment.styled.js
@@ -22,6 +22,7 @@ export const PayFees = styled.div`
 `;
 
 export const PayFeesQQ = styled.h5`
+  font-family: ${(props) => props.theme.systemFont};
   font-size: ${(props) => props.theme.fontSizes[1]};
   font-weight: 500;
   margin: 1rem 0;
@@ -35,6 +36,7 @@ export const Checkbox = styled(SemanticRadio)`
 `;
 
 export const PayFeesDescription = styled.p`
+  font-family: ${(props) => props.theme.systemFont};
   font-size: ${(props) => props.theme.fontSizes[0]};
   line-height: 1.3;
   padding: 0.5rem 0;

--- a/spa/src/components/donationPage/pageContent/DSwag.js
+++ b/spa/src/components/donationPage/pageContent/DSwag.js
@@ -139,7 +139,7 @@ function SwagItem({ swag, isOnlySwag, ...props }) {
   const swagOptions = isOnlySwag ? swag.swagOptions : [NO_SWAG_OPT].concat(swag.swagOptions);
 
   const [selectedSwagOption, setSelectedSwagOption] = useState(swagOptions[0]);
-  debugger;
+
   return (
     <InputGroup {...props} data-testid={`swag-item-${swag.swagName}`}>
       <GroupedLabel>{swag.swagName}</GroupedLabel>

--- a/spa/src/components/donationPage/pageContent/DSwag.js
+++ b/spa/src/components/donationPage/pageContent/DSwag.js
@@ -139,7 +139,7 @@ function SwagItem({ swag, isOnlySwag, ...props }) {
   const swagOptions = isOnlySwag ? swag.swagOptions : [NO_SWAG_OPT].concat(swag.swagOptions);
 
   const [selectedSwagOption, setSelectedSwagOption] = useState(swagOptions[0]);
-
+  debugger;
   return (
     <InputGroup {...props} data-testid={`swag-item-${swag.swagName}`}>
       <GroupedLabel>{swag.swagName}</GroupedLabel>

--- a/spa/src/components/donationPage/pageContent/DSwag.styled.js
+++ b/spa/src/components/donationPage/pageContent/DSwag.styled.js
@@ -19,6 +19,7 @@ export const optSwagimation = {
 };
 
 export const ThresholdMessage = styled.p`
+  font-family: ${(props) => props.theme.systemFont};
   font-style: italic;
 `;
 

--- a/spa/src/components/pageEditor/CreateTemplateModal.styled.js
+++ b/spa/src/components/pageEditor/CreateTemplateModal.styled.js
@@ -7,9 +7,11 @@ export const CreateTemplateModal = styled.div`
   overflow-y: auto;
   background: ${(props) => props.theme.colors.paneBackground};
   border-radius: ${(props) => props.theme.radii[0]};
+  font-family: ${(props) => props.theme.systemFont};
 `;
 
 export const ModalTitle = styled.h2`
+  font-family: ${(props) => props.theme.systemFont};
   text-align: center;
   padding: 2rem 4rem 0;
 `;

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.styled.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.styled.js
@@ -31,6 +31,7 @@ export const Icon = styled(SvgIcon)`
 export const PaymentError = styled.div`
   margin-bottom: 2rem;
   color: ${(props) => props.theme.colors.caution};
+  font-family: ${(props) => props.theme.systemFont};
 `;
 
 export const PayWithCardOption = styled.p`

--- a/spa/src/elements/buttons/SelectableButton.styled.js
+++ b/spa/src/elements/buttons/SelectableButton.styled.js
@@ -12,6 +12,7 @@ export const SelectableButton = styled.div`
   cursor: pointer;
   padding: 0 1rem;
   position: relative;
+  font-family: ${(props) => props.theme.systemFont};
   font-size: ${(props) => props.theme.fontSizes[1]};
   font-weight: 700;
   color: ${(props) => (props.selected ? props.theme.colors.white : props.theme.colors.black)};

--- a/spa/src/elements/inputs/BaseField.styled.js
+++ b/spa/src/elements/inputs/BaseField.styled.js
@@ -27,6 +27,7 @@ export const FieldWrapper = styled.div`
 
 export const Label = styled.label`
   display: block;
+  font-family: ${(props) => props.theme.systemFont};
   font-size: ${(props) => props.theme.fontSizes[1]};
   font-weight: 500;
   color: ${(props) => props.theme.colors.black};
@@ -35,6 +36,7 @@ export const Label = styled.label`
 
 export const HelpText = styled.p`
   margin-top: 1rem;
+  font-family: ${(props) => props.theme.systemFont};
   font-weight: 200;
   font-size: 14px;
   font-style: italic;

--- a/spa/src/elements/inputs/GroupedLabel.styled.js
+++ b/spa/src/elements/inputs/GroupedLabel.styled.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
 export const GroupedLabel = styled.p`
+  font-family: ${(props) => props.theme.systemFont};
   font-size: ${(props) => props.theme.fontSizes[1]};
 `;


### PR DESCRIPTION
…systems font, switches 'Thank You' to custom font
Ticket for Reference: https://app.shortcut.com/caktusgroup/story/12002/areas-that-need-font-changes

#### What's this PR do?
Converts various labels, inputs, buttons, and helpTexts to system font.
Converts "Thank You" to custom font.

#### How should this be manually tested?
Go to a donation page that has a style with a custom font applied and check to ensure that each item pointed out by client in ticket are rendering using the proper font.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
