### PR TITLE
DEV-2408: Stripe webhooks fail for subscriptions

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -289,6 +289,7 @@ class Contribution(IndexedTimeStampedModel, RoleAssignmentResourceModelMixin):
         )
         self.provider_payment_id = intent["id"]
         self.provider_client_secret_id = intent["client_secret"]
+        self.provider_customer_id = intent["customer"]
         self.save()
         return intent
 
@@ -320,6 +321,7 @@ class Contribution(IndexedTimeStampedModel, RoleAssignmentResourceModelMixin):
         )
         self.payment_provider_data = subscription
         self.provider_subscription_id = subscription["id"]
+        self.provider_customer_id = subscription["customer"]
         self.provider_client_secret_id = subscription["latest_invoice"]["payment_intent"]["client_secret"]
         self.save()
         return subscription

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -161,9 +161,9 @@ class ContributionTest(TestCase):
         ...that it returns the created payment intent, and that it saves the payment intent ID and
         client secret back to the contribution
         """
-        return_value = {"id": "fake_id", "client_secret": "fake_client_secret"}
-        mock_create_pi.return_value = return_value
         stripe_customer_id = "fake_stripe_customer_id"
+        return_value = {"id": "fake_id", "client_secret": "fake_client_secret", "customer": stripe_customer_id}
+        mock_create_pi.return_value = return_value
         metadata = {"meta": "data"}
         contributor = ContributorFactory()
         self.contribution.contributor = contributor
@@ -191,9 +191,13 @@ class ContributionTest(TestCase):
         ...that it returns the created subscription, and that it saves the right subscription data
         back to the contribution
         """
-        return_value = {"id": "fake_id", "latest_invoice": {"payment_intent": {"client_secret": "fake_client_secret"}}}
-        mock_create_subscription.return_value = return_value
         stripe_customer_id = "fake_stripe_customer_id"
+        return_value = {
+            "id": "fake_id",
+            "latest_invoice": {"payment_intent": {"client_secret": "fake_client_secret"}},
+            "customer": stripe_customer_id,
+        }
+        mock_create_subscription.return_value = return_value
         metadata = {"meta": "data"}
         contributor = ContributorFactory()
         self.contribution.contributor = contributor

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -183,6 +183,7 @@ class ContributionTest(TestCase):
         self.assertEqual(self.contribution.provider_payment_id, return_value["id"])
         self.assertEqual(self.contribution.provider_client_secret_id, return_value["client_secret"])
         self.assertEqual(payment_intent, return_value)
+        assert self.contribution.provider_customer_id == stripe_customer_id
 
     @patch("stripe.Subscription.create")
     def test_create_stripe_subscription(self, mock_create_subscription):
@@ -231,6 +232,7 @@ class ContributionTest(TestCase):
             return_value["latest_invoice"]["payment_intent"]["client_secret"],
         )
         self.assertEqual(subscription, return_value)
+        assert self.contribution.provider_customer_id == stripe_customer_id
 
     @patch("apps.emails.tasks.send_templated_email.delay")
     def test_handle_thank_you_email_when_nre_sends(self, mock_send_email):

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -894,13 +894,15 @@ class TestCreateOneTimePaymentSerializer:
 
         monkeypatch.setattr("apps.contributions.serializers.make_bad_actor_request", mock_get_bad_actor)
         mock_create_stripe_customer = Mock()
-        mock_create_stripe_customer.return_value = {"id": "some id"}
+        fake_customer_id = "fake-customer-id"
+        mock_create_stripe_customer.return_value = {"id": fake_customer_id}
         monkeypatch.setattr("apps.contributions.models.Contributor.create_stripe_customer", mock_create_stripe_customer)
         mock_create_stripe_one_time_payment_intent = Mock()
         client_secret = "shhhhhhh!"
         mock_create_stripe_one_time_payment_intent.return_value = {
             "id": "some payment intent id",
             "client_secret": client_secret,
+            "customer": fake_customer_id,
         }
         monkeypatch.setattr(
             "apps.contributions.models.stripe.PaymentIntent.create", mock_create_stripe_one_time_payment_intent
@@ -1047,13 +1049,15 @@ class TestCreateRecurringPaymentSerializer:
 
         monkeypatch.setattr("apps.contributions.serializers.make_bad_actor_request", mock_get_bad_actor)
         mock_create_stripe_customer = Mock()
-        mock_create_stripe_customer.return_value = {"id": "some id"}
+        fake_customer_id = "fake-customer-id"
+        mock_create_stripe_customer.return_value = {"id": fake_customer_id}
         monkeypatch.setattr("apps.contributions.models.Contributor.create_stripe_customer", mock_create_stripe_customer)
         mock_create_stripe_subscription = Mock()
         client_secret = "shhhhhhh!"
         mock_create_stripe_subscription.return_value = {
             "id": "some payment intent id",
             "latest_invoice": {"payment_intent": {"client_secret": client_secret}},
+            "customer": fake_customer_id,
         }
         monkeypatch.setattr("apps.contributions.models.stripe.Subscription.create", mock_create_stripe_subscription)
         request = APIRequestFactory(HTTP_REFERER="https://www.google.com").post("", {}, format="json")

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -949,13 +949,17 @@ def stripe_create_customer_response():
 
 
 @pytest.fixture
-def stripe_create_payment_intent_response():
-    return {"id": "some-id", "client_secret": "Shhhhhh!!!"}
+def stripe_create_payment_intent_response(stripe_create_customer_response):
+    return {"id": "some-id", "client_secret": "Shhhhhh!!!", "customer": stripe_create_customer_response["id"]}
 
 
 @pytest.fixture
-def stripe_create_subscription_response():
-    return {"id": "some-id", "latest_invoice": {"payment_intent": {"client_secret": "Shhhhhh!!!"}}}
+def stripe_create_subscription_response(stripe_create_customer_response):
+    return {
+        "id": "some-id",
+        "latest_invoice": {"payment_intent": {"client_secret": "Shhhhhh!!!"}},
+        "customer": stripe_create_customer_response["id"],
+    }
 
 
 @pytest.mark.django_db

--- a/apps/contributions/tests/test_webhooks.py
+++ b/apps/contributions/tests/test_webhooks.py
@@ -125,7 +125,9 @@ class PaymentIntentWebhooksTest(APITestCase):
     def test_webhook_view_invalid_contribution(self, mock_logger, *args):
         self._create_contribution(payment_intent_id="abcd")
         self._run_webhook_view_with_request()
-        self.assertEqual("Could not find contribution matching provider_payment_id", mock_logger.info.call_args[0][0])
+        self.assertEqual(
+            "Could not find contribution matching provider_payment_id", mock_logger.exception.call_args[0][0]
+        )
 
     def test_payment_intent_canceled_webhook(self):
         payment_intent_id = "1234"

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -168,7 +168,7 @@ def process_stripe_webhook_view(request):
     except ValueError:
         logger.exception()
     except Contribution.DoesNotExist:
-        logger.info("Could not find contribution matching provider_payment_id", exc_info=True)
+        logger.exception("Could not find contribution matching provider_payment_id")
 
     return Response(status=status.HTTP_200_OK)
 

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 class StripeWebhookProcessor:
     def __init__(self, event):
+        logger.info("StripeWebhookProcessor called with %s", event)
         self.event = event
         self.obj_data = self.event.data["object"]
 

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -15,6 +15,7 @@ class StripeWebhookProcessor:
         self.obj_data = self.event.data["object"]
 
     def get_contribution_from_event(self):
+        logger.info(self.obj_data)
         if self.obj_data["object"] == "subscription":
             return Contribution.objects.get(provider_subscription_id=self.obj_data["id"])
         else:

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -15,13 +15,10 @@ class StripeWebhookProcessor:
         self.obj_data = self.event.data["object"]
 
     def get_contribution_from_event(self):
-        try:
+        if self.obj_data["object"] == "subscription":
+            return Contribution.objects.get(provider_subscription_id=self.obj_data["id"])
+        else:
             return Contribution.objects.get(provider_payment_id=self.obj_data["id"])
-        except Contribution.DoesNotExist as e:
-            if customer_id := self.obj_data.get("customer"):
-                # This is fine as long as we continue to generate a unique customer per charge.
-                return Contribution.objects.get(provider_customer_id=customer_id)
-            raise Contribution.DoesNotExist(e)
 
     def process(self):
         logger.info('Processing Stripe Event of type "%s"', self.event.type)

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 class StripeWebhookProcessor:
     def __init__(self, event):
+        logger.info("StripeWebhookProcessor initialized with event data: %s", event)
         self.event = event
         self.obj_data = self.event.data["object"]
 

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -21,12 +21,12 @@ class StripeWebhookProcessor:
         elif event_type == "payment_intent":
             try:
                 return Contribution.objects.get(provider_payment_id=self.obj_data["id"])
-            except Contribution.DoesNotExist as e:
+            except Contribution.DoesNotExist:
                 if customer_id := self.obj_data.get("customer"):
                     # This is fine as long as we continue to generate a unique customer per charge.
                     return Contribution.objects.get(provider_customer_id=customer_id)
                 else:
-                    raise e
+                    raise
 
     def process(self):
         logger.info('Processing Stripe Event of type "%s"', self.event.type)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

This fixes a bug discovered in UAT for DEV-2183. It should be merged into DEV-2183-root-branch, and that branch will eventually be merged into main.

#### What's this PR do?

This PR fixes a bug that was causing Stripe webhooks to fail for recurring contributions ("Subscriptions" in Stripe lingo).


The root cause of the bug was that we were not saving the Stripe Customer ID back on to the NRE contribution after creating a Stripe PaymentIntent or Subscription. In our webhooks code, for subscriptions, we were attempting to retrieve by customer ID instead of subscription ID.

To solve for this, this PR changes the contribution retrieval behavior of our webhook so that it searches contributions by Stripe subscription ID for subscriptions. It also updates the payment intent and subscription creation methods in apps.contributions.models.Contribution so that the customer id gets written back to the contribution (even though the customer id is no longer relevant for the webhook in question).

#### Why are we doing this? How does it help us?

Fixes a bug that stops us from shipping DEV-2183.

#### How should this be manually tested? Please include detailed step-by-step instructions.

Create a recurring contribution ([here](https://billypenn-dev-2408.revengine-review.org/donate)), then check in NRH admin ([here](https://dev-2408.revengine-review.org/nrhadmin/contributions/)) and its status should be "paid".

In addition to fixing bug, changes a .info to a .exception so we get sentry errors when webhooks don't match with contributions.


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Tests have been updated

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-2408 | Webhooks are broken for Subscriptions in DEV-2183](https://news-revenue-hub.atlassian.net/jira/software/c/projects/DEV/boards/3?modal=detail&selectedIssue=DEV-2408)
- [DEV-2183](https://news-revenue-hub.atlassian.net/browse/DEV-2183)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No