### PR TITLE
handle page elements that don't have requiredFields

### DIFF
--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -342,7 +342,7 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
     def do_conditional_validation(self, data):
         """Handle validation of conditionally requirable fields"""
         errors = {}
-        for element in [x for x in data["page"].elements if len(x["requiredFields"])]:
+        for element in [x for x in data["page"].elements if len(x.get("requiredFields", []))]:
             for field in element["requiredFields"]:
                 # if it's blank or none or no key for it in data
                 if data.get(field, None) in (None, ""):

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -856,6 +856,13 @@ class TestBaseCreatePaymentSerializer:
         for key, val in expectations.items():
             assert getattr(contribution, key) == val
 
+    def test_donation_page_when_element_not_have_required_fields(self, donation_page, minimally_valid_data):
+        del donation_page.elements[0]["requiredFields"]
+        donation_page.save()
+        request = APIRequestFactory().post("", {}, format="json")
+        serializer = self.serializer_class(data=minimally_valid_data, context={"request": request})
+        assert serializer.is_valid()
+
 
 @pytest.mark.django_db
 class TestCreateOneTimePaymentSerializer:


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Fixes bug ticket [DEV-2421](https://news-revenue-hub.atlassian.net/browse/DEV-2421)

Specifically, fixes a regression caused by refactoring of conditionally required form elements. The pre-existing code had a default empty list when there were no `.requiredFields` for a given dynamic page element ([see here](https://github.com/newsrevenuehub/rev-engine/blob/6ab98b4e56d65be709d42ca13f85024cfaaf5ca9/apps/contributions/serializers.py#L186)). This PR brings back a default empty list for `.requiredFields`.

#### Why are we doing this? How does it help us?

Fixes bug ticket [DEV-2421](https://news-revenue-hub.atlassian.net/browse/DEV-2421)

#### How should this be manually tested? Please include detailed step-by-step instructions.

~Go to https://billypenn-dev-2421.revengine-review.org/donate. It should succeed, and shouldn't generate Sentry errors. You can also take a look at https://dev-2421.revengine-review.org/nrhadmin/pages/donationpage/69/change/?_changelist_filters=revenue_program__id__exact%3D22 and verify that there are page elements that do not have `requiredFields` defined, which triggered the error.
https://dev-2421.revengine-review.org/nrhadmin~

Above instructions won't work because we're at max of review apps currently. [See here](https://dashboard.heroku.com/pipelines/c2cd3f09-9c0a-45d3-8650-3d197481d30e/app-setup/fb123c05-3ba7-48ce-a2dc-55d583b70f78).  

This problem originally was discovered in test env, so can verify there if need be, once merged. https://billypenn-revengine-test.org/donate


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2421](https://news-revenue-hub.atlassian.net/browse/DEV-2421)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

See parent ticket [DEV-2183](https://news-revenue-hub.atlassian.net/browse/DEV-2183)