### PR TITLE
DEV-1728 replace Donation with Contribution

### DIFF
--- a/apps/emails/models.py
+++ b/apps/emails/models.py
@@ -35,9 +35,9 @@ class BaseEmailTemplate(models.Model):
         @staticmethod
         def default_schema():
             return {
-                "donation_date": "test_donation_date",
+                "contribution_date": "test_contribution_date",
                 "donor_email": "test_donor_email",
-                "donation_amount": "test_donation_amount",
+                "contribution_amount": "test_contribution_amount",
                 "copyright_year": "test_copyright_year",
                 "org_name": "test_org_name",
             }
@@ -108,10 +108,10 @@ class PageEmailTemplate(BaseEmailTemplate):
     def one_time_donation(self, payment_manager):
         merge_data = {
             "org_name": payment_manager.get_organization().name,
-            "donation_date": timezone.now().strftime("%m-%d-%y"),
+            "contribution_date": timezone.now().strftime("%m-%d-%y"),
             "donor_email": payment_manager.data["email"],
-            "donation_amount": f"${(payment_manager.data['amount'] / 100):.2f}",
+            "contribution_amount": f"${(payment_manager.data['amount'] / 100):.2f}",
             "copyright_year": timezone.now().strftime("%Y"),
         }
         self.update_default_fields(merge_data)
-        self.send_email(to=payment_manager.data["email"], subject="Thank you for your donation!")
+        self.send_email(to=payment_manager.data["email"], subject="Thank you for your contribution!")

--- a/apps/emails/tasks.py
+++ b/apps/emails/tasks.py
@@ -17,10 +17,10 @@ logger = get_task_logger(f"{settings.DEFAULT_LOGGER}.{__name__}")
     autoretry_for=(AnymailAPIError,),
 )
 def send_donor_email(identifier, to, subject, template_data):  # pragma: no cover
-    logger.info("Sending a donation email")
+    logger.info("Sending receipt email id:%s to:%s subject:%s", identifier, to, subject)
     message = AnymailMessage()
     message.template_id = identifier
-    message.to = [to]
+    message.to = [to, ]
     message.subject = subject
     message.merge_global_data = template_data
     message.send()

--- a/apps/emails/tasks.py
+++ b/apps/emails/tasks.py
@@ -20,7 +20,9 @@ def send_donor_email(identifier, to, subject, template_data):  # pragma: no cove
     logger.info("Sending receipt email id:%s to:%s subject:%s", identifier, to, subject)
     message = AnymailMessage()
     message.template_id = identifier
-    message.to = [to, ]
+    message.to = [
+        to,
+    ]
     message.subject = subject
     message.merge_global_data = template_data
     message.send()

--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -134,8 +134,8 @@ class Template(AbstractPage):
         )
 
     def make_page_from_template(self, page_data={}):
-        """
-        Create a page from from template.
+        """Create DonationPage() instance from self.
+
         Expects template_data as dict, and optional page_data (eg. for creating a template page via org admin).
         We also clean up template and page data here, so that we only copy the fields we want.
         """
@@ -221,6 +221,10 @@ class DonationPage(AbstractPage, SafeDeleteModel):
         super().save(*args, **kwargs)
 
     def make_template_from_page(self, template_data={}):
+        """Create Template() instance from self.
+
+        Clean up template_data and page data here, so that we only copy the fields we want.
+        """
         unwanted_keys = [
             "_state",
             "id",

--- a/apps/slack/slack_manager.py
+++ b/apps/slack/slack_manager.py
@@ -84,7 +84,7 @@ class SlackManager:
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"<{settings.SITE_URL}/dashboard/donations?id={contribution.pk}|View on RevEngine>",
+                "text": f"<{settings.SITE_URL}/dashboard/contributions?id={contribution.pk}|View on RevEngine>",
             },
         }
 

--- a/email_templates/nrh-default-otd.html
+++ b/email_templates/nrh-default-otd.html
@@ -246,9 +246,9 @@ a[x-apple-data-detectors='true'] {
   <div>
     <div style="background-color: #e0e0e0; padding: 24px">
 	<strong>Contribution Details:</strong>
-  <p>Date Received: {{ donation_date }}</p>
+  <p>Date Received: {{ contribution_date }}</p>
   <p>Email: {{ donor_email }}</p>
-  <p>Amount Contributed: {{ donation_amount }}</p>
+  <p>Amount Contributed: {{ contribution_amount }}</p>
 </div>
   </div>
 

--- a/email_templates/nrh-manage-donations-magic-link.html
+++ b/email_templates/nrh-manage-donations-magic-link.html
@@ -124,8 +124,7 @@
                         <td height="25" style="height:25px;" class="em_h20">&nbsp;</td>
                     </tr>
                     <tr>
-                      <td class="em_grey" align="center" valign="top" style="font-family: Arial, sans-serif; font-size: 16px; line-height: 26px; color:#434343;">If you didn't request access to your donations please ignore this message.<br class="em_hide" /></td>
-
+                        <td class="em_grey" align="center" valign="top" style="font-family: Arial, sans-serif; font-size: 16px; line-height: 26px; color:#434343;">If you didn't request access to your contributions please ignore this message.<br class="em_hide" /></td>
                     <tr>
                         <td height="44" style="height:44px;" class="em_h20">&nbsp;</td>
                     </tr>

--- a/email_templates/nrh-v2-default-one-time-donation.html
+++ b/email_templates/nrh-v2-default-one-time-donation.html
@@ -247,7 +247,7 @@ a[x-apple-data-detectors='true'] {
   <div>
     <div style="background-color: #e0e0e0; padding: 24px">
 	<strong>Contribution Details:</strong>
-  <p>Date Received: {{ donation_date }}</p>
+  <p>Date Received: {{ contribution_date }}</p>
   <p>Email: {{ donor_email }}</p>
   <p>Amount Contributed: {{ intent_amount }}</p>
 </div>

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -253,7 +253,7 @@ STRIPE_TEST_SECRET_KEY = os.getenv("TEST_HUB_STRIPE_API_SECRET_KEY", "")
 STRIPE_OAUTH_SCOPE = "read_write"
 STRIPE_LIVE_MODE = os.environ.get("STRIPE_LIVE_MODE", "false").lower() == "true"
 
-GENERIC_STRIPE_PRODUCT_NAME = "Donation via RevEngine"
+GENERIC_STRIPE_PRODUCT_NAME = "Contribution via RevEngine"
 
 # Get it from the section in the Stripe dashboard where you added the webhook endpoint
 STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")


### PR DESCRIPTION

#### What's this PR do?
Rename magic link email template

Also, Rename dashboard url overlooked in DEV-1512

Also started fuller rename (cause I can't stand smelly inconsistent code) but stopped when I learned there were other tickets to correct this.

Rename donation_amount, donation_date in email templates
Rename value of GENERIC_STRIPE_PRODUCT_NAME

#### Why are we doing this? How does it help us?
New / consistent terminology

#### How should this be manually tested?
1. Trigger delievery of receipt email, verify it don't say "donation" no where
2. Trigger delivery of magic link contributions portal, verify it don't say "donation" no where

#### Have automated unit tests been added?
no?

#### How should this change be communicated to end users?
N/A

#### Are there any smells or added technical debt to note?
Nothing added

#### Has this been documented? If so, where?
No

#### What are the relevant tickets?
[DEV-1728]

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
No

#### Are there next steps? If so, what? Have tickets been opened for them?
Yes, febreeze all the smelly code using "donor" [DEV-1446]


[DEV-1728]: https://news-revenue-hub.atlassian.net/browse/DEV-1728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-1446]: https://news-revenue-hub.atlassian.net/browse/DEV-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ