### PR TITLE
DEV 870 - Interstitial form validation failure when changing credit card payment method from contributor portal

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -23,8 +23,8 @@ jobs:
   cypress-test:
     runs-on: ubuntu-latest
     env:
-      REACT_APP_HUB_STRIPE_API_PUB_KEY: pk_test_31XWC5qhlLi9UkV1OzsI634W
-      REACT_APP_STRIPE_ACCOUNT_ID: acct_1ASCSHBMAMOLTEak
+      REACT_APP_HUB_STRIPE_API_PUB_KEY: pk_test_djfoi12312414
+      REACT_APP_STRIPE_ACCOUNT_ID: acc_3kjfo23jj
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -22,6 +22,9 @@ jobs:
 
   cypress-test:
     runs-on: ubuntu-latest
+    env:
+      REACT_APP_HUB_STRIPE_API_PUB_KEY: pk_test_31XWC5qhlLi9UkV1OzsI634W
+      REACT_APP_STRIPE_ACCOUNT_ID: acct_1ASCSHBMAMOLTEak
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -159,60 +159,80 @@ describe('Update recurring contribution modal', () => {
       .click();
   });
 
-  it('should not enable update payment method when card number is not fully entered', () => {
-    cy.setStripeCardElementText('cardExpiry', '0199');
-    cy.setStripeCardElementText('cardCvc', '123');
-    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-    cy.setStripeCardElementText('cardNumber', '4242');
+  it(
+    'should not enable update payment method when card number is not fully entered',
+    { defaultCommandTimeout: 10000 },
+    () => {
+      cy.setStripeCardElement('cardExpiry', '0199');
+      cy.setStripeCardElement('cardCvc', '123');
+      cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+      cy.setStripeCardElement('cardNumber', '4242');
+      cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+    }
+  );
+
+  it('should not enable update payment method when card number is invalid', { defaultCommandTimeout: 15000 }, () => {
+    cy.setStripeCardElement('cardNumber', '1234123412341234');
+    cy.setStripeCardElement('cardExpiry', '0199');
+    cy.setStripeCardElement('cardCvc', '123');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
-  it('should not enable update payment method when card number is invalid', () => {
-    cy.setStripeCardElementText('cardNumber', '1234123412341234');
-    cy.setStripeCardElementText('cardExpiry', '0199');
-    cy.setStripeCardElementText('cardCvc', '123');
+  it(
+    'should not enable update payment method when card expiry is not fully entered',
+    { defaultCommandTimeout: 10000 },
+    () => {
+      cy.setStripeCardElement('cardNumber', '4242424242424242');
+      cy.setStripeCardElement('cardExpiry', '0199');
+      cy.setStripeCardElement('cardCvc', '123');
+      cy.setStripeCardElement('postalCode', '12345');
+      cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+    }
+  );
+
+  it('should not enable update payment method when card expiry is invalid', { defaultCommandTimeout: 15000 }, () => {
+    cy.setStripeCardElement('cardNumber', '4242424242424242');
+    cy.setStripeCardElement('cardCvc', '123');
+    cy.setStripeCardElement('postalCode', '12345');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
-  it('should not enable update payment method when card expiry is not fully entered', () => {
-    cy.setStripeCardElementText('cardNumber', '4242424242424242');
-    cy.setStripeCardElementText('cardExpiry', '0199');
-    cy.setStripeCardElementText('cardCvc', '123');
-    cy.setStripeCardElementText('postalCode', '12345');
-    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-  });
+  it(
+    'should not enable update payment method when card cvc is not fully entered',
+    { defaultCommandTimeout: 10000 },
+    () => {
+      cy.setStripeCardElement('cardNumber', '4242424242424242');
+      cy.setStripeCardElement('cardExpiry', '0199');
+      cy.setStripeCardElement('postalCode', '12345');
+      cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+      cy.setStripeCardElement('cardCvc', '12');
+      cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+    }
+  );
 
-  it('should not enable update payment method when card expiry is invalid', () => {
-    cy.setStripeCardElementText('cardNumber', '4242424242424242');
-    cy.setStripeCardElementText('cardCvc', '123');
-    cy.setStripeCardElementText('postalCode', '12345');
-    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-  });
+  it(
+    'should not enable update payment method when postal code is not fully entered',
+    { defaultCommandTimeout: 10000 },
+    () => {
+      cy.setStripeCardElement('cardNumber', '4242424242424242');
+      cy.setStripeCardElement('cardExpiry', '0199');
+      cy.setStripeCardElement('cardCvc', '123');
+      cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+      cy.setStripeCardElement('postalCode', '1234');
+      cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+    }
+  );
 
-  it('should not enable update payment method when card cvc is not fully entered', () => {
-    cy.setStripeCardElementText('cardNumber', '4242424242424242');
-    cy.setStripeCardElementText('cardExpiry', '0199');
-    cy.setStripeCardElementText('postalCode', '12345');
-    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-    cy.setStripeCardElementText('cardCvc', '12');
-    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-  });
-
-  it('should not enable update payment method when postal code is not fully entered', () => {
-    cy.setStripeCardElementText('cardNumber', '4242424242424242');
-    cy.setStripeCardElementText('cardExpiry', '0199');
-    cy.setStripeCardElementText('cardCvc', '123');
-    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-    cy.setStripeCardElementText('postalCode', '1234');
-    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-  });
-
-  it('should enable update payment method when card details are entered correctly', () => {
-    let today = new Date();
-    cy.setStripeCardElementText('cardNumber', '4242424242424242');
-    cy.setStripeCardElementText('cardExpiry', `${today.getMonth() + 1}${today.getFullYear() % 100}`);
-    cy.setStripeCardElementText('cardCvc', '123');
-    cy.setStripeCardElementText('postalCode', '12345');
-    cy.getByTestId('contrib-update-payment-method-btn').should('not.be.disabled');
-  });
+  it(
+    'should enable update payment method when card details are entered correctly',
+    { defaultCommandTimeout: 10000 },
+    () => {
+      let today = new Date();
+      cy.setStripeCardElement('cardNumber', '4242424242424242');
+      cy.setStripeCardElement('cardExpiry', `${today.getMonth() + 1}${today.getFullYear() % 100}`);
+      cy.setStripeCardElement('cardCvc', '123');
+      cy.setStripeCardElement('postalCode', '12345');
+      cy.getByTestId('contrib-update-payment-method-btn').should('not.be.disabled');
+    }
+  );
 });

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -157,7 +157,7 @@ describe('Update recurring contribution modal', () => {
       .find('[data-testid="payment-method"]')
       .first()
       .click()
-      .wait(1000);
+      .wait(8000);
   });
 
   it('should not enable update payment method when card number is not fully entered', () => {

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -160,10 +160,6 @@ describe('Update recurring contribution modal', () => {
       .wait(1000);
   });
 
-  afterEach(() => {
-    cy.getByTestId('close-modal').click();
-  });
-
   it('should not enable update payment method when card number is not fully entered', () => {
     cy.setStripeCardElementText('cardExpiry', '0199');
     cy.setStripeCardElementText('cardCvc', '123');

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -141,3 +141,80 @@ describe('Contributor portal', () => {
     });
   });
 });
+
+describe('Update recurring contribution modal', () => {
+  beforeEach(() => {
+    // "Log in" to contributor dash
+    cy.intercept({ method: 'POST', url: getEndpoint(VERIFY_TOKEN) }, { fixture: 'user/valid-contributor-1.json' }).as(
+      'login'
+    );
+    cy.interceptPaginatedDonations();
+    cy.visit(CONTRIBUTOR_VERIFY);
+    cy.wait(['@login', '@getDonations']);
+    cy.get('td[data-testcolumnaccessor="interval"]')
+      .contains('Monthly')
+      .closest('tr')
+      .find('[data-testid="payment-method"]')
+      .first()
+      .click();
+  });
+
+  it('should not enable update payment method when card number is not fully entered', () => {
+    cy.getStripeCardElement('cardExpiry').type('0199');
+    cy.getStripeCardElement('cardCvc').type('123');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+    cy.getStripeCardElement('cardNumber').type('4242');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+  });
+
+  it('should not enable update payment method when card number is invalid', () => {
+    debugger;
+
+    cy.getStripeCardElement('cardNumber').type('1234123412341234');
+    cy.getStripeCardElement('cardExpiry').type('0199');
+    cy.getStripeCardElement('cardCvc').type('123');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+  });
+
+  it('should not enable update payment method when card expiry is not fully entered', () => {
+    cy.getStripeCardElement('cardNumber').type('4242424242424242');
+    cy.getStripeCardElement('cardExpiry').type('0199');
+    cy.getStripeCardElement('cardCvc').type('123');
+    cy.getStripeCardElement('postalCode').type('12345');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+  });
+
+  it('should not enable update payment method when card expiry is invalid', () => {
+    cy.getStripeCardElement('cardNumber').type('4242424242424242');
+    cy.getStripeCardElement('cardCvc').type('123');
+    cy.getStripeCardElement('postalCode').type('12345');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+  });
+
+  it('should not enable update payment method when card cvc is not fully entered', () => {
+    cy.getStripeCardElement('cardNumber').type('4242424242424242');
+    cy.getStripeCardElement('cardExpiry').type('0199');
+    cy.getStripeCardElement('postalCode').type('12345');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+    cy.getStripeCardElement('cardCvc').type('12');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+  });
+
+  it('should not enable update payment method when postal code is not fully entered', () => {
+    cy.getStripeCardElement('cardNumber').type('4242424242424242');
+    cy.getStripeCardElement('cardExpiry').type('0199');
+    cy.getStripeCardElement('cardCvc').type('123');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+    cy.getStripeCardElement('postalCode').type('1234');
+    cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
+  });
+
+  it('should enable update payment method when card details are entered correctly', () => {
+    let today = new Date();
+    cy.getStripeCardElement('cardNumber').type('4242424242424242');
+    cy.getStripeCardElement('cardExpiry').type(`${today.getMonth() + 1}${today.getFullYear() % 100}`);
+    cy.getStripeCardElement('cardCvc').type('123');
+    cy.getStripeCardElement('postalCode').type('12345');
+    cy.getByTestId('contrib-update-payment-method-btn').should('not.be.disabled');
+  });
+});

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -156,7 +156,12 @@ describe('Update recurring contribution modal', () => {
       .closest('tr')
       .find('[data-testid="payment-method"]')
       .first()
-      .click();
+      .click()
+      .wait(1000);
+  });
+
+  afterEach(() => {
+    cy.getByTestId('close-modal').click();
   });
 
   it('should not enable update payment method when card number is not fully entered', () => {

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -173,8 +173,6 @@ describe('Update recurring contribution modal', () => {
   });
 
   it('should not enable update payment method when card number is invalid', () => {
-    debugger;
-
     cy.getStripeCardElement('cardNumber').type('1234123412341234');
     cy.getStripeCardElement('cardExpiry').type('0199');
     cy.getStripeCardElement('cardCvc').type('123');

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -156,8 +156,7 @@ describe('Update recurring contribution modal', () => {
       .closest('tr')
       .find('[data-testid="payment-method"]')
       .first()
-      .click()
-      .wait(8000);
+      .click();
   });
 
   it('should not enable update payment method when card number is not fully entered', () => {

--- a/spa/cypress/integration/08 - contributor.spec.js
+++ b/spa/cypress/integration/08 - contributor.spec.js
@@ -165,59 +165,59 @@ describe('Update recurring contribution modal', () => {
   });
 
   it('should not enable update payment method when card number is not fully entered', () => {
-    cy.getStripeCardElement('cardExpiry').type('0199');
-    cy.getStripeCardElement('cardCvc').type('123');
+    cy.setStripeCardElementText('cardExpiry', '0199');
+    cy.setStripeCardElementText('cardCvc', '123');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-    cy.getStripeCardElement('cardNumber').type('4242');
+    cy.setStripeCardElementText('cardNumber', '4242');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
   it('should not enable update payment method when card number is invalid', () => {
-    cy.getStripeCardElement('cardNumber').type('1234123412341234');
-    cy.getStripeCardElement('cardExpiry').type('0199');
-    cy.getStripeCardElement('cardCvc').type('123');
+    cy.setStripeCardElementText('cardNumber', '1234123412341234');
+    cy.setStripeCardElementText('cardExpiry', '0199');
+    cy.setStripeCardElementText('cardCvc', '123');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
   it('should not enable update payment method when card expiry is not fully entered', () => {
-    cy.getStripeCardElement('cardNumber').type('4242424242424242');
-    cy.getStripeCardElement('cardExpiry').type('0199');
-    cy.getStripeCardElement('cardCvc').type('123');
-    cy.getStripeCardElement('postalCode').type('12345');
+    cy.setStripeCardElementText('cardNumber', '4242424242424242');
+    cy.setStripeCardElementText('cardExpiry', '0199');
+    cy.setStripeCardElementText('cardCvc', '123');
+    cy.setStripeCardElementText('postalCode', '12345');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
   it('should not enable update payment method when card expiry is invalid', () => {
-    cy.getStripeCardElement('cardNumber').type('4242424242424242');
-    cy.getStripeCardElement('cardCvc').type('123');
-    cy.getStripeCardElement('postalCode').type('12345');
+    cy.setStripeCardElementText('cardNumber', '4242424242424242');
+    cy.setStripeCardElementText('cardCvc', '123');
+    cy.setStripeCardElementText('postalCode', '12345');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
   it('should not enable update payment method when card cvc is not fully entered', () => {
-    cy.getStripeCardElement('cardNumber').type('4242424242424242');
-    cy.getStripeCardElement('cardExpiry').type('0199');
-    cy.getStripeCardElement('postalCode').type('12345');
+    cy.setStripeCardElementText('cardNumber', '4242424242424242');
+    cy.setStripeCardElementText('cardExpiry', '0199');
+    cy.setStripeCardElementText('postalCode', '12345');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-    cy.getStripeCardElement('cardCvc').type('12');
+    cy.setStripeCardElementText('cardCvc', '12');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
   it('should not enable update payment method when postal code is not fully entered', () => {
-    cy.getStripeCardElement('cardNumber').type('4242424242424242');
-    cy.getStripeCardElement('cardExpiry').type('0199');
-    cy.getStripeCardElement('cardCvc').type('123');
+    cy.setStripeCardElementText('cardNumber', '4242424242424242');
+    cy.setStripeCardElementText('cardExpiry', '0199');
+    cy.setStripeCardElementText('cardCvc', '123');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
-    cy.getStripeCardElement('postalCode').type('1234');
+    cy.setStripeCardElementText('postalCode', '1234');
     cy.getByTestId('contrib-update-payment-method-btn').should('be.disabled');
   });
 
   it('should enable update payment method when card details are entered correctly', () => {
     let today = new Date();
-    cy.getStripeCardElement('cardNumber').type('4242424242424242');
-    cy.getStripeCardElement('cardExpiry').type(`${today.getMonth() + 1}${today.getFullYear() % 100}`);
-    cy.getStripeCardElement('cardCvc').type('123');
-    cy.getStripeCardElement('postalCode').type('12345');
+    cy.setStripeCardElementText('cardNumber', '4242424242424242');
+    cy.setStripeCardElementText('cardExpiry', `${today.getMonth() + 1}${today.getFullYear() % 100}`);
+    cy.setStripeCardElementText('cardCvc', '123');
+    cy.setStripeCardElementText('postalCode', '12345');
     cy.getByTestId('contrib-update-payment-method-btn').should('not.be.disabled');
   });
 });

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -111,38 +111,14 @@ Cypress.Commands.add('editElement', (elementType) => {
     });
 });
 
-Cypress.Commands.add('getStripeCardElement', (elementName) => {
-  return cy
-    .wait(1000)
-    .get('iframe')
-    .its('0.contentDocument.body')
-    .should('not.be.empty')
-    .then(cy.wrap)
-    .find(`input[data-elements-stable-field-name="${elementName}"]`);
-});
-
-Cypress.Commands.add('iframeLoaded', { prevSubject: 'element' }, ($iframe) => {
-  const contentWindow = $iframe.prop('contentWindow');
-  return new Promise((resolve) => {
-    if (contentWindow && contentWindow.document.readyState === 'complete') {
-      resolve(contentWindow.document.body);
-    } else {
-      $iframe.on('load', () => {
-        resolve(contentWindow.document.body);
-      });
-    }
-  });
-});
-
-Cypress.Commands.add('setStripeCardElementText', (elementName, value) => {
-  var selector = `input[data-elements-stable-field-name="${elementName}"]`;
-  cy.getByTestId('edit-recurring-payment-modal').within(($paymentModal) => {
-    cy.wrap($paymentModal)
-      .get('iframe', { timeout: 10000 })
-      .should('be.visible')
-      .iframeLoaded()
-      .find(selector, { timeout: 10000 })
-      .should('exist')
+Cypress.Commands.add('setStripeCardElement', (elementName, value) => {
+  return cy.getByTestId('edit-recurring-payment-modal').within(($modal) => {
+    cy.wrap($modal)
+      .get('iframe')
+      .its('0.contentDocument.body')
+      .should('not.be.empty')
+      .then(cy.wrap)
+      .find(`input[data-elements-stable-field-name="${elementName}"]`)
       .type(value);
   });
 });

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -110,3 +110,12 @@ Cypress.Commands.add('editElement', (elementType) => {
       cy.getByTestId('pencil-button').click({ force: true });
     });
 });
+
+Cypress.Commands.add('getStripeCardElement', (elementName) => {
+  return cy
+    .get('iframe')
+    .its('0.contentDocument.body')
+    .should('not.be.empty')
+    .then(cy.wrap)
+    .find(`input[data-elements-stable-field-name="${elementName}"]`);
+});

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -120,3 +120,14 @@ Cypress.Commands.add('getStripeCardElement', (elementName) => {
     .then(cy.wrap)
     .find(`input[data-elements-stable-field-name="${elementName}"]`);
 });
+
+Cypress.Commands.add('setStripeCardElementText', (elementName, value) => {
+  let selector = `input[data-elements-stable-field-name="${elementName}"]`;
+  return cy
+    .get('iframe')
+    .should((iframe) => expect(iframe.contents().find(selector)).to.exist)
+    .then((iframe) => cy.wrap(iframe.contents().find(selector)))
+    .within((input) => {
+      cy.wrap(input).should('not.be.disabled').clear().type(value);
+    });
+});

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -122,14 +122,16 @@ Cypress.Commands.add('getStripeCardElement', (elementName) => {
 });
 
 Cypress.Commands.add('setStripeCardElementText', (elementName, value) => {
-  return cy
-    .get('.StripeElement')
-    .get('iframe')
-    .should(
-      (iframe) => expect(iframe.contents().find(`input[data-elements-stable-field-name="${elementName}"]`)).to.exist
-    )
-    .then((iframe) => cy.wrap(iframe.contents().find(`input[data-elements-stable-field-name="${elementName}"]`)))
-    .within((input) => {
-      cy.wrap(input).should('not.be.disabled').clear().type(value);
+  return cy.getByTestId('edit-recurring-payment-modal').within(() => {
+    cy.get('.StripeElement').within(() => {
+      cy.get('iframe')
+        .should(
+          (iframe) => expect(iframe.contents().find(`input[data-elements-stable-field-name="${elementName}"]`)).to.exist
+        )
+        .then((iframe) => cy.wrap(iframe.contents().find(`input[data-elements-stable-field-name="${elementName}"]`)))
+        .within((input) => {
+          cy.wrap(input).should('not.be.disabled').clear().type(value);
+        });
     });
+  });
 });

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -113,6 +113,7 @@ Cypress.Commands.add('editElement', (elementType) => {
 
 Cypress.Commands.add('getStripeCardElement', (elementName) => {
   return cy
+    .wait(1000)
     .get('iframe')
     .its('0.contentDocument.body')
     .should('not.be.empty')

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -122,11 +122,13 @@ Cypress.Commands.add('getStripeCardElement', (elementName) => {
 });
 
 Cypress.Commands.add('setStripeCardElementText', (elementName, value) => {
-  let selector = `input[data-elements-stable-field-name="${elementName}"]`;
   return cy
+    .get('.StripeElement')
     .get('iframe')
-    .should((iframe) => expect(iframe.contents().find(selector)).to.exist)
-    .then((iframe) => cy.wrap(iframe.contents().find(selector)))
+    .should(
+      (iframe) => expect(iframe.contents().find(`input[data-elements-stable-field-name="${elementName}"]`)).to.exist
+    )
+    .then((iframe) => cy.wrap(iframe.contents().find(`input[data-elements-stable-field-name="${elementName}"]`)))
     .within((input) => {
       cy.wrap(input).should('not.be.disabled').clear().type(value);
     });

--- a/spa/src/components/contributor/contributorDashboard/EditRecurringPaymentModal.js
+++ b/spa/src/components/contributor/contributorDashboard/EditRecurringPaymentModal.js
@@ -107,7 +107,7 @@ function CardForm({ onPaymentMethod, closeModal }) {
    * Listen for changes in the CardElement and display any errors as the customer types their card details
    */
   const handleChange = async (event) => {
-    setDisabled(event.empty);
+    setDisabled(event.error || !event.complete);
     setErrors({ stripe: event.error ? event.error.message : '' });
   };
 
@@ -150,6 +150,7 @@ function CardForm({ onPaymentMethod, closeModal }) {
           type="positive"
           loading={loading}
           disabled={loading || disabled || succeeded}
+          data-testid="contrib-update-payment-method-btn"
         >
           Update payment method
         </Button>


### PR DESCRIPTION
What's this PR do?
Will not allow user to submit payment update if there are any errors or partially filled payment details.

Why are we doing this? How does it help us?
Fixing this but improves user experience.

How should this be manually tested?
Goto -> `/contributor/contributions/`-> click on payment method (card number) -> provide the card details.
`Update payment method` should not be enabled if the payment details are not completely provided.

Have automated unit tests been added?
Yes

How should this change be communicated to end users?
N/A

Are there any smells or added technical debt to note?
No

Has this been documented? If so, where?
N/A

What are the relevant tickets?
(Note: Please use syntax [JIRA-123] to link any relevant tickets)
[DEV-870]

Do any changes need to be made before deployment to production (adding environment variables, for example)?
No

Are there next steps? If so, what? Have tickets been opened for them?
(Note: Please use syntax [JIRA-123] to link any relevant tickets)

[DEV-870]: https://news-revenue-hub.atlassian.net/browse/DEV-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ