### PR TITLE
12233 - specifies system font for PayWithCardOption

### DIFF
--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.styled.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.styled.js
@@ -37,6 +37,7 @@ export const PaymentError = styled.div`
 
 export const PayWithCardOption = styled.p`
   cursor: pointer;
+  font-family: ${(props) => props.theme.systemFont};
   font-size: ${(props) => props.theme.fontSizes[1]};
   font-style: italic;
   text-align: center;


### PR DESCRIPTION
Ticket Ref: https://app.shortcut.com/caktusgroup/story/12233/update-text-for-i-prefer-to-manually-enter-my-credit-card-to-use-system-fonts

#### What's this PR do?

Sets system font in styling for the PayWithCardOptions text, "I prefer to manually enter my credit card".

#### How should this be manually tested?

Go to a donation page with a custom font applied in the styles.  Check to make sure that text is displayed using the system font.

#### Do any changes need to be made before deployment to staging? production? (adding environment variables, for example)?
