### PR TITLE
DEV-956: Restrict style dropdown in page editor based on active parent element

### DIFF
--- a/apps/pages/filters.py
+++ b/apps/pages/filters.py
@@ -1,0 +1,11 @@
+import django_filters
+
+from apps.pages.models import Style
+
+
+class StyleFilter(django_filters.FilterSet):
+    revenue_program = django_filters.NumberFilter(field_name="revenue_program__id")
+
+    class Meta:
+        model = Style
+        fields = ["revenue_program"]

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 
+import django_filters
 from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -10,6 +11,7 @@ from rest_framework.response import Response
 from apps.api.permissions import HasRoleAssignment
 from apps.element_media.models import MediaImage
 from apps.pages import serializers
+from apps.pages.filters import StyleFilter
 from apps.pages.helpers import PageDetailError, PageFullDetailHelper
 from apps.pages.models import DonationPage, Font, Style, Template
 from apps.public.permissions import IsActiveSuperUser
@@ -139,6 +141,8 @@ class StyleViewSet(viewsets.ModelViewSet, FilterQuerySetByUserMixin, PerUserCrea
     serializer_class = serializers.StyleListSerializer
     pagination_class = None
     permission_classes = [IsAuthenticated, IsActiveSuperUser | HasRoleAssignment]
+    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
+    filterset_class = StyleFilter
 
     def get_queryset(self):
         return self.filter_queryset_for_user(self.request.user, self.model.objects.all())

--- a/spa/cypress/fixtures/styles/list-styles-1.json
+++ b/spa/cypress/fixtures/styles/list-styles-1.json
@@ -3,39 +3,45 @@
     "id": 1,
     "name": "My Test Styles 01",
     "used_live": true,
-    "colors": {
-      "primary": "pink",
-      "secondary": "blue",
-      "fieldBackground": "yellow",
-      "paneBackground": "green"
-    },
-    "font": "Monospace",
-    "fontSizes": []
+    "styles":{
+        "colors": {
+          "primary": "pink",
+          "secondary": "blue",
+          "fieldBackground": "yellow",
+          "paneBackground": "green"
+        },
+        "font": "Monospace",
+        "fontSizes": []
+  }
   },
   {
     "id": 2,
     "name": "My Test Styles 02",
     "used_live": false,
-    "colors": {
-      "primary": "purple",
-      "secondary": "orange",
-      "fieldBackground": "brown",
-      "paneBackground": "grey"
-    },
-    "font": "Monospace",
-    "fontSizes": []
+    "styles":{
+        "colors": {
+          "primary": "purple",
+          "secondary": "orange",
+          "fieldBackground": "brown",
+          "paneBackground": "grey"
+        },
+        "font": "Monospace",
+        "fontSizes": []
+        }
   },
   {
     "id": 3,
     "name": "My Test Styles 03",
     "used_live": false,
-    "colors": {
-      "primary": "papayawhip",
-      "secondary": "blanchedalmond",
-      "fieldBackground": "gainsboro",
-      "paneBackground": "thistle"
-    },
-    "font": "Monospace",
-    "fontSizes": []
+    "styles":{
+        "colors": {
+          "primary": "papayawhip",
+          "secondary": "blanchedalmond",
+          "fieldBackground": "gainsboro",
+          "paneBackground": "thistle"
+        },
+        "font": "Monospace",
+        "fontSizes": []
+      }
   }
 ]

--- a/spa/src/components/content/Content.js
+++ b/spa/src/components/content/Content.js
@@ -33,7 +33,13 @@ function Content() {
     requestGetStyles(
       { method: 'GET', url: LIST_STYLES },
       {
-        onSuccess: ({ data }) => setStyles(data),
+        onSuccess: ({ data }) => {
+          setStyles(
+            data.map(({ styles, id, revenue_program, name, used_live }) => {
+              return { ...styles, id, revenue_program, name, used_live };
+            })
+          );
+        },
         onFailure: () => alert.error(GENERIC_ERROR)
       }
     );

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -142,6 +142,7 @@ function PageEditor() {
 
   useEffect(() => {
     const rpId = page?.revenue_program?.id;
+
     if (rpId) {
       setLoading(true);
       requestGetPageStyles(
@@ -157,7 +158,7 @@ function PageEditor() {
         }
       );
     }
-  }, []);
+  }, [page]);
 
   const handlePreview = () => {
     setSelectedButton(PREVIEW);

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -141,20 +141,22 @@ function PageEditor() {
   }, [pageId, parameters.revProgramSlug, parameters.pageSlug, handleGetPageFailure]);
 
   useEffect(() => {
-    setLoading(true);
-    requestGetPageStyles(
-      { method: 'GET', url: LIST_STYLES },
-      {
-        onSuccess: ({ data }) => {
-          setAvailableStyles(data);
-          setLoading(false);
-        },
-        onFailure: () => {
-          setLoading(false);
+    const rpId = page?.revenue_program?.id;
+    if (rpId) {
+      setLoading(true);
+      requestGetPageStyles(
+        { method: 'GET', url: LIST_STYLES, params: { revenue_program: rpId } },
+        {
+          onSuccess: ({ data }) => {
+            setAvailableStyles(data);
+            setLoading(false);
+          },
+          onFailure: () => {
+            setLoading(false);
+          }
         }
-      }
-    );
-    // Don't include requestGetPageStyles for now.
+      );
+    }
   }, []);
 
   const handlePreview = () => {

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -158,6 +158,7 @@ function PageEditor() {
         }
       );
     }
+    // Don't include requestGetPageStyles for now.
   }, [page]);
 
   const handlePreview = () => {

--- a/spa/src/components/stylesEditor/StylesEditor.js
+++ b/spa/src/components/stylesEditor/StylesEditor.js
@@ -116,7 +116,7 @@ function StylesEditor({ styles, setStyles, handleKeepChanges, handleDiscardChang
   const handleCreateStyles = () => {
     setLoading(true);
     requestCreateStyles(
-      { method: 'POST', url: LIST_STYLES, data: styles },
+      { method: 'POST', url: LIST_STYLES, data: { ...styles, revenue_program: styles.revenue_program.id } },
       {
         onSuccess: handleRequestSuccess,
         onFailure: handleRequestError
@@ -184,8 +184,13 @@ function StylesEditor({ styles, setStyles, handleKeepChanges, handleDiscardChang
           <Select
             label="Select a revenue program"
             items={availableRevenuePrograms}
-            selectedItem={styles.revenue_program}
-            onSelectedItemChange={({ selectedItem }) => setStyles({ ...styles, revenue_program: selectedItem.id })}
+            // if no selected item, need to default to object with empty string for name
+            // otherwise initial value will be undefined, and when updated,
+            // will cause a warning re: changing from uncontrolled to controlled.
+            selectedItem={styles.revenue_program || { id: null, name: '' }}
+            onSelectedItemChange={({ selectedItem }) => {
+              setStyles({ ...styles, revenue_program: selectedItem });
+            }}
             testId="heading-font-select"
             name="revenue_program"
             placeholder="Select a revenue program"


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR filters styles available in the dropdown in the page editor. It does this by including a query parameter for the current RP when making a request to retrieve styles from the server.

This required adding a filter to the styles API resource so that can be filtered by revenue program ID.

#### Why are we doing this? How does it help us?

Makes the page editor easier to use for  users who have access to many styles.

#### How should this be manually tested?

Log in to the SPA as, say, an RP admin user for an org that has many styles. Either create or edit an existing page, and in the page editor, go to the styles tab. The dropdown should only include styles for the RP of the page.

#### Have automated unit tests been added?

No.

#### How should this change be communicated to end users?


#### Are there any smells or added technical debt to note?

#### Has this been documented? If so, where?

#### What are the relevant tickets?
**(Note: Please use syntax [JIRA-123] to link any relevant tickets)**

[DEV-956]

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them?

No