### PR TITLE
DEV-1493: Hide template functionality in add page modal

### DIFF
--- a/spa/cypress/integration/03 - donation-page-list.spec.js
+++ b/spa/cypress/integration/03 - donation-page-list.spec.js
@@ -58,7 +58,7 @@ describe('Donation page list', () => {
     cy.contains('You need to set up a revenue program to create a page.');
   });
 
-  it('should show template list dropdown, if templates exist', () => {
+  it.skip('should show template list dropdown, if templates exist', () => {
     cy.intercept(
       { method: 'GET', pathname: getEndpoint(TEMPLATES) },
       { fixture: 'pages/templates.json', statusCode: 200 }
@@ -67,7 +67,7 @@ describe('Donation page list', () => {
     cy.getByTestId('template-picker').should('exist');
   });
 
-  it('should contain rev_program and template in outoing request', () => {
+  it.skip('should contain rev_program and template in outgoing request', () => {
     cy.intercept(
       { method: 'GET', pathname: getEndpoint(TEMPLATES) },
       { fixture: 'pages/templates.json', statusCode: 200 }
@@ -87,5 +87,16 @@ describe('Donation page list', () => {
       expect(request.body).to.have.property('revenue_program');
       expect(request.body).to.have.property('template_pk');
     });
+  });
+
+  it('should contain rev_program in outgoing request', () => {
+    cy.get('button[aria-label="New Page"]').click();
+    cy.getByTestId('page-name').type('My Testing Page');
+    cy.getByTestId('page-name').blur();
+    cy.getByTestId('revenue-program-picker').click();
+    cy.getByTestId('select-item-0').click();
+    cy.intercept({ method: 'POST', pathname: getEndpoint(LIST_PAGES) }).as('createNewPage');
+    cy.getByTestId('save-new-page-button').click({ force: true });
+    cy.wait('@createNewPage').then(({ request }) => expect(request.body).to.have.property('revenue_program'));
   });
 });

--- a/spa/src/components/content/pages/AddPageModal.js
+++ b/spa/src/components/content/pages/AddPageModal.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import * as S from './AddPageModal.styled';
 import { useTheme } from 'styled-components';
 
@@ -14,7 +14,7 @@ import slugify from 'utilities/slugify';
 
 // AJAX
 import useRequest from 'hooks/useRequest';
-import { REVENUE_PROGRAMS, LIST_PAGES, TEMPLATES } from 'ajax/endpoints';
+import { LIST_PAGES } from 'ajax/endpoints';
 
 import useUser from 'hooks/useUser';
 
@@ -23,7 +23,10 @@ import Modal from 'elements/modal/Modal';
 import Input from 'elements/inputs/Input';
 import Select from 'elements/inputs/Select';
 import CircleButton from 'elements/buttons/CircleButton';
-import { GENERIC_ERROR } from 'constants/textConstants';
+// Intentionally commented out, see DEV-1493
+// import { GENERIC_ERROR } from 'constants/textConstants';
+// import { REVENUE_PROGRAMS, LIST_PAGES, TEMPLATES } from 'ajax/endpoints';
+
 import FormErrors from 'elements/inputs/FormErrors';
 
 function AddPageModal({ isOpen, closeModal }) {
@@ -31,40 +34,38 @@ function AddPageModal({ isOpen, closeModal }) {
   const theme = useTheme();
   const history = useHistory();
   const { revenue_programs: revenuePrograms } = useUser();
-
-  const fetchTemplates = useRequest();
   const createPage = useRequest();
-
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState({});
   const [name, setName] = useState('');
   const [slug, setSlug] = useState('');
 
   const [revenueProgram, setRevenueProgram] = useState();
-  const [templates, setTemplates] = useState([]);
-  const [template, setTemplate] = useState();
 
-  const handleRequestFailure = useCallback(
-    (e) => {
-      alert.error(GENERIC_ERROR);
-    },
-    [alert]
-  );
-
-  useEffect(() => {
-    async function getTemplates() {
-      setLoading(true);
-      fetchTemplates(
-        {
-          method: 'GET',
-          url: TEMPLATES
-        },
-        { onSuccess: ({ data }) => setTemplates(data), onFailure: handleRequestFailure }
-      );
-    }
-    getTemplates();
-    setLoading(false);
-  }, [handleRequestFailure]);
+  // Intentionally commented out, see DEV-1493
+  // const fetchTemplates = useRequest();
+  // const [templates, setTemplates] = useState([]);
+  // const [template, setTemplate] = useState();
+  // const handleRequestFailure = useCallback(
+  //   (e) => {
+  //     alert.error(GENERIC_ERROR);
+  //   },
+  //   [alert]
+  // );
+  // useEffect(() => {
+  //   async function getTemplates() {
+  //     setLoading(true);
+  //     fetchTemplates(
+  //       {
+  //         method: 'GET',
+  //         url: TEMPLATES
+  //       },
+  //       { onSuccess: ({ data }) => setTemplates(data), onFailure: handleRequestFailure }
+  //     );
+  //   }
+  //   getTemplates();
+  //   setLoading(false);
+  // }, [handleRequestFailure]);
 
   const handleNameBlur = () => {
     if (!slug) setSlug(slugify(name));
@@ -97,7 +98,8 @@ function AddPageModal({ isOpen, closeModal }) {
       slug,
       revenue_program: revenueProgram.id
     };
-    if (template) formData.template_pk = template.id;
+    // Intentionally commented-out, see DEV-1493
+    // if (template) formData.template_pk = template.id;
     createPage(
       {
         method: 'POST',
@@ -166,7 +168,9 @@ function AddPageModal({ isOpen, closeModal }) {
             {!loading && revenuePrograms.length === 0 && (
               <S.NoRevPrograms>You need to set up a revenue program to create a page.</S.NoRevPrograms>
             )}
-            {templates.length > 0 && (
+            {/*
+             // Intentionally commented out, see DEV-1493
+             templates.length > 0 && (
               <S.InputWrapper>
                 <Select
                   label="[Optional] Choose a page template"
@@ -180,7 +184,8 @@ function AddPageModal({ isOpen, closeModal }) {
                   testId="template-picker"
                 />
               </S.InputWrapper>
-            )}
+            )
+             */}
             <FormErrors errors={errors?.non_field_errors} />
           </S.FormFields>
           <S.Buttons>


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Removes the template drop-down menu when adding a new page, even if templates exist. (The dropdown is already hidden if there are no templates available.)

#### Why are we doing this? How does it help us?

We're rethinking this functionality.

#### How should this be manually tested? Please include detailed step-by-step instructions.

This is a little tricky as it needs to be done on a deploy that has pre-existing templates, and a page created from a template.

Two test plans:

1. Log into the dashboard and go to `/pages`.
2. Choose to add a new donation page.
3. Confirm that there is no template dropdown menu.

1. View a page that was previously created from a template. Make sure it displays and functions correctly.
2. Edit the page that was previously created from a template and confirm editing works as usual.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

It doesn't look like we mention templates in our knowledge base. 

#### Have automated unit tests been added? If not, why?

I skipped the Cypress tests related to the dropdown and added a pruned-down test to ensure that the revenue program is set correctly when creating a new page.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

I skipped tests and commented out relevant code. If we're confident this functionality is not coming back anytime soon, we might want to delete out code entirely.

#### Has this been documented? If so, where?

n/a

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-1493

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.