### PR TITLE
DEV-1684 - protect contributions section behind a feature flag  Part 2 (SPA changes)

### DIFF
--- a/spa/cypress/.eslintrc
+++ b/spa/cypress/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        "testing-library/prefer-screen-queries": "off",
+        "testing-library/await-async-utils": "off"
+    }
+}

--- a/spa/cypress/fixtures/user/hub-admin.json
+++ b/spa/cypress/fixtures/user/hub-admin.json
@@ -5,7 +5,8 @@
         "email": "hub-admin@fundjournalism.org",
         "role_type": ["hub_admin","Hub Admin"],
         "organizations": [],
-        "revenue_programs": []
+        "revenue_programs": [],
+        "flags": []
     },
     "csrftoken": "ZgynND503GQ3Dkyy3xMBHoExWftlTIjDe5znbDLACDH55g49FYrbFKuOJFBA9W6Y"
 }

--- a/spa/cypress/fixtures/user/org-admin.json
+++ b/spa/cypress/fixtures/user/org-admin.json
@@ -3,6 +3,7 @@
     "user": {
         "id": 1,
         "email": "rp-admin@some-org.com",
+        "flags": [],
         "role_type": [
             "rp_admin",
             "RP Admin"

--- a/spa/cypress/fixtures/user/rp-admin.json
+++ b/spa/cypress/fixtures/user/rp-admin.json
@@ -3,6 +3,7 @@
     "user": {
         "id": 1,
         "email": "rp-admin@some-org.com",
+        "flags": [],
         "role_type": [
             "rp_admin",
             "RP Admin"

--- a/spa/cypress/fixtures/user/stripe-connected.json
+++ b/spa/cypress/fixtures/user/stripe-connected.json
@@ -6,7 +6,8 @@
       "name": "Stripe Connected Org",
       "default_payment_provider": "stripe",
       "stripe_account_id": "stripe_connected_account_id",
-      "stripe_verified": false
+      "stripe_verified": false,
+      "flags": []
     }
   }
 }

--- a/spa/cypress/fixtures/user/stripe-verified.json
+++ b/spa/cypress/fixtures/user/stripe-verified.json
@@ -2,6 +2,7 @@
   "detail": "success",
   "user": {
     "id": 1,
+    "flags": [],
     "organization": {
       "name": "Fully Verified Org",
       "default_payment_provider": "stripe",

--- a/spa/cypress/integration/04 - donations.spec.js
+++ b/spa/cypress/integration/04 - donations.spec.js
@@ -12,12 +12,13 @@ import formatDatetimeForDisplay from 'utilities/formatDatetimeForDisplay';
 import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
 import toTitleCase from 'utilities/toTitleCase';
 
-import hubAdminUser from '../fixtures/user/hub-admin';
+import hubAdminWithoutFlags from '../fixtures/user/hub-admin';
+const hubAdminWithFeatureFlags = { ...hubAdminWithFeatureFlags, user: { ...hubAdminWithFeatureFlags.user, flags: [] } };
 
 describe('Donations list', () => {
   describe('Table', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFeatureFlags);
       cy.interceptPaginatedDonations();
       cy.visit(DONATIONS_SLUG);
     });
@@ -265,7 +266,7 @@ describe('Donations list', () => {
 
   describe('Filtering', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFeatureFlags);
       cy.interceptPaginatedDonations();
       cy.visit(DONATIONS_SLUG);
     });

--- a/spa/cypress/integration/04 - donations.spec.js
+++ b/spa/cypress/integration/04 - donations.spec.js
@@ -43,6 +43,7 @@ describe('Donations list', () => {
       cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithoutFlags });
       cy.interceptPaginatedDonations();
       cy.visit(DONATIONS_SLUG);
+      cy.url().should('include', DONATIONS_SLUG);
       cy.getByTestId('donations-table').should('not.exist');
     });
   });

--- a/spa/cypress/integration/06 - donation-detail.spec.js
+++ b/spa/cypress/integration/06 - donation-detail.spec.js
@@ -3,18 +3,30 @@ import prevFlaggedContributionDetailData from '../fixtures/donations/donation-pr
 import flaggedContributionDetailData from '../fixtures/donations/donation-flagged.json';
 
 import { DONATIONS_SLUG } from 'routes';
-import { CONTRIBUTIONS, PROCESS_FLAGGED } from 'ajax/endpoints';
+import { CONTRIBUTIONS, PROCESS_FLAGGED, USER } from 'ajax/endpoints';
 import { getEndpoint } from '../support/util';
 import { GENERIC_ERROR } from 'constants/textConstants';
 
-import hubAdminUser from '../fixtures/user/hub-admin';
+import hubAdminWithoutFlags from '../fixtures/user/hub-admin';
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+
+const contribSectionsFlag = {
+  id: '1234',
+  name: CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME
+};
+
+const hubAdminWithFlags = {
+  ...hubAdminWithoutFlags,
+  flags: [{ ...contribSectionsFlag }]
+};
 
 const CONTRIBUTION_PK = 123;
 
 describe('Donation detail', () => {
   describe('Unflagged donation', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}/${CONTRIBUTION_PK}/`), {
         body: unflaggedContributionDetailData
       }).as('getUnflaggedDonation');
@@ -39,7 +51,8 @@ describe('Donation detail', () => {
   });
   describe('Previously but no-longer-flagged donation', () => {
     beforeEach(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}/${CONTRIBUTION_PK}/`), {
         body: prevFlaggedContributionDetailData
       }).as('getNoLongerFlaggedDonation');
@@ -69,7 +82,8 @@ describe('Donation detail', () => {
 
   describe('Flagged donation', () => {
     before(() => {
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${CONTRIBUTION_PK}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');
@@ -97,7 +111,8 @@ describe('Donation detail', () => {
       // There's a frustrating issue with cypress and the way we're utilizing React.createPortal for the confirmation modal.
       // For whatever reason, cypress returns to the login screen here.
       const contributionId = flaggedContributionDetailData.id;
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${contributionId}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');
@@ -129,7 +144,8 @@ describe('Donation detail', () => {
       // There's a frustrating issue with cypress and the way we're utilizing React.createPortal for the confirmation modal.
       // For whatever reason, cypress returns to the login screen here.
       const contributionId = flaggedContributionDetailData.id;
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${contributionId}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');
@@ -148,7 +164,8 @@ describe('Donation detail', () => {
       // There's a frustrating issue with cypress and the way we're utilizing React.createPortal for the confirmation modal.
       // For whatever reason, cypress returns to the login screen here.
       const contributionId = flaggedContributionDetailData.id;
-      cy.forceLogin(hubAdminUser);
+      cy.forceLogin(hubAdminWithFlags);
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
       cy.intercept('GET', getEndpoint(`${CONTRIBUTIONS}${contributionId}/`), {
         body: flaggedContributionDetailData
       }).as('getFlaggedDonation');

--- a/spa/cypress/integration/11 - dashboard.spec.js
+++ b/spa/cypress/integration/11 - dashboard.spec.js
@@ -1,0 +1,40 @@
+import { getEndpoint } from '../support/util';
+import { LIST_STYLES, LIST_PAGES, USER } from 'ajax/endpoints';
+import { DASHBOARD_SLUG } from 'routes';
+
+import hubAdminWithoutFlags from '../fixtures/user/hub-admin';
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+
+const contribSectionsFlag = {
+  id: '1234',
+  name: CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME
+};
+
+const hubAdminWithFlags = {
+  ...hubAdminWithoutFlags,
+  flags: [{ ...contribSectionsFlag }]
+};
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    cy.forceLogin(hubAdminWithFlags);
+    cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_PAGES) }, { fixture: 'pages/list-pages-1' });
+    cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_STYLES) }, { fixture: 'styles/list-styles-1' });
+  });
+  context('User does NOT have contributions section access flag', () => {
+    it('should only show `Content` section/related nav elements and not `Contributions`', () => {
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithoutFlags });
+      cy.visit(DASHBOARD_SLUG);
+      cy.getByTestId('nav-content-item').should('exist');
+      cy.getByTestId('nav-contributions-item').should('not.exist');
+    });
+  });
+  context('User DOES have contributions section access flag', () => {
+    it('should show `Content` and `Contributions` sections/related nav elements', () => {
+      cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: hubAdminWithFlags });
+      cy.visit(DASHBOARD_SLUG);
+      cy.getByTestId('nav-content-item').should('exist');
+      cy.getByTestId('nav-contributions-item').should('exist');
+    });
+  });
+});

--- a/spa/src/components/dashboard/Dashboard.js
+++ b/spa/src/components/dashboard/Dashboard.js
@@ -15,7 +15,16 @@ import Content from 'components/content/Content';
 import GlobalLoading from 'elements/GlobalLoading';
 import ProviderConnect from 'components/connect/ProviderConnect';
 
+// Feature flag-related
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+import flagIsActiveForUser from 'utilities/flagIsActiveForUser';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+
 function Dashboard() {
+  const userFlags = useFeatureFlags();
+  const hasContributionsSectionAccess =
+    userFlags && userFlags.length && flagIsActiveForUser(CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME, userFlags);
+
   const { checkingProvider, paymentProviderConnectState } = usePaymentProviderContext();
 
   const getShouldAllowDashboard = () => {
@@ -38,9 +47,11 @@ function Dashboard() {
         <S.DashboardContent>
           {getShouldAllowDashboard() && (
             <Switch>
-              <Route path={DONATIONS_SLUG}>
-                <Donations />
-              </Route>
+              {hasContributionsSectionAccess && (
+                <Route path={DONATIONS_SLUG}>
+                  <Donations />
+                </Route>
+              )}
               <Route path={CONTENT_SLUG}>
                 <Content />
               </Route>

--- a/spa/src/components/dashboard/sidebar/DashboardSidebar.js
+++ b/spa/src/components/dashboard/sidebar/DashboardSidebar.js
@@ -2,10 +2,16 @@ import * as S from './DashboardSidebar.styled';
 import { DONATIONS_SLUG, CONTENT_SLUG } from 'routes';
 import { ICONS } from 'assets/icons/SvgIcon';
 
-// Util
 import logout from 'components/authentication/logout';
+import { CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+import flagIsActiveForUser from 'utilities/flagIsActiveForUser';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 function DashboardSidebar({ shouldAllowDashboard }) {
+  const userFlags = useFeatureFlags();
+  const hasContributionsSectionAccess =
+    userFlags && userFlags.length && flagIsActiveForUser(CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME, userFlags);
+
   const handleClick = (e) => {
     if (!shouldAllowDashboard) e.preventDefault();
   };
@@ -16,9 +22,11 @@ function DashboardSidebar({ shouldAllowDashboard }) {
         <S.NavItem to={CONTENT_SLUG} onClick={handleClick} disabled={!shouldAllowDashboard}>
           Content
         </S.NavItem>
-        <S.NavItem to={DONATIONS_SLUG} onClick={handleClick} disabled={!shouldAllowDashboard}>
-          Contributions
-        </S.NavItem>
+        {hasContributionsSectionAccess && (
+          <S.NavItem to={DONATIONS_SLUG} onClick={handleClick} disabled={!shouldAllowDashboard}>
+            Contributions
+          </S.NavItem>
+        )}
       </S.NavList>
       <S.OtherContent>
         <S.Logout onClick={logout} whileHover={{ scale: 1.05, x: -3 }} whileTap={{ scale: 1, x: 0 }}>

--- a/spa/src/components/dashboard/sidebar/DashboardSidebar.js
+++ b/spa/src/components/dashboard/sidebar/DashboardSidebar.js
@@ -19,14 +19,24 @@ function DashboardSidebar({ shouldAllowDashboard }) {
   return (
     <S.DashboardSidebar>
       <S.NavList>
-        <S.NavItem to={CONTENT_SLUG} onClick={handleClick} disabled={!shouldAllowDashboard}>
+        <S.NavItem
+          data-testid="nav-content-item"
+          to={CONTENT_SLUG}
+          onClick={handleClick}
+          disabled={!shouldAllowDashboard}
+        >
           Content
         </S.NavItem>
-        {hasContributionsSectionAccess && (
-          <S.NavItem to={DONATIONS_SLUG} onClick={handleClick} disabled={!shouldAllowDashboard}>
+        {hasContributionsSectionAccess ? (
+          <S.NavItem
+            data-testid="nav-contributions-item"
+            to={DONATIONS_SLUG}
+            onClick={handleClick}
+            disabled={!shouldAllowDashboard}
+          >
             Contributions
           </S.NavItem>
-        )}
+        ) : null}
       </S.NavList>
       <S.OtherContent>
         <S.Logout onClick={logout} whileHover={{ scale: 1.05, x: -3 }} whileTap={{ scale: 1, x: 0 }}>

--- a/spa/src/constants/featureFlagConstants.js
+++ b/spa/src/constants/featureFlagConstants.js
@@ -1,0 +1,1 @@
+export const CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME = 'spa-contributions-section-access';

--- a/spa/src/hooks/useFeatureFlags.js
+++ b/spa/src/hooks/useFeatureFlags.js
@@ -15,8 +15,7 @@ function useFeatureFlags() {
       {
         onSuccess: ({ data }) => setFlags(data.flags),
         onFailure: (e) => {
-          // need to do something better here.
-          console.error(e);
+          throw new Error('Something unexpected happened in `useFeatureFlags`');
         }
       }
     );

--- a/spa/src/hooks/useFeatureFlags.js
+++ b/spa/src/hooks/useFeatureFlags.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+import { USER } from 'ajax/endpoints';
+import useRequest from 'hooks/useRequest';
+
+function useFeatureFlags() {
+  const [flags, setFlags] = useState([]);
+  const requestUser = useRequest();
+  useEffect(() => {
+    requestUser(
+      {
+        method: 'GET',
+        url: USER
+      },
+      {
+        onSuccess: ({ data }) => setFlags(data.flags),
+        onFailure: (e) => {
+          // need to do something better here.
+          console.error(e);
+        }
+      }
+    );
+  }, []);
+
+  return flags;
+}
+
+export default useFeatureFlags;

--- a/spa/src/hooks/useFeatureFlags.js
+++ b/spa/src/hooks/useFeatureFlags.js
@@ -20,7 +20,7 @@ function useFeatureFlags() {
         }
       }
     );
-  }, []);
+  }, [requestUser]);
 
   return flags;
 }

--- a/spa/src/hooks/useRequest.js
+++ b/spa/src/hooks/useRequest.js
@@ -1,23 +1,26 @@
-// import { useCallback } from 'react';
 import axios, { AuthenticationError } from 'ajax/axios';
+import { useCallback } from 'react';
+
 import { useGlobalContext } from 'components/MainLayout';
 
 function useRequest() {
   const { getReauth } = useGlobalContext();
-  const makeRequest = (config, callbacks) => {
-    const { onSuccess, onFailure } = callbacks;
-    axios.request(config).then(onSuccess, (e) => {
-      if (e instanceof AuthenticationError) {
-        // If this custom error type is raised, we know a
-        // 401 has been returned and we should offer reauth.
-        getReauth(() => makeRequest(config, callbacks));
-      } else {
-        onFailure(e);
-      }
-    });
-  };
-
-  return (...args) => makeRequest(...args);
+  const makeRequest = useCallback(
+    (config, callbacks) => {
+      const { onSuccess, onFailure } = callbacks;
+      axios.request(config).then(onSuccess, (e) => {
+        if (e instanceof AuthenticationError) {
+          // If this custom error type is raised, we know a
+          // 401 has been returned and we should offer reauth.
+          getReauth(() => makeRequest(config, callbacks));
+        } else {
+          onFailure(e);
+        }
+      });
+    },
+    [getReauth]
+  );
+  return makeRequest;
 }
 
 export default useRequest;

--- a/spa/src/utilities/flagIsActiveForUser.js
+++ b/spa/src/utilities/flagIsActiveForUser.js
@@ -1,0 +1,7 @@
+function flagIsActiveForUser(flagName, userFlags) {
+  return userFlags.some((flag) => {
+    return flag.name === flagName;
+  });
+}
+
+export default flagIsActiveForUser;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

This PR is step 2 of 2 in a sequence of PRs meant to together ship DEV-1684. The feature branch branches from the branch for the step 1 PR, which also serves as base (for rationale and additional details on the plan, [see the notes in this PR](https://github.com/newsrevenuehub/rev-engine/pull/427)).

#### What's this PR do?

Narrowly, it supports hiding/showing contributions section (and related sidebar entry) based on a user's flags. More broadly, it creates a generalized approach that we'll use for future  SPA-side feature flagging.

- Adds a new `useFeatureFlags` and a related utility function called `flagIsActiveForUser` that together can be used to determine if a flag with a given name is active for a user, which in turn can be used to conditionally display components.
- Makes displaying "Contributions" in sidebar and main page contingent on a flag with the name defined at `spa.src.constants.featureFlagConstants.CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME` appearing in `user.flags` (where the user data is returned by the `/api/v1/users/` endpoint).
- Updates existing Cypress tests that broke with introduction of contributions section flag.
- Adds `spac.cypress.integration.11 - dashboard.spec.js` which has a thin test of /dashboard, confirming that the side bar behaves as expected given flags.
- Adds testing around flag-based gating of contributions section
- Fixes a bug in `spa.src.hooks.useRequest` that caused an infinite loop when the result of calling that hook was  provided as a dependency for another hook.



#### Why are we doing this? How does it help us?

Documented elsewhere.


#### How should this be manually tested?

- Log in to the Django admin
- If you haven't created the feature flag required to get access to the contributions API endpoint (as described i[n DEV-1684 PR notes](https://github.com/newsrevenuehub/rev-engine/pull/427)), do that.
- Create a flag whose name is the value defined in spa.src.constants.featureFlagConstants.CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME.  You can choose which settings (everyone or for a specific user).
- In a separate, incognito browser tab, log in to the SPA as a user for whom you have granted the two flags described above. You should see the contributions section and a link to it in the sidebar.
- Back in Django admin, update the `spa-contributions-section-access` flag so that it no longer applies to the user you logged in to the SPA with.
- Refresh the SPA. This time, you should not be able to see any reference to contributions. 

#### Have automated unit tests been added?

Yes.

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### Has this been documented? If so, where?

#### What are the relevant tickets?
**(Note: Please use syntax [JIRA-123] to link any relevant tickets)**

[DEV-1684]

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No, but after this is merged, it will be necessary to create a feature flag in the Django admin with the name defined in `spa.src.constants.featureFlagConstants.CONTRIBUTIONS_SECTION_ACCESS_FLAG_NAME`, and then grant access as required.

#### Are there next steps? If so, what? Have tickets been opened for them?

