### PR TITLE
install and enable drf-yasg for browsable api

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Next, we need to set up a fake test Stripe ID so that stripe functionality will 
 echo "export REACT_APP_HUB_STRIPE_API_PUB_KEY=pk_test_3737373" >> .envrc
 ```
 
-To use a local Web browsable version of the API add `export ENABLE_BROWSABLE_API=True` to your `.envrc`.  (Then visit /api/swagger/ or /api/redoc/.)
+To use a local Web browsable version of the API add `export ENABLE_API_BROWSER=True` to your `.envrc`.  (Then visit /api/swagger/ or /api/redoc/.)
 
 
 To allow direnv to inject the variable into your environment, do:

--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ Next, we need to set up a fake test Stripe ID so that stripe functionality will 
 echo "export REACT_APP_HUB_STRIPE_API_PUB_KEY=pk_test_3737373" >> .envrc
 ```
 
+To use a local Web browsable version of the API add `export ENABLE_BROWSABLE_API=True` to your `.envrc`.  (Then visit /api/swagger/ or /api/redoc/.)
+
+
 To allow direnv to inject the variable into your environment, do:
 
 ```sh

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -1,4 +1,5 @@
-from django.urls import include, path
+from django.conf import settings
+from django.urls import include, path, re_path
 from django.views.decorators.csrf import csrf_exempt
 
 from apps.api.views import (
@@ -24,3 +25,25 @@ urlpatterns = [
     path("v1/contrib-email/", RequestContributorTokenEmailView.as_view(), name="contributor-token-request"),
     path("v1/contrib-verify/", csrf_exempt(VerifyContributorTokenView.as_view()), name="contributor-verify-token"),
 ]
+
+if settings.ENABLE_API_BROWSER:
+    from csp.decorators import csp_exempt
+    from drf_yasg import openapi
+    from drf_yasg.views import get_schema_view
+    from rest_framework import permissions  # for drf_yasg
+
+    schema_view = get_schema_view(
+        openapi.Info(
+            title="News Revenue Engine API",
+            default_version="v1",
+            description="News Revenue Engine API",
+        ),
+        public=True,
+        permission_classes=[permissions.AllowAny],
+    )
+
+    urlpatterns += [
+        re_path(r"^swagger(?P<format>\.json|\.yaml)$", schema_view.without_ui(cache_timeout=0), name="schema-json"),
+        re_path(r"^swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
+        re_path(r"^redoc/$", csp_exempt(schema_view.with_ui("redoc", cache_timeout=0)), name="schema-redoc"),
+    ]

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 import stripe
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, status, viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action, api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -280,7 +280,7 @@ class ContributionsViewSet(viewsets.ReadOnlyModelViewSet, FilterQuerySetByUserMi
     ]
     model = Contribution
     filterset_class = ContributionFilter
-    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filter_backends = [DjangoFilterBackend]
 
     def get_queryset(self):
         # load contributions from cache if the user is a contributor

--- a/poetry.lock
+++ b/poetry.lock
@@ -290,6 +290,31 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "coreapi"
+version = "2.3.3"
+description = "Python client library for Core API."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+coreschema = "*"
+itypes = "*"
+requests = "*"
+uritemplate = "*"
+
+[[package]]
+name = "coreschema"
+version = "0.0.4"
+description = "Core Schema."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+jinja2 = "*"
+
+[[package]]
 name = "coverage"
 version = "6.4.4"
 description = "Code coverage measurement for Python"
@@ -668,6 +693,28 @@ djangorestframework = ">=3.9.2"
 base64imagefield = ["Pillow (>=6.2.1)"]
 
 [[package]]
+name = "drf-yasg"
+version = "1.21.3"
+description = "Automated generation of real Swagger/OpenAPI 2.0 schemas from Django Rest Framework code."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coreapi = ">=2.3.3"
+coreschema = ">=0.0.4"
+django = ">=2.2.16"
+djangorestframework = ">=3.10.3"
+inflection = ">=0.3.1"
+packaging = ">=21.0"
+pytz = ">=2021.1"
+"ruamel.yaml" = ">=0.16.13"
+uritemplate = ">=3.0.0"
+
+[package.extras]
+validation = ["swagger-spec-validator (>=2.1.0)"]
+
+[[package]]
 name = "execnet"
 version = "1.9.0"
 description = "execnet: rapid multi-Python deployment"
@@ -915,6 +962,14 @@ perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
+name = "inflection"
+version = "0.5.1"
+description = "A port of Ruby on Rails inflector to Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -980,6 +1035,14 @@ colors = ["colorama (>=0.4.3,<0.5.0)"]
 plugins = ["setuptools"]
 
 [[package]]
+name = "itypes"
+version = "1.2.0"
+description = "Simple immutable types for python."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "jedi"
 version = "0.18.1"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -993,6 +1056,20 @@ parso = ">=0.8.0,<0.9.0"
 [package.extras]
 qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
+
+[[package]]
+name = "jinja2"
+version = "3.1.2"
+description = "A very fast and expressive template engine."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonlines"
@@ -1032,6 +1109,14 @@ sqlalchemy = ["sqlalchemy"]
 sqs = ["boto3 (>=1.9.12)", "pycurl (>=7.44.1,<7.45.0)", "urllib3 (>=1.26.7)"]
 yaml = ["PyYAML (>=3.10)"]
 zookeeper = ["kazoo (>=1.3.1)"]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "matplotlib-inline"
@@ -1529,6 +1614,29 @@ python-versions = ">=3.6,<4"
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "ruamel.yaml"
+version = "0.17.21"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+category = "dev"
+optional = false
+python-versions = ">=3"
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.6", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.11\""}
+
+[package.extras]
+docs = ["ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel.yaml.clib"
+version = "0.2.6"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "sentry-sdk"
 version = "1.9.5"
 description = "Python client for Sentry (https://sentry.io)"
@@ -1691,6 +1799,14 @@ optional = false
 python-versions = ">=2"
 
 [[package]]
+name = "uritemplate"
+version = "4.1.1"
+description = "Implementation of RFC 6570 URI Templates"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
 version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1778,7 +1894,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "1daab7c22c79658348d643607945d60e4dec059e3bbf98537783e597e05367b0"
+content-hash = "3d702a0815d2f1c854ab9987b138ff638812c16f72f630d255146434d27c890c"
 
 [metadata.files]
 amqp = [
@@ -1885,6 +2001,8 @@ colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
+coreapi = []
+coreschema = []
 coverage = [
     {file = "coverage-6.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e7b4da9bafad21ea45a714d3ea6f3e1679099e420c8741c74905b92ee9bfa7cc"},
     {file = "coverage-6.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fde17bc42e0716c94bf19d92e4c9f5a00c5feb401f5bc01101fdf2a8b7cacf60"},
@@ -2018,6 +2136,7 @@ drf-extra-fields = [
     {file = "drf-extra-fields-3.4.0.tar.gz", hash = "sha256:6224ae29ddfe80f38e36a1a5f7f1837cec1a4ec90e8960b473d43167f6d427d0"},
     {file = "drf_extra_fields-3.4.0-py3-none-any.whl", hash = "sha256:cc4e35e8b0fbef92a4295dfa5adac1436c0d51402ecc4facadb406e45e24f3bb"},
 ]
+drf-yasg = []
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
@@ -2106,6 +2225,7 @@ importlib-metadata = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
+inflection = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -2122,10 +2242,12 @@ isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
+itypes = []
 jedi = [
     {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
     {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
 ]
+jinja2 = []
 jsonlines = [
     {file = "jsonlines-3.1.0-py3-none-any.whl", hash = "sha256:632f5e38f93dfcb1ac8c4e09780b92af3a55f38f26e7c47ae85109d420b6ad39"},
     {file = "jsonlines-3.1.0.tar.gz", hash = "sha256:2579cb488d96f815b0eb81629e3e6b0332da0962a18fa3532958f7ba14a5c37f"},
@@ -2134,6 +2256,7 @@ kombu = [
     {file = "kombu-5.2.4-py3-none-any.whl", hash = "sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4"},
     {file = "kombu-5.2.4.tar.gz", hash = "sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610"},
 ]
+markupsafe = []
 matplotlib-inline = [
     {file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"},
     {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
@@ -2446,6 +2569,8 @@ responses = [
     {file = "responses-0.21.0.tar.gz", hash = "sha256:b82502eb5f09a0289d8e209e7bad71ef3978334f56d09b444253d5ad67bf5253"},
 ]
 rsa = []
+"ruamel.yaml" = []
+"ruamel.yaml.clib" = []
 sentry-sdk = [
     {file = "sentry-sdk-1.9.5.tar.gz", hash = "sha256:2d7ec7bc88ebbdf2c4b6b2650b3257893d386325a96c9b723adcd31033469b63"},
     {file = "sentry_sdk-1.9.5-py2.py3-none-any.whl", hash = "sha256:b4b41f90951ed83e7b4c176eef021b19ecba39da5b73aca106c97a9b7e279a90"},
@@ -2496,6 +2621,10 @@ typing-extensions = [
     {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 tzdata = []
+uritemplate = [
+    {file = "uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e"},
+    {file = "uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0"},
+]
 urllib3 = []
 uwsgi = [
     {file = "uwsgi-2.0.20.tar.gz", hash = "sha256:88ab9867d8973d8ae84719cf233b7dafc54326fcaec89683c3f9f77c002cdff9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ pytest-xdist = "*"
 flake8-logging-format = "*"
 pytest-mock = "^3.8.2"
 Faker = "^13.15.0"
+drf-yasg = "^1.21.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,9 +93,9 @@ pyyaml = "*"
 responses = "*"
 pytest-xdist = "*"
 flake8-logging-format = "*"
-pytest-mock = "^3.8.2"
-Faker = "^13.15.0"
-drf-yasg = "^1.21.3"
+pytest-mock = "*"
+Faker = "*"
+drf-yasg = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -19,6 +19,8 @@ DEBUG = os.getenv("DJANGO_DEBUG", "False") == "True"
 # be truncated for testing (as much as possible, currently).
 USE_DEBUG_INTERVALS = os.getenv("USE_DEBUG_INTERVALS", False)
 
+ENABLE_API_BROWSER = os.getenv("ENABLE_API_BROWSER", "false").lower() == "true"
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -114,6 +116,11 @@ INSTALLED_APPS = [
     "reversion_compare",
     "django_test_migrations.contrib.django_checks.AutoNames",
 ]
+
+if ENABLE_API_BROWSER:
+    INSTALLED_APPS += [
+        "drf_yasg",
+    ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION

#### What's this PR do?

Installs Swagger and ReDoc as options to have a browsable view of the API

#### Why are we doing this? How does it help us?

- It will allow users of the DRF API to have an easier time browsing/exploring the API
- I'm hopeful it will help us self-document the API better

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. `export ENABLE_API_BROWSER=True`
2. Visit /api/redoc/ and /api/swagger/ for two different interfaces to the API

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No, it was mostly settings and boilerplate copied from the instructions for drf-yasg. 

#### How should this change be communicated to end users?

No.

#### Are there any smells or added technical debt to note?

No. I did make decision here about trying to move toward a flat settings file instead of multiple files. For now there's a mix. 
I also tried out a similar package called drf-spectacular. I pushed that up as a separate branch if you'd like to take a look at that one. I also opted to make this only available locally for now, partly because I had to disable CSP on the views for it. 

#### Has this been documented? If so, where?

In the README as part of this PR. 

#### What are the relevant tickets? Add a link to any relevant ones.

- https://news-revenue-hub.atlassian.net/browse/DEV-2221
- https://news-revenue-hub.atlassian.net/browse/DEV-469


#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No. 

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No. 
