### PR TITLE
DEV-2435 | fix bug around next url for default donation page

### DIFF
--- a/spa/cypress/integration/01 - donation-page.spec.js
+++ b/spa/cypress/integration/01 - donation-page.spec.js
@@ -408,18 +408,18 @@ describe('User flow: happy path', () => {
         confirmParams: { return_url }
       } = x.getCalls()[0].args[0];
       expect(return_url).to.equal(
-        getPaymentSuccessUrl(
-          'http://revenueprogram.revengine-testabc123.com:3000/',
-          '',
-          '123.01',
-          fakeEmailHash,
-          'one-time',
-          'foo@bar.com',
-          livePageOne.slug,
-          livePageOne.revenue_program.slug,
-          `/${livePageOne.slug}`,
-          fakeStripeSecret
-        )
+        getPaymentSuccessUrl({
+          baseUrl: 'http://revenueprogram.revengine-testabc123.com:3000/',
+          thankYouRedirectUrl: '',
+          amount: '123.01',
+          emailHash: fakeEmailHash,
+          frequencyDisplayValue: 'one-time',
+          contributorEmail: 'foo@bar.com',
+          pageSlug: livePageOne.slug,
+          rpSlug: livePageOne.revenue_program.slug,
+          pathName: `/${livePageOne.slug}`,
+          stripeClientSecret: fakeStripeSecret
+        })
       );
     });
   });
@@ -481,19 +481,20 @@ describe('User flow: happy path', () => {
       const {
         confirmParams: { return_url }
       } = x.getCalls()[0].args[0];
+
       expect(return_url).to.equal(
-        getPaymentSuccessUrl(
-          'http://revenueprogram.revengine-testabc123.com:3000/',
-          '',
-          '10.53',
-          fakeEmailHash,
-          'monthly',
-          'foo@bar.com',
-          livePageOne.slug,
-          livePageOne.revenue_program.slug,
-          `/${livePageOne.slug}`,
-          fakeStripeSecret
-        )
+        getPaymentSuccessUrl({
+          baseUrl: 'http://revenueprogram.revengine-testabc123.com:3000/',
+          thankYouRedirectUrl: '',
+          amount: '10.53',
+          emailHash: fakeEmailHash,
+          frequencyDisplayValue: 'monthly',
+          contributorEmail: 'foo@bar.com',
+          pageSlug: livePageOne.slug,
+          rpSlug: livePageOne.revenue_program.slug,
+          pathName: `/${livePageOne.slug}`,
+          stripeClientSecret: fakeStripeSecret
+        })
       );
     });
   });
@@ -534,18 +535,18 @@ describe('User flow: happy path', () => {
         confirmParams: { return_url }
       } = x.getCalls()[0].args[0];
       expect(return_url).to.equal(
-        getPaymentSuccessUrl(
-          'http://revenueprogram.revengine-testabc123.com:3000/',
-          '',
-          '10.53',
-          fakeEmailHash,
-          'monthly',
-          'foo@bar.com',
-          livePageOne.slug,
-          livePageOne.revenue_program.slug,
-          '',
-          fakeStripeSecret
-        )
+        getPaymentSuccessUrl({
+          baseUrl: 'http://revenueprogram.revengine-testabc123.com:3000/',
+          thankYouRedirectUrl: '',
+          amount: '10.53',
+          emailHash: fakeEmailHash,
+          frequencyDisplayValue: 'monthly',
+          contributorEmail: 'foo@bar.com',
+          pageSlug: livePageOne.slug,
+          rpSlug: livePageOne.revenue_program.slug,
+          pathName: '',
+          stripeClientSecret: fakeStripeSecret
+        })
       );
     });
   });
@@ -617,7 +618,7 @@ const successPageQueryParams = {
   payment_intent_client_secret: fakeStripeSecret
 };
 
-describe.only('Payment success page', () => {
+describe('Payment success page', () => {
   beforeEach(() => {
     cy.intercept(
       {

--- a/spa/cypress/support/commands.js
+++ b/spa/cypress/support/commands.js
@@ -1,7 +1,7 @@
 import 'cypress-localstorage-commands';
 
 import { TOKEN } from 'ajax/endpoints';
-import { getEndpoint, getTestingDonationPageUrl, EXPECTED_RP_SLUG } from './util';
+import { getEndpoint, getTestingDonationPageUrl, getTestingDefaultDonationPageUrl, EXPECTED_RP_SLUG } from './util';
 import { LIVE_PAGE_DETAIL, STRIPE_PAYMENT, CONTRIBUTIONS } from 'ajax/endpoints';
 import { DEFAULT_RESULTS_ORDERING } from 'components/donations/DonationsTable';
 import { ApiResourceList } from '../support/restApi';
@@ -36,6 +36,16 @@ Cypress.Commands.add('visitDonationPage', () => {
   cy.visit(getTestingDonationPageUrl('my-page'));
   cy.url().should('include', EXPECTED_RP_SLUG);
   cy.url().should('include', 'my-page');
+  cy.wait('@getPageDetail');
+});
+
+Cypress.Commands.add('visitDefaultDonationPage', () => {
+  cy.intercept(
+    { method: 'GET', pathname: getEndpoint(LIVE_PAGE_DETAIL) },
+    { fixture: 'pages/live-page-1', statusCode: 200 }
+  ).as('getPageDetail');
+  cy.visit(getTestingDefaultDonationPageUrl());
+  cy.url().should('include', EXPECTED_RP_SLUG);
   cy.wait('@getPageDetail');
 });
 

--- a/spa/cypress/support/util.js
+++ b/spa/cypress/support/util.js
@@ -13,3 +13,7 @@ export const EXPECTED_RP_SLUG = 'revenueprogram';
 export function getTestingDonationPageUrl(pageSlug = '', queryString = '') {
   return `http://${EXPECTED_RP_SLUG}.revengine-testabc123.com:3000/${pageSlug}${queryString}`;
 }
+
+export function getTestingDefaultDonationPageUrl(queryString = '') {
+  return `http://${EXPECTED_RP_SLUG}.revengine-testabc123.com:3000/${queryString}`;
+}

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -7,54 +7,9 @@ import * as S from './StripePaymentForm.styled';
 import { usePage } from 'components/donationPage/DonationPage';
 import { ICONS } from 'assets/icons/SvgIcon';
 import DonationPageDisclaimer from 'components/donationPage/DonationPageDisclaimer';
-import { PAYMENT_SUCCESS } from 'routes';
 import { getFrequencyThankYouText } from 'utilities/parseFrequency';
 import { useAlert } from 'react-alert';
-
-export function getPaymentSuccessUrl(
-  baseUrl,
-  thankYouRedirectUrl,
-  amount,
-  emailHash,
-  frequencyDisplayValue,
-  contributorEmail,
-  pageSlug,
-  rpSlug,
-  pathname,
-  stripeClientSecret
-) {
-  // This is the URL that Stripe will send the user to if payment is successfully
-  // processed. We send users to an interstitial payment success page where we can
-  // track successful conversion in analytics, before forwarding them on to the default
-  // thank you page.
-  const paymentSuccessUrl = new URL(PAYMENT_SUCCESS, baseUrl);
-  paymentSuccessUrl.searchParams.append('next', thankYouRedirectUrl);
-  paymentSuccessUrl.searchParams.append('amount', amount);
-  paymentSuccessUrl.searchParams.append('frequency', frequencyDisplayValue);
-  // When a donation page has a custom thank you page that is off-site, we
-  // eventually next the user to that page, appending several query parameters, one
-  // of which is a `uid` parameter that org's can use to anonymously track contributors
-  // in their analytics layer without exposing raw contributor email to ad tech providers.
-  paymentSuccessUrl.searchParams.append('uid', emailHash);
-  // On other hand, our internal thank you page needs the raw value of the contributor
-  // email to display message on the page. There's no privacy concerns around sharing the
-  // email address with Stripe (they already have it) or within our site.
-  paymentSuccessUrl.searchParams.append('email', contributorEmail);
-  // The thank you page that eventually loads needs to data that is on the
-  // page model from API. We pass the `pageSlug`, and the success page will be able to use this +
-  // the `rpSlug`to request the LIVE_PAGE_DETAIL. Ideally, we'd just use the page
-  // id to this end, but at present that API endpoint requires authentication.
-  paymentSuccessUrl.searchParams.append('pageSlug', pageSlug);
-  paymentSuccessUrl.searchParams.append('rpSlug', rpSlug);
-  // We pass this along because the thank you page we eventually need to show
-  // will appear at rev-program-slug.revengine.com/page-name/thank-you if the page was served
-  // from specific page name. On other hand, if a revenue program has a default donation page
-  // set up, that page can appear at rev-program-slug.revengine.com/ (with no page), in which
-  // case, the thank-you page URL can be rev-program-slug.revengine.com/thank-you.
-  paymentSuccessUrl.searchParams.append('fromPath', pathname);
-  paymentSuccessUrl.searchParams.append('payment_intent_client_secret', stripeClientSecret);
-  return paymentSuccessUrl.href;
-}
+import { getPaymentSuccessUrl } from './stripeFns';
 
 function StripePaymentForm() {
   const {

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -47,18 +47,18 @@ function StripePaymentForm() {
     // processed. We send users to an interstitial payment success page where we can
     // track successful conversion in analytics, before forwarding them on to the default
     // thank you page.
-    const return_url = getPaymentSuccessUrl(
-      window.location.origin,
-      thank_you_redirect || '',
-      amount,
-      emailHash,
-      getFrequencyThankYouText(frequency),
-      contributorEmail,
-      pageSlug,
-      rpSlug,
-      pathname,
-      stripeClientSecret
-    );
+    const return_url = getPaymentSuccessUrl({
+      baseUrl: window.location.origin,
+      thankYouRedirectUrl: thank_you_redirect || '',
+      amount: amount,
+      emailHash: emailHash,
+      frequencyDisplayValue: getFrequencyThankYouText(frequency),
+      contributorEmail: contributorEmail,
+      pageSlug: pageSlug,
+      rpSlug: rpSlug,
+      pathName: pathname,
+      stripeClientSecret: stripeClientSecret
+    });
 
     const { error } = await stripe.confirmPayment({
       elements,

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -107,7 +107,7 @@ export async function createPaymentMethod(stripe, card, data) {
   });
 }
 
-export function getPaymentSuccessUrl(
+export function getPaymentSuccessUrl({
   baseUrl,
   thankYouRedirectUrl,
   amount,
@@ -116,9 +116,9 @@ export function getPaymentSuccessUrl(
   contributorEmail,
   pageSlug,
   rpSlug,
-  pathname,
+  pathName,
   stripeClientSecret
-) {
+}) {
   // This is the URL that Stripe will send the user to if payment is successfully
   // processed. We send users to an interstitial payment success page where we can
   // track successful conversion in analytics, before forwarding them on to the default
@@ -147,7 +147,7 @@ export function getPaymentSuccessUrl(
   // from specific page name. On other hand, if a revenue program has a default donation page
   // set up, that page can appear at rev-program-slug.revengine.com/ (with no page), in which
   // case, the thank-you page URL can be rev-program-slug.revengine.com/thank-you.
-  paymentSuccessUrl.searchParams.append('fromPath', pathname === '/' ? '' : pathname);
+  paymentSuccessUrl.searchParams.append('fromPath', pathName === '/' ? '' : pathName);
   paymentSuccessUrl.searchParams.append('payment_intent_client_secret', stripeClientSecret);
   return paymentSuccessUrl.href;
 }

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -119,7 +119,6 @@ export function getPaymentSuccessUrl({
   pathName,
   stripeClientSecret
 }) {
-  console.log(arguments);
   const missingParams = Object.fromEntries(
     Object.entries({
       baseUrl,

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -1,4 +1,5 @@
 import calculateStripeFee from 'utilities/calculateStripeFee';
+import { PAYMENT_SUCCESS } from 'routes';
 
 /******************\
  *  Process Data  *
@@ -104,4 +105,49 @@ export async function createPaymentMethod(stripe, card, data) {
     card: card,
     billing_details
   });
+}
+
+export function getPaymentSuccessUrl(
+  baseUrl,
+  thankYouRedirectUrl,
+  amount,
+  emailHash,
+  frequencyDisplayValue,
+  contributorEmail,
+  pageSlug,
+  rpSlug,
+  pathname,
+  stripeClientSecret
+) {
+  // This is the URL that Stripe will send the user to if payment is successfully
+  // processed. We send users to an interstitial payment success page where we can
+  // track successful conversion in analytics, before forwarding them on to the default
+  // thank you page.
+  const paymentSuccessUrl = new URL(PAYMENT_SUCCESS, baseUrl);
+  paymentSuccessUrl.searchParams.append('next', thankYouRedirectUrl);
+  paymentSuccessUrl.searchParams.append('amount', amount);
+  paymentSuccessUrl.searchParams.append('frequency', frequencyDisplayValue);
+  // When a donation page has a custom thank you page that is off-site, we
+  // eventually next the user to that page, appending several query parameters, one
+  // of which is a `uid` parameter that org's can use to anonymously track contributors
+  // in their analytics layer without exposing raw contributor email to ad tech providers.
+  paymentSuccessUrl.searchParams.append('uid', emailHash);
+  // On other hand, our internal thank you page needs the raw value of the contributor
+  // email to display message on the page. There's no privacy concerns around sharing the
+  // email address with Stripe (they already have it) or within our site.
+  paymentSuccessUrl.searchParams.append('email', contributorEmail);
+  // The thank you page that eventually loads needs to data that is on the
+  // page model from API. We pass the `pageSlug`, and the success page will be able to use this +
+  // the `rpSlug`to request the LIVE_PAGE_DETAIL. Ideally, we'd just use the page
+  // id to this end, but at present that API endpoint requires authentication.
+  paymentSuccessUrl.searchParams.append('pageSlug', pageSlug);
+  paymentSuccessUrl.searchParams.append('rpSlug', rpSlug);
+  // We pass this along because the thank you page we eventually need to show
+  // will appear at rev-program-slug.revengine.com/page-name/thank-you if the page was served
+  // from specific page name. On other hand, if a revenue program has a default donation page
+  // set up, that page can appear at rev-program-slug.revengine.com/ (with no page), in which
+  // case, the thank-you page URL can be rev-program-slug.revengine.com/thank-you.
+  paymentSuccessUrl.searchParams.append('fromPath', pathname === '/' ? '' : pathname);
+  paymentSuccessUrl.searchParams.append('payment_intent_client_secret', stripeClientSecret);
+  return paymentSuccessUrl.href;
 }

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -119,38 +119,26 @@ export function getPaymentSuccessUrl({
   pathName,
   stripeClientSecret
 }) {
-  if (
-    !baseUrl ||
-    !thankYouRedirectUrl ||
-    !amount ||
-    !emailHash ||
-    !frequencyDisplayValue ||
-    !contributorEmail ||
-    !pageSlug ||
-    !rpSlug ||
-    !pathName ||
-    !stripeClientSecret
-  ) {
-    throw new Error('Missing argument for payment success URL');
+  console.log(arguments);
+  const missingParams = Object.fromEntries(
+    Object.entries({
+      baseUrl,
+      thankYouRedirectUrl,
+      amount,
+      emailHash,
+      frequencyDisplayValue,
+      contributorEmail,
+      pageSlug,
+      rpSlug,
+      pathName,
+      stripeClientSecret
+    }).filter(([_, v]) => v in [undefined, null, ''])
+  );
+  if (Object.entries(missingParams).length) {
+    throw new Error(`Missing argument for: ${Object.keys(missingParams).join(', ')}`);
   }
-  // This is the URL that Stripe will send the user to if payment is successfully
-  // processed. We send users to an interstitial payment success page where we can
-  // track successful conversion in analytics, before forwarding them on to the default
-  // thank you page.
   const paymentSuccessUrl = new URL(PAYMENT_SUCCESS, baseUrl);
-  paymentSuccessUrl.search = new URLSearchParams({
-    amount,
-    pageSlug,
-    rpSlug,
-    email: contributorEmail,
-    frequency: frequencyDisplayValue,
-    fromPath: pathName === '/' ? '' : pathName,
-    next: thankYouRedirectUrl,
-    payment_intent_client_secret: stripeClientSecret,
-    uid: emailHash
-  });
-  // RE: some passed params
-  //
+  // Some notes on parameters for URL search generation below:
   // uid: maps to emailHash from function params
   //
   // When a donation page has a custom thank you page that is off-site, we
@@ -181,6 +169,16 @@ export function getPaymentSuccessUrl({
   // case, the thank-you page URL can be rev-program-slug.revengine.com/thank-you.
 
   // payment_intent_client_secret : stripeClientSecret in function params
-  paymentSuccessUrl.searchParams.append('payment_intent_client_secret', stripeClientSecret);
+  paymentSuccessUrl.search = new URLSearchParams({
+    amount,
+    pageSlug,
+    rpSlug,
+    email: contributorEmail,
+    frequency: frequencyDisplayValue,
+    fromPath: pathName === '/' ? '' : pathName,
+    next: thankYouRedirectUrl,
+    payment_intent_client_secret: stripeClientSecret,
+    uid: emailHash
+  });
   return paymentSuccessUrl.href;
 }

--- a/spa/src/components/paymentProviders/stripe/stripeFns.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.js
@@ -119,35 +119,68 @@ export function getPaymentSuccessUrl({
   pathName,
   stripeClientSecret
 }) {
+  if (
+    !baseUrl ||
+    !thankYouRedirectUrl ||
+    !amount ||
+    !emailHash ||
+    !frequencyDisplayValue ||
+    !contributorEmail ||
+    !pageSlug ||
+    !rpSlug ||
+    !pathName ||
+    !stripeClientSecret
+  ) {
+    throw new Error('Missing argument for payment success URL');
+  }
   // This is the URL that Stripe will send the user to if payment is successfully
   // processed. We send users to an interstitial payment success page where we can
   // track successful conversion in analytics, before forwarding them on to the default
   // thank you page.
   const paymentSuccessUrl = new URL(PAYMENT_SUCCESS, baseUrl);
-  paymentSuccessUrl.searchParams.append('next', thankYouRedirectUrl);
-  paymentSuccessUrl.searchParams.append('amount', amount);
-  paymentSuccessUrl.searchParams.append('frequency', frequencyDisplayValue);
+  paymentSuccessUrl.search = new URLSearchParams({
+    amount,
+    pageSlug,
+    rpSlug,
+    email: contributorEmail,
+    frequency: frequencyDisplayValue,
+    fromPath: pathName === '/' ? '' : pathName,
+    next: thankYouRedirectUrl,
+    payment_intent_client_secret: stripeClientSecret,
+    uid: emailHash
+  });
+  // RE: some passed params
+  //
+  // uid: maps to emailHash from function params
+  //
   // When a donation page has a custom thank you page that is off-site, we
   // eventually next the user to that page, appending several query parameters, one
   // of which is a `uid` parameter that org's can use to anonymously track contributors
   // in their analytics layer without exposing raw contributor email to ad tech providers.
-  paymentSuccessUrl.searchParams.append('uid', emailHash);
-  // On other hand, our internal thank you page needs the raw value of the contributor
+  //
+  // email: maps to contributorEmail from function params
+  //
+  // Our internal thank you page needs the raw value of the contributor
   // email to display message on the page. There's no privacy concerns around sharing the
   // email address with Stripe (they already have it) or within our site.
-  paymentSuccessUrl.searchParams.append('email', contributorEmail);
+
+  // pageSlug
+  //
   // The thank you page that eventually loads needs to data that is on the
   // page model from API. We pass the `pageSlug`, and the success page will be able to use this +
   // the `rpSlug`to request the LIVE_PAGE_DETAIL. Ideally, we'd just use the page
   // id to this end, but at present that API endpoint requires authentication.
-  paymentSuccessUrl.searchParams.append('pageSlug', pageSlug);
-  paymentSuccessUrl.searchParams.append('rpSlug', rpSlug);
+
+  // rpSlug: nothing special to note
+
+  // fromPath: pathName in function params
   // We pass this along because the thank you page we eventually need to show
   // will appear at rev-program-slug.revengine.com/page-name/thank-you if the page was served
   // from specific page name. On other hand, if a revenue program has a default donation page
   // set up, that page can appear at rev-program-slug.revengine.com/ (with no page), in which
   // case, the thank-you page URL can be rev-program-slug.revengine.com/thank-you.
-  paymentSuccessUrl.searchParams.append('fromPath', pathName === '/' ? '' : pathName);
+
+  // payment_intent_client_secret : stripeClientSecret in function params
   paymentSuccessUrl.searchParams.append('payment_intent_client_secret', stripeClientSecret);
   return paymentSuccessUrl.href;
 }

--- a/spa/src/components/paymentProviders/stripe/stripeFns.test.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.test.js
@@ -28,11 +28,8 @@ const fromDefaultPageParams = {
 };
 
 describe('getPaymentSuccessUrl function', () => {
-  it.each([
-    [fromPageSlugParams, ''],
-    [fromDefaultPageParams, '']
-  ])('generates the expected payment success URL,', (args, expectedUrl) => {
-    const url = getPaymentSuccessUrl(...Object.values(args));
+  it.each([[fromPageSlugParams], [fromDefaultPageParams]])('generates the expected payment success URL,', (args) => {
+    const url = getPaymentSuccessUrl(args);
     const parsed = new URL(url);
     expect(`${parsed.protocol}//${parsed.hostname}`).toEqual(args.baseUrl);
     expect(parsed.pathname).toEqual(PAYMENT_SUCCESS);

--- a/spa/src/components/paymentProviders/stripe/stripeFns.test.js
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.test.js
@@ -1,0 +1,50 @@
+import { getPaymentSuccessUrl } from './stripeFns';
+import { PAYMENT_SUCCESS } from 'routes';
+
+const fromPageSlugParams = {
+  baseUrl: 'https://my-rp.localhost',
+  thankYouRedirectUrl: 'https://www.google.com',
+  amount: '123.01',
+  emailHash: 'someEmailHash3737',
+  frequencyDisplayValue: 'month',
+  contributorEmail: 'foo@bar.com',
+  pageSlug: 'my-page',
+  rpSlug: 'my-rp',
+  pathName: '/my-page',
+  stripeClientSecret: 'shhhhh'
+};
+
+const fromDefaultPageParams = {
+  baseUrl: 'https://my-rp.localhost',
+  thankYouRedirectUrl: 'https://www.google.com',
+  amount: '123.01',
+  emailHash: 'someEmailHash3737',
+  frequencyDisplayValue: 'month',
+  contributorEmail: 'foo@bar.com',
+  pageSlug: 'my-page',
+  rpSlug: 'my-rp',
+  pathName: '/',
+  stripeClientSecret: 'shhhhh'
+};
+
+describe('getPaymentSuccessUrl function', () => {
+  it.each([
+    [fromPageSlugParams, ''],
+    [fromDefaultPageParams, '']
+  ])('generates the expected payment success URL,', (args, expectedUrl) => {
+    const url = getPaymentSuccessUrl(...Object.values(args));
+    const parsed = new URL(url);
+    expect(`${parsed.protocol}//${parsed.hostname}`).toEqual(args.baseUrl);
+    expect(parsed.pathname).toEqual(PAYMENT_SUCCESS);
+    const search = new URLSearchParams(parsed.search);
+    expect(search.get('next')).toEqual(args['thankYouRedirectUrl']);
+    expect(search.get('amount')).toEqual(args['amount']);
+    expect(search.get('frequency')).toEqual(args['frequencyDisplayValue']);
+    expect(search.get('uid')).toEqual(args.emailHash);
+    expect(search.get('email')).toEqual(args.contributorEmail);
+    expect(search.get('pageSlug')).toEqual(args.pageSlug);
+    expect(search.get('rpSlug')).toEqual(args.rpSlug);
+    expect(search.get('fromPath')).toEqual(args.pathName === '/' ? '' : args.pathName);
+    expect(search.get('payment_intent_client_secret')).toEqual(args.stripeClientSecret);
+  });
+});


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

Merge this into DEV-2183-root-branch, then deploy that to test. Once passes UAT, PR DEV-2183-root-branch into main.

#### What's this PR do?

This solves a bug identified in [DEV-2435](https://news-revenue-hub.atlassian.net/browse/DEV-2435).

The root cause of the bug had to do with how a convenience function called `getPaymentSuccessUrl` was dealing with being passed the value `'\'` for its `pathname` parameter. That parameter ultimately determines redirection behavior of the PaymentSuccess component ([see here](https://github.com/newsrevenuehub/rev-engine/blob/DEV-2183-root-branch/spa/src/components/donationPage/live/PaymentSuccess.js#L106-L117)). 

The bug narrowly could be caused by default donation pages (note that billypenn.revengine-test.org/donate does not generate the reported error, while billypenn.revengine-test.org/ does).  In the default donation page context, `getPaymentSuccessUrl` was getting passed `\` for the pathname parameter, and that was leading to erroneous redirection as observed by @x110dc 

#### Why are we doing this? How does it help us?

To release DEV-2183

#### How should this be manually tested? Please include detailed step-by-step instructions.

Make a contribution to default donation page

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2435](https://news-revenue-hub.atlassian.net/browse/DEV-2435)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No