### PR TITLE
DEV-2268-Active-style-sheet-is-affecting-system-notifications

### DIFF
--- a/spa/src/components/pageEditor/UnsavedChangesModal.styled.js
+++ b/spa/src/components/pageEditor/UnsavedChangesModal.styled.js
@@ -32,6 +32,7 @@ export const Description = styled.p`
   font-size: ${(props) => props.theme.fontSizesUpdated.md};
   padding: 1rem 1rem 0;
   margin: 0;
+  font-family: ${(props) => props.theme.systemFont};
 `;
 
 export const Buttons = styled.div`


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
Fixes Unsaved modal notification to use global font.

#### What's this PR do?
Fixes Unsaved modal notification to use global font.

#### Why are we doing this? How does it help us?
More readable description in modal, independent of donation page styling.

#### How should this be manually tested? Please include detailed step-by-step instructions.
For the link below, on making a change and clicking back, the unsaved modal changes text should be in a system font.
https://dev-2268.revengine-review.org/dashboard/edit/newsrevenuehub-dev-2268/donate

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/30353391/185724822-75345151-2295-4a3e-81c1-335d0daa4af6.png">


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

#### Have automated unit tests been added? If not, why?
n/a

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
n/a

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-2268

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
