### PR TITLE
DEV-1684 - protect contributions section behind a feature flag Part 1 (API changes)

### DIFF
--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from rest_framework import permissions
 from waffle import get_waffle_flag_model
 
+from apps.common.constants import CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME
 from apps.contributions.models import Contributor
-from apps.flags.constants import CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME
 from apps.users.choices import Roles
 
 from .exceptions import ApiConfigurationError

--- a/apps/common/constants.py
+++ b/apps/common/constants.py
@@ -65,5 +65,6 @@ STATE_CHOICES = [
     ("YT", "Yukon"),
 ]
 
-
+# HasFlaggedAccessToContributionsApiResource references a flag with this name in order
+# to determine access permission.
 CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME = "contributions-api-endpoint-access"

--- a/apps/common/constants.py
+++ b/apps/common/constants.py
@@ -64,3 +64,6 @@ STATE_CHOICES = [
     ("SK", "Saskatchewan"),
     ("YT", "Yukon"),
 ]
+
+
+CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME = "contributions-api-endpoint-access"

--- a/apps/common/tests/test_resources.py
+++ b/apps/common/tests/test_resources.py
@@ -7,9 +7,9 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 from waffle import get_waffle_flag_model
 
+from apps.common.constants import CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME
 from apps.contributions.models import Contributor
 from apps.contributions.tests.factories import ContributionFactory, ContributorFactory
-from apps.flags.constants import CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME
 from apps.organizations.models import Feature, Organization, Plan, RevenueProgram
 from apps.organizations.tests.factories import (
     FeatureFactory,

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -17,12 +17,12 @@ from waffle import get_waffle_flag_model
 
 from apps.api.tests import RevEngineApiAbstractTestCase
 from apps.api.tokens import ContributorRefreshToken
+from apps.common.constants import CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME
 from apps.common.tests.test_resources import AbstractTestCase
 from apps.contributions.models import Contribution, ContributionInterval
 from apps.contributions.payment_managers import PaymentBadParamsError, PaymentProviderError
 from apps.contributions.tests.factories import ContributionFactory, ContributorFactory
 from apps.contributions.views import stripe_payment
-from apps.flags.constants import CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME
 from apps.organizations.models import RevenueProgram
 from apps.organizations.tests.factories import OrganizationFactory
 from apps.pages.models import DonationPage

--- a/apps/flags/apps.py
+++ b/apps/flags/apps.py
@@ -1,6 +1,0 @@
-from django.apps import AppConfig
-
-
-class FlagsConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
-    name = "apps.flags"

--- a/apps/flags/constants.py
+++ b/apps/flags/constants.py
@@ -1,1 +1,0 @@
-CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME = "contributions-api-endpoint-access"

--- a/apps/users/tests/test_serializers.py
+++ b/apps/users/tests/test_serializers.py
@@ -185,11 +185,12 @@ def test_user_serializer_flags(
     data = serializers.UserSerializer(user, context={"request": request}).data
     expected_flag_count = sum([x for x in [expect_flag1, expect_flag2] if x])
     assert len(data["flags"]) == expected_flag_count
+    flags = [(flag["name"], flag["id"]) for flag in data["flags"]]
     if expect_flag1:
-        assert any(flag["name"] == flag1.name and flag["id"] == flag1.id for flag in data["flags"])
+        assert (flag1.name, flag1.id) in flags
     if not expect_flag1:
-        assert not any(flag["name"] == flag1.name and flag["id"] == flag1.id for flag in data["flags"])
+        assert (flag1.name, flag1.id) not in flags
     if expect_flag2:
-        assert any(flag["name"] == flag2.name and flag["id"] == flag2.id for flag in data["flags"])
+        assert (flag2.name, flag2.id) in flags
     if not expect_flag2:
-        assert not any(flag["name"] == flag2.name and flag["id"] == flag2.id for flag in data["flags"])
+        assert (flag2.name, flag2.id) not in flags

--- a/apps/users/tests/test_serializers.py
+++ b/apps/users/tests/test_serializers.py
@@ -183,13 +183,13 @@ def test_user_serializer_flags(
     request = APIRequestFactory().get("/")
     request.user = user
     data = serializers.UserSerializer(user, context={"request": request}).data
-    expected_flag_count = len([x for x in [expect_flag1, expect_flag2] if x])
+    expected_flag_count = sum([x for x in [expect_flag1, expect_flag2] if x])
     assert len(data["flags"]) == expected_flag_count
     if expect_flag1:
-        assert any([flag["name"] == flag1.name and flag["id"] == flag1.id for flag in data["flags"]])
+        assert any(flag["name"] == flag1.name and flag["id"] == flag1.id for flag in data["flags"])
     if not expect_flag1:
-        assert not any([flag["name"] == flag1.name and flag["id"] == flag1.id for flag in data["flags"]])
+        assert not any(flag["name"] == flag1.name and flag["id"] == flag1.id for flag in data["flags"])
     if expect_flag2:
-        assert any([flag["name"] == flag2.name and flag["id"] == flag2.id for flag in data["flags"]])
+        assert any(flag["name"] == flag2.name and flag["id"] == flag2.id for flag in data["flags"])
     if not expect_flag2:
-        assert not any([flag["name"] == flag2.name and flag["id"] == flag2.id for flag in data["flags"]])
+        assert not any(flag["name"] == flag2.name and flag["id"] == flag2.id for flag in data["flags"])

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -38,7 +38,6 @@ INSTALLED_APPS = [
     "apps.element_media",
     "apps.public",
     "apps.config",
-    "apps.flags",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/spa/cypress/.eslintrc
+++ b/spa/cypress/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        "testing-library/prefer-screen-queries": "off",
+        "testing-library/await-async-utils": "off"
+    }
+}

--- a/spa/cypress/fixtures/user/hub-admin.json
+++ b/spa/cypress/fixtures/user/hub-admin.json
@@ -5,7 +5,8 @@
         "email": "hub-admin@fundjournalism.org",
         "role_type": ["hub_admin","Hub Admin"],
         "organizations": [],
-        "revenue_programs": []
+        "revenue_programs": [],
+        "flags": []
     },
     "csrftoken": "ZgynND503GQ3Dkyy3xMBHoExWftlTIjDe5znbDLACDH55g49FYrbFKuOJFBA9W6Y"
 }

--- a/spa/cypress/fixtures/user/org-admin.json
+++ b/spa/cypress/fixtures/user/org-admin.json
@@ -3,6 +3,7 @@
     "user": {
         "id": 1,
         "email": "rp-admin@some-org.com",
+        "flags": [],
         "role_type": [
             "rp_admin",
             "RP Admin"

--- a/spa/cypress/fixtures/user/rp-admin.json
+++ b/spa/cypress/fixtures/user/rp-admin.json
@@ -3,6 +3,7 @@
     "user": {
         "id": 1,
         "email": "rp-admin@some-org.com",
+        "flags": [],
         "role_type": [
             "rp_admin",
             "RP Admin"

--- a/spa/cypress/fixtures/user/stripe-connected.json
+++ b/spa/cypress/fixtures/user/stripe-connected.json
@@ -6,7 +6,8 @@
       "name": "Stripe Connected Org",
       "default_payment_provider": "stripe",
       "stripe_account_id": "stripe_connected_account_id",
-      "stripe_verified": false
+      "stripe_verified": false,
+      "flags": []
     }
   }
 }

--- a/spa/cypress/fixtures/user/stripe-verified.json
+++ b/spa/cypress/fixtures/user/stripe-verified.json
@@ -2,6 +2,7 @@
   "detail": "success",
   "user": {
     "id": 1,
+    "flags": [],
     "organization": {
       "name": "Fully Verified Org",
       "default_payment_provider": "stripe",

--- a/spa/cypress/integration/04 - donations.spec.js
+++ b/spa/cypress/integration/04 - donations.spec.js
@@ -2,6 +2,7 @@ import isEqual from 'lodash.isequal';
 
 import { NO_VALUE } from 'constants/textConstants';
 import { DONATIONS_SLUG } from 'routes';
+import { USER } from 'ajax/endpoints';
 
 // Data
 import donationsData from '../fixtures/donations/18-results.json';
@@ -11,13 +12,46 @@ import { getFrequencyAdjective } from 'utilities/parseFrequency';
 import formatDatetimeForDisplay from 'utilities/formatDatetimeForDisplay';
 import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
 import toTitleCase from 'utilities/toTitleCase';
+import { getEndpoint } from '../support/util';
 
-import hubAdminUser from '../fixtures/user/hub-admin';
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+import hubAdminWithoutFlags from '../fixtures/user/hub-admin';
+
+const contribSectionsFlag = {
+  id: '1234',
+  name: CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME
+};
+
+const hubAdminWithFlags = {
+  ...hubAdminWithoutFlags,
+  flags: [{ ...contribSectionsFlag }]
+};
 
 describe('Donations list', () => {
+  context('User does have contributions section access flag', () => {
+    it('should be accessible', () => {
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
+      cy.interceptPaginatedDonations();
+      cy.visit(DONATIONS_SLUG);
+      cy.getByTestId('donations-table').should('exist');
+    });
+  });
+  context('User does NOT have contributions section access flag', () => {
+    it('should not be accessible', () => {
+      cy.forceLogin(hubAdminWithoutFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithoutFlags });
+      cy.interceptPaginatedDonations();
+      cy.visit(DONATIONS_SLUG);
+      cy.url().should('include', DONATIONS_SLUG);
+      cy.getByTestId('donations-table').should('not.exist');
+    });
+  });
+
   describe('Table', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.interceptPaginatedDonations();
       cy.visit(DONATIONS_SLUG);
     });
@@ -265,7 +299,8 @@ describe('Donations list', () => {
 
   describe('Filtering', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.interceptPaginatedDonations();
       cy.visit(DONATIONS_SLUG);
     });

--- a/spa/cypress/integration/06 - donation-detail.spec.js
+++ b/spa/cypress/integration/06 - donation-detail.spec.js
@@ -3,18 +3,30 @@ import prevFlaggedContributionDetailData from '../fixtures/donations/donation-pr
 import flaggedContributionDetailData from '../fixtures/donations/donation-flagged.json';
 
 import { DONATIONS_SLUG } from 'routes';
-import { CONTRIBUTIONS, PROCESS_FLAGGED } from 'ajax/endpoints';
+import { CONTRIBUTIONS, PROCESS_FLAGGED, USER } from 'ajax/endpoints';
 import { getEndpoint } from '../support/util';
 import { GENERIC_ERROR } from 'constants/textConstants';
 
-import hubAdminUser from '../fixtures/user/hub-admin';
+import hubAdminWithoutFlags from '../fixtures/user/hub-admin';
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+
+const contribSectionsFlag = {
+  id: '1234',
+  name: CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME
+};
+
+const hubAdminWithFlags = {
+  ...hubAdminWithoutFlags,
+  flags: [{ ...contribSectionsFlag }]
+};
 
 const CONTRIBUTION_PK = 123;
 
 describe('Donation detail', () => {
   describe('Unflagged donation', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}/${CONTRIBUTION_PK}/`), {
         body: unflaggedContributionDetailData
       }).as('getUnflaggedDonation');
@@ -39,7 +51,8 @@ describe('Donation detail', () => {
   });
   describe('Previously but no-longer-flagged donation', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}/${CONTRIBUTION_PK}/`), {
         body: prevFlaggedContributionDetailData
       }).as('getNoLongerFlaggedDonation');
@@ -69,7 +82,8 @@ describe('Donation detail', () => {
 
   describe('Flagged donation', () => {
     before(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${CONTRIBUTION_PK}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');
@@ -97,7 +111,8 @@ describe('Donation detail', () => {
       // There's a frustrating issue with cypress and the way we're utilizing React.createPortal for the confirmation modal.
       // For whatever reason, cypress returns to the login screen here.
       const contributionId = flaggedContributionDetailData.id;
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${contributionId}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');
@@ -129,7 +144,8 @@ describe('Donation detail', () => {
       // There's a frustrating issue with cypress and the way we're utilizing React.createPortal for the confirmation modal.
       // For whatever reason, cypress returns to the login screen here.
       const contributionId = flaggedContributionDetailData.id;
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${contributionId}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');
@@ -148,7 +164,8 @@ describe('Donation detail', () => {
       // There's a frustrating issue with cypress and the way we're utilizing React.createPortal for the confirmation modal.
       // For whatever reason, cypress returns to the login screen here.
       const contributionId = flaggedContributionDetailData.id;
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${contributionId}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');

--- a/spa/cypress/integration/11 - dashboard.spec.js
+++ b/spa/cypress/integration/11 - dashboard.spec.js
@@ -1,0 +1,40 @@
+import { getEndpoint } from '../support/util';
+import { LIST_STYLES, LIST_PAGES, USER } from 'ajax/endpoints';
+import { DASHBOARD_SLUG } from 'routes';
+
+import hubAdminWithoutFlags from '../fixtures/user/hub-admin';
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+
+const contribSectionsFlag = {
+  id: '1234',
+  name: CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME
+};
+
+const hubAdminWithFlags = {
+  ...hubAdminWithoutFlags,
+  flags: [{ ...contribSectionsFlag }]
+};
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    cy.forceLogin(hubAdminWithFlags);
+    cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_PAGES) }, { fixture: 'pages/list-pages-1' });
+    cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_STYLES) }, { fixture: 'styles/list-styles-1' });
+  });
+  context('User does NOT have contributions section access flag', () => {
+    it('should only show `Content` section/related nav elements and not `Contributions`', () => {
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithoutFlags });
+      cy.visit(DASHBOARD_SLUG);
+      cy.getByTestId('nav-content-item').should('exist');
+      cy.getByTestId('nav-contributions-item').should('not.exist');
+    });
+  });
+  context('User DOES have contributions section access flag', () => {
+    it('should show `Content` and `Contributions` sections/related nav elements', () => {
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
+      cy.visit(DASHBOARD_SLUG);
+      cy.getByTestId('nav-content-item').should('exist');
+      cy.getByTestId('nav-contributions-item').should('exist');
+    });
+  });
+});

--- a/spa/src/components/dashboard/Dashboard.js
+++ b/spa/src/components/dashboard/Dashboard.js
@@ -15,7 +15,16 @@ import Content from 'components/content/Content';
 import GlobalLoading from 'elements/GlobalLoading';
 import ProviderConnect from 'components/connect/ProviderConnect';
 
+// Feature flag-related
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+import flagIsActiveForUser from 'utilities/flagIsActiveForUser';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+
 function Dashboard() {
+  const userFlags = useFeatureFlags();
+  const hasContributionsSectionAccess =
+    userFlags && userFlags.length && flagIsActiveForUser(CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME, userFlags);
+
   const { checkingProvider, paymentProviderConnectState } = usePaymentProviderContext();
 
   const getShouldAllowDashboard = () => {
@@ -38,9 +47,11 @@ function Dashboard() {
         <S.DashboardContent>
           {getShouldAllowDashboard() && (
             <Switch>
-              <Route path={DONATIONS_SLUG}>
-                <Donations />
-              </Route>
+              {hasContributionsSectionAccess && (
+                <Route path={DONATIONS_SLUG}>
+                  <Donations />
+                </Route>
+              )}
               <Route path={CONTENT_SLUG}>
                 <Content />
               </Route>

--- a/spa/src/components/dashboard/sidebar/DashboardSidebar.js
+++ b/spa/src/components/dashboard/sidebar/DashboardSidebar.js
@@ -2,10 +2,16 @@ import * as S from './DashboardSidebar.styled';
 import { DONATIONS_SLUG, CONTENT_SLUG } from 'routes';
 import { ICONS } from 'assets/icons/SvgIcon';
 
-// Util
 import logout from 'components/authentication/logout';
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+import flagIsActiveForUser from 'utilities/flagIsActiveForUser';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 function DashboardSidebar({ shouldAllowDashboard }) {
+  const userFlags = useFeatureFlags();
+  const hasContributionsSectionAccess =
+    userFlags && userFlags.length && flagIsActiveForUser(CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME, userFlags);
+
   const handleClick = (e) => {
     if (!shouldAllowDashboard) e.preventDefault();
   };
@@ -13,12 +19,24 @@ function DashboardSidebar({ shouldAllowDashboard }) {
   return (
     <S.DashboardSidebar>
       <S.NavList>
-        <S.NavItem to={CONTENT_SLUG} onClick={handleClick} disabled={!shouldAllowDashboard}>
+        <S.NavItem
+          data-testid="nav-content-item"
+          to={CONTENT_SLUG}
+          onClick={handleClick}
+          disabled={!shouldAllowDashboard}
+        >
           Content
         </S.NavItem>
-        <S.NavItem to={DONATIONS_SLUG} onClick={handleClick} disabled={!shouldAllowDashboard}>
-          Contributions
-        </S.NavItem>
+        {hasContributionsSectionAccess ? (
+          <S.NavItem
+            data-testid="nav-contributions-item"
+            to={DONATIONS_SLUG}
+            onClick={handleClick}
+            disabled={!shouldAllowDashboard}
+          >
+            Contributions
+          </S.NavItem>
+        ) : null}
       </S.NavList>
       <S.OtherContent>
         <S.Logout onClick={logout} whileHover={{ scale: 1.05, x: -3 }} whileTap={{ scale: 1, x: 0 }}>

--- a/spa/src/constants/featureFlagConstants.js
+++ b/spa/src/constants/featureFlagConstants.js
@@ -1,0 +1,1 @@
+export const CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME = 'spa-contributions-section-access';

--- a/spa/src/hooks/useFeatureFlags.js
+++ b/spa/src/hooks/useFeatureFlags.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import { USER } from 'ajax/endpoints';
+import useRequest from 'hooks/useRequest';
+
+function useFeatureFlags() {
+  const [flags, setFlags] = useState([]);
+  const requestUser = useRequest();
+  useEffect(() => {
+    requestUser(
+      {
+        method: 'GET',
+        url: USER
+      },
+      {
+        onSuccess: ({ data }) => setFlags(data.flags),
+        onFailure: (e) => {
+          throw new Error('Something unexpected happened in `useFeatureFlags`');
+        }
+      }
+    );
+  }, [requestUser]);
+
+  return flags;
+}
+
+export default useFeatureFlags;

--- a/spa/src/hooks/useRequest.js
+++ b/spa/src/hooks/useRequest.js
@@ -1,23 +1,26 @@
-// import { useCallback } from 'react';
 import axios, { AuthenticationError } from 'ajax/axios';
+import { useCallback } from 'react';
+
 import { useGlobalContext } from 'components/MainLayout';
 
 function useRequest() {
   const { getReauth } = useGlobalContext();
-  const makeRequest = (config, callbacks) => {
-    const { onSuccess, onFailure } = callbacks;
-    axios.request(config).then(onSuccess, (e) => {
-      if (e instanceof AuthenticationError) {
-        // If this custom error type is raised, we know a
-        // 401 has been returned and we should offer reauth.
-        getReauth(() => makeRequest(config, callbacks));
-      } else {
-        onFailure(e);
-      }
-    });
-  };
-
-  return (...args) => makeRequest(...args);
+  const makeRequest = useCallback(
+    (config, callbacks) => {
+      const { onSuccess, onFailure } = callbacks;
+      axios.request(config).then(onSuccess, (e) => {
+        if (e instanceof AuthenticationError) {
+          // If this custom error type is raised, we know a
+          // 401 has been returned and we should offer reauth.
+          getReauth(() => makeRequest(config, callbacks));
+        } else {
+          onFailure(e);
+        }
+      });
+    },
+    [getReauth]
+  );
+  return makeRequest;
 }
 
 export default useRequest;

--- a/spa/src/utilities/flagIsActiveForUser.js
+++ b/spa/src/utilities/flagIsActiveForUser.js
@@ -1,0 +1,7 @@
+function flagIsActiveForUser(flagName, userFlags) {
+  return userFlags.some((flag) => {
+    return flag.name === flagName;
+  });
+}
+
+export default flagIsActiveForUser;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

In working on [DEV-1684], I've decided to break up the work into two separate PRs, an initial one (this one) that is limited to the backend changes required to add active flags to a `.flags` property on serialized users.  In a separate PR, I'll tackle the SPA changes that rely on this data.  This will allow a smaller diff initially that I can pass to Norm for backend review, and then for part 2, can have a dev with React expertise review.

NB: The base for this PR is [DEV-1021] since this branches from that branch, which itself is in an unmerged PR. Once that has been merged, I will change the base for this PR to main. Until then, this approach will allow a review that focuses on narrow changes of this PR, rather than broader set of changes vis-a-vis main that would be in diff from unmerged DEV-1021.

#### What's this PR do?

- Gets rid of the flags app entirely, as I opted to serialize flag data in users (@njharman you were right about not needing those app files 😉 ).
- Moves `CONTRIBUTIONS_API_ENDPOINT_ACCESS_FLAG_NAME` to `apps.common.constants`.
- Adds a `flags` property to the user serializer and a related `get_active_flags_for_user` serializer method. This method retrieves all flags that are active for a user (taking into account whether or not the user is a superuser).
- Adds `apps.users.tests.test_serializers.test_user_serializer_flags` demonstrating expected behavior.

#### Why are we doing this? How does it help us?

First of two PRs to ship [DEV-1684], the business value of which is articulated in JIRA.


#### How should this be manually tested?

1. Create a flag. In Django admin, set "everyone" to "Yes". Save.
2. Log in as the user (either through Django admin or through SPA).
3. In a browser tab, go to `/ap1/v1/users/`. You should see a `flags` property on the returned user object, and it should be a length-1 list whose only item is a dict whose values for id and name are same as the flag you created.
4. Go through above flow, but try different combinations of flag settings and logged in users (for instance, set `everyone` to False, and `superusers` to True on the flag, and then log in as a super user and a non superuser -- only the superuser should have flags).

#### Have automated unit tests been added?

Yes

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### Has this been documented? If so, where?

#### What are the relevant tickets?
**(Note: Please use syntax [JIRA-123] to link any relevant tickets)**

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

#### Are there next steps? If so, what? Have tickets been opened for them?


[DEV-1684]: https://news-revenue-hub.atlassian.net/browse/DEV-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEV-1021]: https://news-revenue-hub.atlassian.net/browse/DEV-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ