### PR TITLE
dev-2267-page-editor-default-styling

### DIFF
--- a/spa/src/components/pageEditor/editInterface/EditInterface.styled.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.styled.js
@@ -27,4 +27,11 @@ export const EditInterface = styled(motion.aside)`
   h5 {
     font-family: ${(props) => props.theme.systemFont};
   }
+
+  *,
+  *::after,
+  *::before {
+    box-sizing: inherit;
+    outline-color: ${(props) => props.theme.colors.primary};
+  }
 `;

--- a/spa/src/components/stylesEditor/StylesEditor.styled.js
+++ b/spa/src/components/stylesEditor/StylesEditor.styled.js
@@ -30,6 +30,13 @@ export const StylesEditor = styled.div`
   h5 {
     font-family: ${(props) => props.theme.systemFont};
   }
+
+  *,
+  *::after,
+  *::before {
+    box-sizing: inherit;
+    outline-color: ${(props) => props.theme.colors.primary};
+  }
 `;
 
 export const StylesForm = styled.div`


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
The custom-styling of donation page should not impact the page editor styling

#### What's this PR do?
This PR ensures edit-page UI is not impacted by donation page styling

#### Why are we doing this? How does it help us?
To ensure that edit-page UI is consistent.

#### How should this be manually tested? Please include detailed step-by-step instructions.
For testing the following donation page with a custom style can be used
_Edit Page_
https://dev-2267.revengine-review.org/dashboard/edit/newsrevenuehub-dev-2267/donate 
_Donation page_
https://newsrevenuehub-dev-2267.revengine-review.org/donate

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/30353391/186446984-16508c00-1ec9-4649-b620-add3e657134f.png">


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no

#### Have automated unit tests been added? If not, why?
n/a

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
n/a

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-2267

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
