### PR TITLE
DEV-1952 | React app view failed to retrieve RP by subdomain support

### DIFF
--- a/revengine/views.py
+++ b/revengine/views.py
@@ -35,7 +35,7 @@ class ReactAppView(TemplateView):
             try:
                 return RevenueProgram.objects.get(slug=subdomain)
             except RevenueProgram.DoesNotExist:
-                logger.warning('ReactAppView failed to retrieve RevenueProgram by subdomain "%s"', subdomain)
+                logger.info('ReactAppView failed to retrieve RevenueProgram by subdomain "%s"', subdomain)
 
     def _add_social_media_context(self, revenue_program, context):
         serializer = SocialMetaInlineSerializer(revenue_program.social_meta, context={"request": self.request})


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

Base is provisionally `DEV-1856` because it makes a bunch of changes to logs, and this PR presupposes one of those changes.

#### What's this PR do?

Changes a log level from warning to info.

#### Why are we doing this? How does it help us?

Reduce Sentry noise.

#### How should this be manually tested?

N/A

#### Have automated unit tests been added?

N/A

#### How should this change be communicated to end users?

N/A


#### Are there any smells or added technical debt to note?

N/A


#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-1952 | ReactAppView failed to retrieve RevenueProgram by subdomain "support"](https://news-revenue-hub.atlassian.net/jira/software/c/projects/DEV/boards/3?modal=detail&selectedIssue=DEV-1952)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them?

N/A