### PR TITLE
sc-11983 Removes string None in styles PK response.

### DIFF
--- a/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
@@ -8,7 +8,7 @@ function StylesChooser({ styles = [], selected, setSelected }) {
         label="Choose from existing styles"
         onSelectedItemChange={({ selectedItem }) => setSelected(selectedItem)}
         selectedItem={selected}
-        items={[{ name: '----none----', id: 'None' }].concat(styles)}
+        items={[{ name: '----none----', id: '' }].concat(styles)}
         itemToString={(i) => i.name}
         placeholder="Select a style"
         dropdownPosition="below"


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug that was causing the serializer to reject an "unset styles for this page" request.

#### How should this be manually tested?

1. Open a page and edit the styles.
2. Set the styles to `--none--`
3. Save the page.
The page should save successfully.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
