### PR TITLE
DEV-1106: Server Side Changes 

### DIFF
--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -335,6 +335,7 @@ class RevenueProgram(IndexedTimeStampedModel):
 
 class PaymentProvider(IndexedTimeStampedModel):
     stripe_account_id = models.CharField(max_length=255, unique=True, null=True, blank=True)
+    # TODO find out logic around this. Should it have a default value
     stripe_product_id = models.CharField(max_length=255, blank=True, null=True)
 
     currency = models.CharField(max_length=3, choices=CURRENCY_CHOICES, default="USD")

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -335,7 +335,6 @@ class RevenueProgram(IndexedTimeStampedModel):
 
 class PaymentProvider(IndexedTimeStampedModel):
     stripe_account_id = models.CharField(max_length=255, unique=True, null=True, blank=True)
-    # TODO find out logic around this. Should it have a default value
     stripe_product_id = models.CharField(max_length=255, blank=True, null=True)
 
     currency = models.CharField(max_length=3, choices=CURRENCY_CHOICES, default="USD")

--- a/apps/organizations/tests/test_org_views.py
+++ b/apps/organizations/tests/test_org_views.py
@@ -342,94 +342,17 @@ def rp_role_assignment(user, rp):
 
 
 @pytest.mark.django_db
-class TestCreateStripeAccount:
-    def test_happy_path(self, rp_role_assignment, monkeypatch):
-        account_id = "someID"
-        mock_fn = mock.MagicMock(return_value={"id": account_id})
-        monkeypatch.setattr("stripe.Account.create", mock_fn)
-        rp = rp_role_assignment.revenue_programs.first()
-        rp.payment_provider.stripe_account_id = None
-        rp.payment_provider.save()
-        url = reverse("create-stripe-account", args=(rp.pk,))
-        client = APIClient()
-        client.force_authenticate(user=rp_role_assignment.user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_201_CREATED
-        rp.payment_provider.refresh_from_db()
-        assert rp.payment_provider.stripe_account_id == account_id
-        mock_fn.assert_called_once_with(type="standard", country=rp.country)
-
-    def test_when_unauthenticated(self, rp):
-        url = reverse("create-stripe-account", args=(rp.pk,))
-        client = APIClient()
-        response = client.post(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_when_no_role_assignment(self, user, rp):
-        url = reverse("create-stripe-account", args=(rp.pk,))
-        client = APIClient()
-        client.force_authenticate(user=user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_when_rp_not_found(self, rp_role_assignment):
-        rp = rp_role_assignment.revenue_programs.first()
-        url = reverse("create-stripe-account", args=(rp.pk,))
-        rp.delete()
-        client = APIClient()
-        client.force_authenticate(user=rp_role_assignment.user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_when_dont_have_access_to_rp(self, rp_role_assignment):
-        unowned_rp = RevenueProgramFactory()
-        assert unowned_rp not in rp_role_assignment.revenue_programs.all()
-        url = reverse("create-stripe-account", args=(unowned_rp.pk,))
-        client = APIClient()
-        client.force_authenticate(user=rp_role_assignment.user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_when_no_payment_provider(self, rp_role_assignment):
-        (rp := rp_role_assignment.revenue_programs.first()).payment_provider.delete()
-        url = reverse("create-stripe-account", args=(rp.pk,))
-        client = APIClient()
-        client.force_authenticate(user=rp_role_assignment.user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-
-    def test_when_payment_provider_already_has_stripe_account_id(self, rp_role_assignment):
-        (rp := rp_role_assignment.revenue_programs.first()).payment_provider.stripe_verified = True
-        rp.payment_provider.save()
-        url = reverse("create-stripe-account", args=(rp.pk,))
-        client = APIClient()
-        client.force_authenticate(user=rp_role_assignment.user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_409_CONFLICT
-
-    # mock stripe call to raise error
-    def test_when_stripe_error(self, rp_role_assignment, monkeypatch):
-        mock_fn = mock.MagicMock()
-        mock_fn.side_effect = StripeError("Stripe blew up")
-        monkeypatch.setattr("stripe.Account.create", mock_fn)
-        (rp := rp_role_assignment.revenue_programs.first()).payment_provider.stripe_account_id = None
-        rp.payment_provider.save()
-        url = reverse("create-stripe-account", args=(rp.pk,))
-        client = APIClient()
-        client.force_authenticate(user=rp_role_assignment.user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-
-
-@pytest.mark.django_db
 class TestCreateStripeAccountLink:
     def test_happy_path(self, monkeypatch, rp_role_assignment):
         return_value = {"fake": "return value"}
-        mock_fn = mock.MagicMock(return_value=return_value)
-        monkeypatch.setattr("stripe.AccountLink.create", mock_fn)
+        mock_account_link_create = mock.MagicMock(return_value=return_value)
+        monkeypatch.setattr("stripe.AccountLink.create", mock_account_link_create)
+        account_id = "someID"
+        mock_account_create = mock.MagicMock(return_value={"id": account_id})
+        monkeypatch.setattr("stripe.Account.create", mock_account_create)
         rp = rp_role_assignment.revenue_programs.first()
         rp.payment_provider.stripe_verified = False
-        rp.payment_provider.stripe_account_id = "fake-stripe-account-id"
+        rp.payment_provider.stripe_account_id = None
         rp.payment_provider.save()
         url = reverse("create-stripe-account-link", args=(rp.pk,))
         client = APIClient()
@@ -437,7 +360,10 @@ class TestCreateStripeAccountLink:
         response = client.post(url)
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == return_value
-        mock_fn.assert_called_once_with(
+        rp.payment_provider.refresh_from_db()
+        assert rp.payment_provider.stripe_account_id == account_id
+        mock_account_create.assert_called_once_with(type="standard", country=rp.country)
+        mock_account_link_create.assert_called_once_with(
             account=rp.payment_provider.stripe_account_id,
             refresh_url="http://testserver/",
             return_url="http://testserver/",
@@ -483,20 +409,12 @@ class TestCreateStripeAccountLink:
         response = client.post(url)
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
-    def test_when_payment_provider_has_no_stripe_account_id(self, rp_role_assignment):
-        (rp := rp_role_assignment.revenue_programs.first()).payment_provider.stripe_account_id = None
-        rp.payment_provider.save()
-        url = reverse("create-stripe-account-link", args=(rp.pk,))
-        client = APIClient()
-        client.force_authenticate(user=rp_role_assignment.user)
-        response = client.post(url)
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-
     def test_when_stripe_error(self, rp_role_assignment, monkeypatch):
         mock_fn = mock.MagicMock()
         mock_fn.side_effect = StripeError("Stripe blew up")
-        monkeypatch.setattr("stripe.AccountLink.create", mock_fn)
+        monkeypatch.setattr("stripe.Account.create", mock_fn)
         rp = rp_role_assignment.revenue_programs.first()
+        rp.payment_provider.stripe_account_id = None
         rp.payment_provider.stripe_verified = False
         rp.payment_provider.save()
         url = reverse("create-stripe-account-link", args=(rp.pk,))

--- a/apps/organizations/tests/test_org_views.py
+++ b/apps/organizations/tests/test_org_views.py
@@ -438,7 +438,10 @@ class TestCreateStripeAccountLink:
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == return_value
         mock_fn.assert_called_once_with(
-            account=rp.payment_provider.stripe_account_id, refresh_url="", return_url="", type="account_onboarding"
+            account=rp.payment_provider.stripe_account_id,
+            refresh_url="http://testserver/",
+            return_url="http://testserver/",
+            type="account_onboarding",
         )
 
     def test_when_unauthenticated(self, rp):

--- a/apps/organizations/urls.py
+++ b/apps/organizations/urls.py
@@ -11,4 +11,13 @@ router.register(r"organizations", views.OrganizationViewSet, basename="organizat
 router.register(r"plans", views.PlanViewSet, basename="plan")
 router.register(r"revenue-programs", views.RevenueProgramViewSet, basename="revenue-program")
 
-urlpatterns = [path("", include(router.urls))]
+urlpatterns = [
+    path("", include(router.urls)),
+    path("create-stripe-account/<rp_pk>/", views.create_stripe_account, name="create-stripe-account"),
+    path("create-stripe-account-link/<rp_pk>/", views.create_stripe_account_link, name="create-stripe-account-link"),
+    path(
+        "create-stripe-account-link-complete/<rp_pk>/",
+        views.create_stripe_account_link_complete,
+        name="create-stripe-account-link-complete",
+    ),
+]

--- a/apps/organizations/urls.py
+++ b/apps/organizations/urls.py
@@ -13,7 +13,6 @@ router.register(r"revenue-programs", views.RevenueProgramViewSet, basename="reve
 
 urlpatterns = [
     path("", include(router.urls)),
-    path("create-stripe-account/<rp_pk>/", views.create_stripe_account, name="create-stripe-account"),
     path("create-stripe-account-link/<rp_pk>/", views.create_stripe_account_link, name="create-stripe-account-link"),
     path(
         "create-stripe-account-link-complete/<rp_pk>/",

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -78,63 +78,6 @@ class RevenueProgramViewSet(viewsets.ReadOnlyModelViewSet):
 
 @api_view(["POST"])
 @permission_classes([IsAuthenticated, HasRoleAssignment])
-def create_stripe_account(request, rp_pk=None):
-    """This view allows a requesting user to create a Stripe Account and save its ID to a given revenue program"""
-    revenue_program = get_object_or_404(RevenueProgram, pk=rp_pk)
-    if not request.user.roleassignment.can_access_rp(revenue_program):
-        logger.warning(
-            (
-                "[create_stripe_account] was asked to create an account for RP with ID %s by user with id %s who does "
-                "not have access."
-            ),
-            rp_pk,
-            request.user.id,
-        )
-        raise PermissionDenied(f"You do not have permission to access revenue program with the PK {rp_pk}")
-    if not (payment_provider := revenue_program.payment_provider):
-        logger.info(
-            (
-                "[create_stripe_account] was asked to create a Stripe an account for revenue program "
-                "with ID: %s, but that RP doesn't have a payment provider"
-            ),
-            rp_pk,
-        )
-        return Response(
-            {"detail": "This revenue program is missing a payment provider"},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
-    if payment_provider.stripe_account_id:
-        logger.info(
-            (
-                "[create_stripe_account] was asked to create a Stripe account for revenue program "
-                "with ID: %s, payment provider with ID %s, but that payment provider already has a stripe "
-                "account id"
-            ),
-            rp_pk,
-            payment_provider.stripe_account_id,
-        )
-        return Response(
-            {"detail": "This revenue program's payment provider already has a stripe account"},
-            status=status.HTTP_409_CONFLICT,
-        )
-    try:
-        stripe_response = stripe.Account.create(
-            type="standard",
-            country=revenue_program.country,
-        )
-    except StripeError:
-        logger.exception("[create_stripe_account] A stripe error occurred")
-        return Response(
-            {"detail": "Something went wrong creating Stripe account. Try again later."},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
-    payment_provider.stripe_account_id = stripe_response["id"]
-    payment_provider.save()
-    return Response({"detail": "Success"}, status=status.HTTP_201_CREATED)
-
-
-@api_view(["POST"])
-@permission_classes([IsAuthenticated, HasRoleAssignment])
 def create_stripe_account_link(request, rp_pk=None):
     """This endpoint is for the SPA to initiate the Stripe account linking process.
 
@@ -172,18 +115,19 @@ def create_stripe_account_link(request, rp_pk=None):
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     if not payment_provider.stripe_account_id:
-        logger.warning(
-            (
-                "[create_stripe_account_link] was asked to create an account link for RP with ID %s , "
-                "but that RP's payment provider (with ID of %s) does not have a stripe_account_id"
-            ),
-            rp_pk,
-            payment_provider.id,
-        )
-        return Response(
-            {"detail": ("The revenue program you're trying to link has a payment provider, but no stripe account id.")},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        try:
+            stripe_response = stripe.Account.create(
+                type="standard",
+                country=revenue_program.country,
+            )
+        except StripeError:
+            logger.exception("[create_stripe_account_link] A stripe error occurred")
+            return Response(
+                {"detail": "Something went wrong creating Stripe account. Try again later."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        payment_provider.stripe_account_id = stripe_response["id"]
+        payment_provider.save()
     try:
         stripe_response = stripe.AccountLink.create(
             account=payment_provider.stripe_account_id,

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.reverse import reverse
 from stripe.error import StripeError
 
 from apps.api.permissions import HasRoleAssignment
@@ -188,13 +189,11 @@ def create_stripe_account_link(request, rp_pk=None):
             account=payment_provider.stripe_account_id,
             # The URL the user will be redirected to if the account link is expired, has been
             # previously-visited, or is otherwise invalid.
-            # TBD in spa side
-            # refresh_url=request.build_absolute_uri(reverse("create-stripe-account-link", args=(rp_pk,))),
+            # NB: this may get updated when second PR focused on SPA-side changes is done
+            refresh_url=request.build_absolute_uri(reverse("index")),
             # The URL that the user will be redirected to upon leaving or completing the linked flow.
-            # TBD in spa side
-            # return_url=request.build_absolute_uri(reverse("create-stripe-account-link-complete", args=(rp_pk,))),
-            refresh_url="",
-            return_url="",
+            # NB: this may get updated when second PR focused on SPA-side changes is done
+            return_url=request.build_absolute_uri(reverse("index")),
             type="account_onboarding",
         )
     except StripeError:

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -2,13 +2,17 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-
-from rest_framework import viewsets
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+from rest_framework.decorators import action, api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated
+import stripe
+from stripe.error import StripeError
+
 
 from apps.api.permissions import HasRoleAssignment
 from apps.organizations import serializers
-from apps.organizations.models import Feature, Organization, Plan, RevenueProgram
+from apps.organizations.models import Feature, Organization, PaymentProvider, Plan, RevenueProgram
 from apps.public.permissions import IsActiveSuperUser
 from apps.users.views import FilterQuerySetByUserMixin
 
@@ -67,3 +71,155 @@ class RevenueProgramViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsAuthenticated, IsActiveSuperUser]
     serializer_class = serializers.RevenueProgramSerializer
     pagination_class = None
+
+
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+def link_stripe_account(request):
+    # get user
+    # if user wrong type, eerror
+    # if already linked, let client know
+    # else
+    response = stripe.Account.create(
+        type="standard",
+        account="acct__",
+        # https://stripe.com/docs/api/account_links/create#create_account_link-refresh_url
+        # The URL the user will be redirected to if the account link is expired, has been
+        # previously-visited, or is otherwise invalid.
+        refresh_url="",
+        # The URL that the user will be redirected to upon leaving or completing the linked flow.
+        return_url="",
+        type="account_onboarding",
+    )
+
+
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+def create_stripe_account(request, rp_pk=None):
+    # ensure requesting user has access to RP
+    # get or 404
+    revenue_program = RevenueProgram.get(pk=rp_pk)
+    if revenue_program.payment_provider:
+        logger.info(
+            (
+                "[create_stripe_account] was asked to create a Stripe an account for revenue program "
+                "that already has one (ID: %s)"
+            ),
+            revenue_program.id,
+        )
+        return Response(
+            {"detail": "Stripe account already exists for this revenue program"}, status=status.HTTP_409_CONFLICT
+        )
+    try:
+        stripe_response = stripe.Account.create(
+            type="standard",
+            country=revenue_program.country,
+            # should we set this?
+            email=None,
+            # enum of individual company non_profit government_entity
+            # https://stripe.com/docs/api/accounts/create#create_account-business_type
+            business_type="",
+            company={
+                "name": "TBD",
+            },
+            metadata={},
+        )
+    except StripeError:
+        logger.exception("[create_stripe_account] A stripe error occurred")
+        return Response({"detail": ""}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    try:
+        payment_provider = PaymentProvider.obects.create(
+            stripe_account_id=stripe_response.id,
+        )
+        revenue_program.payment_provider = payment_provider
+        revenue_program.save()
+    except:
+        pass
+    return Response({"detail": "Success"}, status=status.HTTP_201_CREATED)
+
+
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+def create_stripe_account_link(request, rp_pk=None):
+    # ensure requesting user has access to RP
+    # get user -- get account fo
+    revenue_program = get_object_or_404()
+    # rp id from request data
+    # if user wrong type, eerror
+    # if already linked, let client know
+    # else
+    try:
+        stripe_response = stripe.AccountLink.create(
+            type="standard",
+            account="acct__",
+            # https://stripe.com/docs/api/account_links/create#create_account_link-refresh_url
+            # The URL the user will be redirected to if the account link is expired, has been
+            # previously-visited, or is otherwise invalid.
+            refresh_url="",
+            # The URL that the user will be redirected to upon leaving or completing the linked flow.
+            return_url="",
+            type="account_onboarding",
+        )
+    except StripeError:
+        logger.exception("[create_stripe_account_link] A stripe error occurred")
+        return Response({"detail": ""}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    return Response(stripe_response, status=status.HTTP_202_ACCEPTED)
+
+
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+def create_stripe_account_link_complete(request, rp_pk=None):
+    # ensure user has permits for rp
+    # https://stripe.com/docs/connect/standard-accounts#return-user
+    revenue_program = get_object_or_404()
+    if revenue_program.payment_provider and revenue_program.payment_provider.stripe_verified:
+        logger.info(
+            (
+                "[create_stripe_account_link_complete] was to do post-account-link side effects for revenue program (ID: %), "
+                "but that revenue program already has a verified payment provider."
+            ),
+            revenue_program.id,
+        )
+        return Response(
+            {"detail": "This RP already has a Stripe Account Link that has been verified"},
+            status=status.HTTP_409_CONFLICT,
+        )
+    if revenue_program.payment_provider and revenue_program.payment_provider.stripe_account_id != "":
+        logger.info()
+        return Response()
+    try:
+        stripe_account = stripe.Account.retrieve("account_id")
+    except StripeError:
+        pass
+        logger.exception("[create_stripe_account_link] A stripe error occurred")
+        return Response({"detail": ""}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    # https://stripe.com/docs/api/accounts/object#account_object-details_submitted
+    # we're getting the details_submitted field, which may or may not mean same as status quo
+    if revenue_program.payment_provider.stripe_verified != stripe_account["details_submitted"]:
+        revenue_program.payment_provider.stripe_verified = stripe_account["details_submitted"]
+        revenue_program.save()
+    return Response({"detail": "success"}, status=status.HTTP_202_ACCEPTED)
+
+
+# DOES THIS NEED TO BE SEP, OR CAN BE SAME AS INITIAL CREATE
+
+# @api_view(["POST"])
+# @authentication_classes([])
+# @permission_classes([])
+# def create_stripe_account_link_refresh(request, rp_pk=None):
+#     # verify user
+#     revenue_program = get_object_or_404()
+#     if revenue_program.payment_provider and revenue_program.payment_provider.stripe_verified:
+#         logger.info(
+#             "[create_stripe_account_link_refresh] ... %s",
+#             revenue_program.id,
+#         )
+#         return Response(
+#             {"detail": "This RP already has a Stripe Account Link that has been verified"},
+#             status=status.HTTP_409_CONFLICT,
+#         )
+#     return create_stripe_account_link(request, rp_pk=rp_pk)

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -81,7 +81,11 @@ class RevenueProgramViewSet(viewsets.ReadOnlyModelViewSet):
 def create_stripe_account_link(request, rp_pk=None):
     """This endpoint is for the SPA to initiate the Stripe account linking process.
 
-    It does so by calling `stripe.accountLink.create`, including a parameter for a `return_url`, which
+    If the rp's payment provider doesn't have a Stripe Account, this endpoint calls
+    `stripe.Account.create` to create a Stripe Account, and saves the account id to the
+    NRE payment provider instance.
+
+    Next, it calls `stripe.accountLink.create`, including a parameter for a `return_url`, which
     should be a user-facing view in the SPA. Stripe creates an AccountLink entity (with an expiry) and provides
     an off-site URL that the user should be redirected to in the SPA in order to complete the account setup process.
 

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -156,14 +156,13 @@ def create_stripe_account_link_complete(request, rp_pk=None):
     setup (after visiting the Stripe-controlled URL furnished in the call to `stripe.AccountLink.create` in
     `create_stripe_account_link`)
 
-    After retrieving the target RP and related payment provier, it sets the payment provider's `stripe_verified`
-    value to `True` and saves if Stripe reports that the account has "charges_enabled".
+    After retrieving the target RP and related payment provider, if the Stripe account's `charges_enabled`
+    property is True, it sets the NRE payment provider instance's `stripe_verified`
+    value to `True` and saves.
 
     Assuming the happy path, the response data will contain a `stripe_verified` boolean which the SPA can
     use to decide what to do next in onboarding flow, without having to make an additional request to
     retrieve the revenue program anew.
-
-    TODO: Make the app in background regrab RP via react query
     """
     revenue_program = get_object_or_404(RevenueProgram, pk=rp_pk)
     if not request.user.roleassignment.can_access_rp(revenue_program):

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -91,6 +91,8 @@ class RoleAssignment(models.Model):
         """
         return any(
             [
+                self.user.is_superuser,
+                self.role_type == Roles.HUB_ADMIN,
                 self.role_type == Roles.ORG_ADMIN and self.organization == revenue_program.organization,
                 self.role_type == Roles.RP_ADMIN and revenue_program in self.revenue_programs.all(),
             ]

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -82,6 +82,20 @@ class RoleAssignment(models.Model):
             return f"{Roles.RP_ADMIN.label} for these revenue programs: {', '.join(owned_rps_as_strings)}"
         return f"Unspecified RoleAssignment ({self.pk})"
 
+    def can_access_rp(self, revenue_program):
+        """Determine if role assignment grants basic acess to a given revenue program
+
+        Note that this is a "dumb" notion of having access. It doesn't distinguish between
+        read and write. It's used to show that a user should be able to
+        have access to an rp by virtue of their role type, orgnaization, and revenue_programs.
+        """
+        return any(
+            [
+                self.role_type == Roles.ORG_ADMIN and self.organization == revenue_program.organization,
+                self.role_type == Roles.RP_ADMIN and revenue_program in self.revenue_programs.all(),
+            ]
+        )
+
 
 class UnexpectedRoleType(Exception):
     """For signalling an unexpected value for `role_assignment.role_type`"""


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

This one of 3 planned stacked PRs to deliver [DEV-1106](https://news-revenue-hub.atlassian.net/jira/software/c/projects/DEV/boards/3?modal=detail&selectedIssue=DEV-1106).

The base for this PR is `DEV-1106-main`, which was initially the result of merging (a then not yet merged) `dev-2199n-connect-to-stripe-new` into (a then not yet merged) `dev-1679-create-account`, and then merging `main`.

This PR contains the server-side changes required to facilitate the new Stripe Account link flow.

The next PR will be SPA-focused, hooking up existing UI components to the endpoints created in this PR. This PR will also be into `DEV-1106-main`.

Finally, there will be a third PR of `DEV-1106-main` into `main`, where final merge conflicts can be handled and any late changes.

#### What's this PR do?

This PR contains the server-side changes required to facilitate the new Stripe Account link flow.


Specifically, it creates 2 new API endpoints:

| URL | View Name | HTTP Method |
| ------------- | ------------- | ---------- |
| /api/v1/create-stripe-account-link/<rp_pk>/  | `apps.organizations.views.create_stripe_accoun_linkt`  |  POST  |
| /api/v1/create-stripe-accoun-link-complete/<rp_pk>/  | `apps.organizations.views.create_stripe_account_link_complete`  |  POST  |

These endpoints implement the server-side changes demonstrated in [the Stripe docs on the account linking workflow](https://stripe.com/docs/connect/standard-accounts).

#### Why are we doing this? How does it help us?

Requirement for self-service onboarding flow.

#### How should this be manually tested? Please include detailed step-by-step instructions.

For this PR, the only good option is to use Postman to make requests. I can share a Postman collection if anyone wants that. This would allow you to try out the off-site Account creation and linkage flow, much of which happens off site on a Stripe site. 

UX-focused testing should happen in the PR that follows this one.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Yes. It's a whole new onboarding flow for Stripe.

#### Have automated unit tests been added? If not, why?

Yes. Happy path + likely unhappy paths both new endpoints.

#### How should this change be communicated to end users?

TBD

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-1106](https://news-revenue-hub.atlassian.net/jira/software/c/projects/DEV/boards/3?modal=detail&selectedIssue=DEV-1106).

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A