### PR TITLE
DEV-1089 Adjust migration script

### DIFF
--- a/apps/organizations/migrations/0052_map_benefits_and_levels_to_rp_not_org.py
+++ b/apps/organizations/migrations/0052_map_benefits_and_levels_to_rp_not_org.py
@@ -41,7 +41,7 @@ def update_data(apps, *args):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("organizations", "0052_associate_stripe_with_rp"),
+        ("organizations", "0051_historicalorganization_slug"),
     ]
 
     operations = [

--- a/apps/organizations/migrations/0053_associate_stripe_with_rp.py
+++ b/apps/organizations/migrations/0053_associate_stripe_with_rp.py
@@ -48,7 +48,7 @@ def migrate_data(apps, *args):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("organizations", "0051_historicalorganization_slug"),
+        ("organizations", "0052_map_benefits_and_levels_to_rp_not_org"),
     ]
 
     operations = [


### PR DESCRIPTION
#### What's this PR do?
Modify the migration script dependency.
Renaming `0052_associate_stripe_with_rp.py` to `0053_associate_stripe_with_rp.py``
Renaming `0053_map_benefits_and_levels_to_rp_not_org.py` to `0052_map_benefits_and_levels_to_rp_not_org.py`

Modifying dependency of `0052_map_benefits_and_levels_to_rp_not_org.py` to `("organizations", "0051_historicalorganization_slug"),`

Modifying dependency of `0053_associate_stripe_with_rp.py` to `"0052_map_benefits_and_levels_to_rp_not_org"`

#### Why are we doing this? How does it help us?
Migration is failing due to incorrect dependence and hierarchy.

#### How should this be manually tested?
Just running migration

#### Have automated unit tests been added?
NA

#### How should this change be communicated to end users?
NA

#### Are there any smells or added technical debt to note?
NA

#### Has this been documented? If so, where?
NA

#### What are the relevant tickets? Add a link to any relevant ones.
[DEV-1089]

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
NA

#### Are there next steps? If so, what? Have tickets been opened for them?
NA

[DEV-1089]: https://news-revenue-hub.atlassian.net/browse/DEV-1089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ