### PR TITLE
DEV-1984 | Fix bug allowing NaN amount in donation submission data

### DIFF
--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -83,8 +83,8 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
   const stripe = useStripe();
   const elements = useElements();
 
-  const amountIsValid = !isNaN(amount);
-
+  // const amountIsValid = !isNaN(amount);
+  const amountIsValid = (amount) => amount && !isNaN(amount);
   /**
    * Listen for changes in the CardElement and display any errors as the customer types their card details
    */
@@ -246,7 +246,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
 
     let disabledWallets = getDisabledWallets(page);
 
-    if (stripe && amountIsValid && !paymentRequest) {
+    if (stripe && amountIsValid(amount) && !paymentRequest) {
       const pr = stripe.paymentRequest({
         country: page?.organization_country,
         currency: page?.currency?.code?.toLowerCase(),
@@ -271,7 +271,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
    * that is not passed in are setState calls which are already memoized.
    */
   useEffect(() => {
-    if (paymentRequest) {
+    if (paymentRequest && amountIsValid(amount)) {
       function handlePaymentMethodEvent(paymentMethodEvent) {
         handlePaymentRequestSubmit({ amount, payFee, ...params }, paymentMethodEvent);
       }
@@ -348,7 +348,7 @@ function StripePaymentForm({ loading, setLoading, offerPayFees }) {
 
           <S.PaymentSubmitButton
             onClick={handleCardSubmit}
-            disabled={!cardReady || loading || disabled || succeeded || !amountIsValid}
+            disabled={!cardReady || loading || disabled || succeeded || !amountIsValid(amount)}
             loading={loading}
             data-testid="donation-submit"
           >


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

This is a short term fix for a bug that allows donation form to be submitted in a state where the value is `NaN`.  Longer-term, we should consider a deeper refactor of the donation page form (which in turn will require a refactor of the donation page editor, which shares elements), all with an eye toward implementing client-side form validation (there is none at the moment!) using React Hook Form + Yup.js, and overall making this code more maintainable and testable.

#### What's this PR do?

Converts `amountIsValid` into a function instead of a constant, so that its value wont end up stale.

#### Why are we doing this? How does it help us?

Prevents users from submitting the donation form with `NaN` for amount.

#### How should this be manually tested?

In a branch that is not this one, you can trigger the bug by doing the following steps:

1. Visit a donation page and include `amount` query param in URL.  For instance, you can go to [https://billypenn.revengine-staging.org/donate?amount=foo](https://billypenn.revengine-staging.org/donate?amount=foo).
2. After the page loads, open developer tools and make sure the "Network" tab is visible.
3. Scroll to the Card details element, and enter test CC info (`4242 4242 4242 4242` for card number, any future mm/dd for date, and any length-3 cvc).  At this point, the button should still be disabled, and it should say "Enter a valid amount".
4. Go to the amount element which should have the value "NaN".  Click on the input, which should zero out the `Nan` value. DO NOT ENTER a new value.
5. Scroll back down to the submit button.  It should still say "Enter a valid amount" but it is no longer disabled. Click it. 
6. In the Network tab of dev tools, you should see a red error entry to the endpoint /payment. If you inspect the submitted data, you'll find that the request payload has "NaN" for the "amount" property. 

#### Have automated unit tests been added?

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### Has this been documented? If so, where?

#### What are the relevant tickets? Add a link to any relevant ones.

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

#### Are there next steps? If so, what? Have tickets been opened for them?
