### PR TITLE
sc-11850 Fixes empty revenue program accessor.

### DIFF
--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -51,7 +51,8 @@ class AbstractPage(IndexedTimeStampedModel):
 
     @property
     def organization(self):
-        return self.revenue_program.organization
+        if self.revenue_program:
+            return self.revenue_program.organization
 
     @classmethod
     def field_names(cls):


### PR DESCRIPTION
#### What's this PR do?

Ensures that a page has a revenue program before attempting to access properties of that revenue program.

#### How should this be manually tested?
With a current staging database, visit http://localhost:8000/nrhadmin/pages/donationpage/ 

it should not 500

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
