### PR TITLE
DEV-2387: Add info tooltip to Tax Status field, refactor components

### DIFF
--- a/spa/src/components/account/Profile/InfoTooltip.js
+++ b/spa/src/components/account/Profile/InfoTooltip.js
@@ -1,7 +1,7 @@
 import { ButtonBase, ClickAwayListener } from '@material-ui/core';
+import PropTypes from 'prop-types';
 import { Tooltip } from 'components/base';
 import useModal from 'hooks/useModal';
-import PropTypes from 'prop-types';
 import { Icon } from './InfoTooltip.styled';
 
 export const InfoTooltip = (props) => {

--- a/spa/src/components/account/Profile/InfoTooltip.js
+++ b/spa/src/components/account/Profile/InfoTooltip.js
@@ -2,7 +2,7 @@ import { ButtonBase, ClickAwayListener } from '@material-ui/core';
 import { Tooltip } from 'components/base';
 import useModal from 'hooks/useModal';
 import PropTypes from 'prop-types';
-import * as S from './InfoTooltip.styled';
+import { Icon } from './InfoTooltip.styled';
 
 export const InfoTooltip = (props) => {
   const { buttonLabel, ...other } = props;
@@ -21,7 +21,7 @@ export const InfoTooltip = (props) => {
           {...other}
         >
           <ButtonBase aria-label={buttonLabel} disableRipple disableTouchRipple onClick={handleOpen}>
-            <S.Icon />
+            <Icon />
           </ButtonBase>
         </Tooltip>
       </span>

--- a/spa/src/components/account/Profile/InfoTooltip.js
+++ b/spa/src/components/account/Profile/InfoTooltip.js
@@ -1,0 +1,35 @@
+import { ButtonBase, ClickAwayListener } from '@material-ui/core';
+import { Tooltip } from 'components/base';
+import { useState } from 'react';
+import * as S from './InfoTooltip.styled';
+
+export const InfoTooltip = (props) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <span className={props.className}>
+        <Tooltip
+          disableFocusListener
+          disableHoverListener
+          disableTouchListener
+          onClose={() => setOpen(false)}
+          open={open}
+          PopperProps={{
+            disablePortal: true
+          }}
+          tooltipWidth={160}
+          {...props}
+        >
+          <ButtonBase aria-label="Help" disableRipple disableTouchRipple onClick={() => setOpen(true)}>
+            <S.Icon />
+          </ButtonBase>
+        </Tooltip>
+      </span>
+    </ClickAwayListener>
+  );
+};
+
+InfoTooltip.propTypes = Tooltip.propTypes;
+
+export default InfoTooltip;

--- a/spa/src/components/account/Profile/InfoTooltip.js
+++ b/spa/src/components/account/Profile/InfoTooltip.js
@@ -1,26 +1,26 @@
 import { ButtonBase, ClickAwayListener } from '@material-ui/core';
-import PropTypes from 'prop-types';
 import { Tooltip } from 'components/base';
-import { useState } from 'react';
+import useModal from 'hooks/useModal';
+import PropTypes from 'prop-types';
 import * as S from './InfoTooltip.styled';
 
 export const InfoTooltip = (props) => {
   const { buttonLabel, ...other } = props;
-  const [open, setOpen] = useState(false);
+  const { handleClose, handleOpen, open } = useModal();
 
   return (
-    <ClickAwayListener onClickAway={() => setOpen(false)}>
+    <ClickAwayListener onClickAway={handleClose}>
       <span className={props.className}>
         <Tooltip
           disableFocusListener
           disableHoverListener
           disableTouchListener
-          onClose={() => setOpen(false)}
+          onClose={handleClose}
           open={open}
           tooltipWidth={160}
           {...other}
         >
-          <ButtonBase aria-label={buttonLabel} disableRipple disableTouchRipple onClick={() => setOpen(true)}>
+          <ButtonBase aria-label={buttonLabel} disableRipple disableTouchRipple onClick={handleOpen}>
             <S.Icon />
           </ButtonBase>
         </Tooltip>

--- a/spa/src/components/account/Profile/InfoTooltip.js
+++ b/spa/src/components/account/Profile/InfoTooltip.js
@@ -1,9 +1,11 @@
 import { ButtonBase, ClickAwayListener } from '@material-ui/core';
+import PropTypes from 'prop-types';
 import { Tooltip } from 'components/base';
 import { useState } from 'react';
 import * as S from './InfoTooltip.styled';
 
 export const InfoTooltip = (props) => {
+  const { buttonLabel, ...other } = props;
   const [open, setOpen] = useState(false);
 
   return (
@@ -15,13 +17,10 @@ export const InfoTooltip = (props) => {
           disableTouchListener
           onClose={() => setOpen(false)}
           open={open}
-          PopperProps={{
-            disablePortal: true
-          }}
           tooltipWidth={160}
-          {...props}
+          {...other}
         >
-          <ButtonBase aria-label="Help" disableRipple disableTouchRipple onClick={() => setOpen(true)}>
+          <ButtonBase aria-label={buttonLabel} disableRipple disableTouchRipple onClick={() => setOpen(true)}>
             <S.Icon />
           </ButtonBase>
         </Tooltip>
@@ -30,6 +29,9 @@ export const InfoTooltip = (props) => {
   );
 };
 
-InfoTooltip.propTypes = Tooltip.propTypes;
+InfoTooltip.propTypes = {
+  buttonLabel: PropTypes.string.isRequired,
+  ...Tooltip.propTypes
+};
 
 export default InfoTooltip;

--- a/spa/src/components/account/Profile/InfoTooltip.styled.js
+++ b/spa/src/components/account/Profile/InfoTooltip.styled.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import { InfoOutlined } from '@material-ui/icons';
+
+export const Icon = styled(InfoOutlined)`
+  && {
+    height: 18px;
+    width: 18px;
+  }
+`;

--- a/spa/src/components/account/Profile/InfoTooltip.test.js
+++ b/spa/src/components/account/Profile/InfoTooltip.test.js
@@ -35,9 +35,18 @@ describe('InfoTooltip', () => {
     await waitFor(() => expect(screen.queryByText('mock-tooltip-text')).not.toBeInTheDocument());
   });
 
-  it('is accessible', async () => {
-    const { container } = tree();
+  describe('accessibility', () => {
+    it('is accessible when the tooltip is not open', async () => {
+      const { container } = tree();
 
-    expect(await axe(container)).toHaveNoViolations();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('is accessible when the tooltip is open', async () => {
+      const { container } = tree();
+
+      userEvent.click(screen.getByRole('button', { name: 'Help' }));
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 });

--- a/spa/src/components/account/Profile/InfoTooltip.test.js
+++ b/spa/src/components/account/Profile/InfoTooltip.test.js
@@ -1,0 +1,43 @@
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { render, screen, waitFor } from 'test-utils';
+import InfoTooltip from './InfoTooltip';
+
+function tree(props) {
+  return render(<InfoTooltip title="mock-tooltip-text" {...props} />);
+}
+
+describe('InfoTooltip', () => {
+  it('displays a button labeled Help', () => {
+    tree();
+    expect(screen.getByRole('button', { name: 'Help' })).toBeVisible();
+  });
+
+  it('displays the tooltip when the button is clicked', async () => {
+    tree({ title: 'test tooltip' });
+    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    await waitFor(() => expect(screen.getByText('test tooltip')).toBeVisible());
+  });
+
+  it('keeps the tooltip open if the button is clicked repeatedly', async () => {
+    tree();
+    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    await waitFor(() => expect(screen.getByText('mock-tooltip-text')).toBeVisible());
+    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    expect(screen.getByText('mock-tooltip-text')).toBeVisible();
+  });
+
+  it('hides the tooltip if the user clicks elsewhere', async () => {
+    tree();
+    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    await waitFor(() => expect(screen.getByText('mock-tooltip-text')).toBeVisible());
+    userEvent.click(document.body);
+    await waitFor(() => expect(screen.queryByText('mock-tooltip-text')).not.toBeInTheDocument());
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/account/Profile/InfoTooltip.test.js
+++ b/spa/src/components/account/Profile/InfoTooltip.test.js
@@ -4,32 +4,32 @@ import { render, screen, waitFor } from 'test-utils';
 import InfoTooltip from './InfoTooltip';
 
 function tree(props) {
-  return render(<InfoTooltip title="mock-tooltip-text" {...props} />);
+  return render(<InfoTooltip buttonLabel="mock-label" title="mock-tooltip-text" {...props} />);
 }
 
 describe('InfoTooltip', () => {
-  it('displays a button labeled Help', () => {
-    tree();
-    expect(screen.getByRole('button', { name: 'Help' })).toBeVisible();
+  it('displays a button labeled with the buttonLabel prop', () => {
+    tree({ buttonLabel: 'test label' });
+    expect(screen.getByRole('button', { name: 'test label' })).toBeVisible();
   });
 
   it('displays the tooltip when the button is clicked', async () => {
     tree({ title: 'test tooltip' });
-    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    userEvent.click(screen.getByRole('button', { name: 'mock-label' }));
     await waitFor(() => expect(screen.getByText('test tooltip')).toBeVisible());
   });
 
   it('keeps the tooltip open if the button is clicked repeatedly', async () => {
     tree();
-    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    userEvent.click(screen.getByRole('button', { name: 'mock-label' }));
     await waitFor(() => expect(screen.getByText('mock-tooltip-text')).toBeVisible());
-    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    userEvent.click(screen.getByRole('button', { name: 'mock-label' }));
     expect(screen.getByText('mock-tooltip-text')).toBeVisible();
   });
 
   it('hides the tooltip if the user clicks elsewhere', async () => {
     tree();
-    userEvent.click(screen.getByRole('button', { name: 'Help' }));
+    userEvent.click(screen.getByRole('button', { name: 'mock-label' }));
     await waitFor(() => expect(screen.getByText('mock-tooltip-text')).toBeVisible());
     userEvent.click(document.body);
     await waitFor(() => expect(screen.queryByText('mock-tooltip-text')).not.toBeInTheDocument());
@@ -45,7 +45,7 @@ describe('InfoTooltip', () => {
     it('is accessible when the tooltip is open', async () => {
       const { container } = tree();
 
-      userEvent.click(screen.getByRole('button', { name: 'Help' }));
+      userEvent.click(screen.getByRole('button', { name: 'mock-label' }));
       expect(await axe(container)).toHaveNoViolations();
     });
   });

--- a/spa/src/components/account/Profile/Profile.js
+++ b/spa/src/components/account/Profile/Profile.js
@@ -19,7 +19,7 @@ import { useConfigureAnalytics } from 'components/analytics';
 import ProfileForm from './ProfileForm';
 
 function Profile() {
-  const { open, handleClose } = useModal(true);
+  const { open } = useModal(true);
   const history = useHistory();
   const [profileState, dispatch] = useReducer(fetchReducer, initialState);
   const { user } = useUserContext();

--- a/spa/src/components/account/Profile/Profile.js
+++ b/spa/src/components/account/Profile/Profile.js
@@ -55,12 +55,7 @@ function Profile() {
   const formSubmitErrors = profileState?.errors?.length && 'An Error Occurred';
 
   return (
-    <S.Modal
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="profile-modal-title"
-      data-testid="finalize-profile-modal"
-    >
+    <S.Modal open={open} aria-labelledby="profile-modal-title" data-testid="finalize-profile-modal">
       <S.Profile>
         <S.h1 id="profile-modal-title">Let's Customize Your Account</S.h1>
         <S.Description>Help us create your personalized experience!</S.Description>

--- a/spa/src/components/account/Profile/ProfileForm.js
+++ b/spa/src/components/account/Profile/ProfileForm.js
@@ -70,7 +70,10 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
             </TextField>
           )}
         />
-        <S.TaxStatusInfoTooltip title="Your tax status determines the contribution fees charged through Stripe." />
+        <S.TaxStatusInfoTooltip
+          buttonLabel="Help for Company Tax Status"
+          title="Your tax status determines the contribution fees charged through Stripe."
+        />
       </S.TaxStatusContainer>
       <S.FillRow>
         <Button disabled={disabled} fullWidth type="submit">

--- a/spa/src/components/account/Profile/ProfileForm.js
+++ b/spa/src/components/account/Profile/ProfileForm.js
@@ -1,7 +1,7 @@
 import { Button, TextField } from 'components/base';
 import PropTypes from 'prop-types';
 import { Controller, useForm } from 'react-hook-form';
-import * as S from './ProfileForm.styled';
+import { FieldLabelOptional, FillRow, Form, TaxStatusContainer, TaxStatusInfoTooltip } from './ProfileForm.styled';
 
 function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
   const { control, handleSubmit, watch } = useForm();
@@ -15,7 +15,7 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
     onProfileSubmit(formData);
   };
   return (
-    <S.Form onSubmit={handleSubmit(onSubmit)} data-testid="finalize-profile-form">
+    <Form onSubmit={handleSubmit(onSubmit)} data-testid="finalize-profile-form">
       <Controller
         name="firstName"
         control={control}
@@ -28,7 +28,7 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
         defaultValue=""
         render={({ field }) => <TextField id="profile-last" label="Last Name" {...field} />}
       />
-      <S.FillRow>
+      <FillRow>
         <Controller
           name="jobTitle"
           control={control}
@@ -39,23 +39,23 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
               fullWidth
               label={
                 <>
-                  Job Title <S.FieldLabelOptional>Optional</S.FieldLabelOptional>
+                  Job Title <FieldLabelOptional>Optional</FieldLabelOptional>
                 </>
               }
               {...field}
             />
           )}
         />
-      </S.FillRow>
-      <S.FillRow>
+      </FillRow>
+      <FillRow>
         <Controller
           name="companyName"
           control={control}
           defaultValue=""
           render={({ field }) => <TextField fullWidth id="profile-company-name" label="Company Name" {...field} />}
         />
-      </S.FillRow>
-      <S.TaxStatusContainer>
+      </FillRow>
+      <TaxStatusContainer>
         <Controller
           name="companyTaxStatus"
           control={control}
@@ -70,17 +70,17 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
             </TextField>
           )}
         />
-        <S.TaxStatusInfoTooltip
+        <TaxStatusInfoTooltip
           buttonLabel="Help for Company Tax Status"
           title="Your tax status determines the contribution fees charged through Stripe."
         />
-      </S.TaxStatusContainer>
-      <S.FillRow>
+      </TaxStatusContainer>
+      <FillRow>
         <Button disabled={disabled} fullWidth type="submit">
           Finalize Account
         </Button>
-      </S.FillRow>
-    </S.Form>
+      </FillRow>
+    </Form>
   );
 }
 

--- a/spa/src/components/account/Profile/ProfileForm.js
+++ b/spa/src/components/account/Profile/ProfileForm.js
@@ -1,19 +1,10 @@
-import { useForm } from 'react-hook-form';
+import { Button, TextField } from 'components/base';
 import PropTypes from 'prop-types';
-
-import * as F from './ProfileForm.styled';
-import * as S from 'components/account/Account.styled';
-import * as P from './Profile.styled';
-import { KeyboardArrowDown } from '@material-ui/icons';
+import { Controller, useForm } from 'react-hook-form';
+import * as S from './ProfileForm.styled';
 
 function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    watch
-  } = useForm();
-
+  const { control, handleSubmit, watch } = useForm();
   const firstName = watch('firstName', '');
   const lastName = watch('lastName', '');
   const companyName = watch('companyName', '');
@@ -23,103 +14,70 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
   const onSubmit = (formData) => {
     onProfileSubmit(formData);
   };
-
   return (
-    <form onSubmit={handleSubmit(onSubmit)} data-testid="finalize-profile-form">
-      <P.Row>
-        <P.Column>
-          <S.InputLabel hasError={errors.firstName} htmlFor="firstName">
-            First Name
-          </S.InputLabel>
-          <S.InputOuter hasError={errors.firstName}>
-            <input
-              id="firstName"
-              name="firstName"
-              {...register('firstName')}
-              type="text"
-              status={errors.firstName}
-              data-testid="first-name"
-            />
-          </S.InputOuter>
-          {errors.firstName ? <S.Message role="error">{errors.firstName.message}</S.Message> : <S.MessageSpacer />}
-        </P.Column>
-        <P.Column>
-          <S.InputLabel hasError={errors.lastName} htmlFor="lastName">
-            Last Name
-          </S.InputLabel>
-          <S.InputOuter hasError={errors.lastName}>
-            <input
-              id="lastName"
-              name="lastName"
-              {...register('lastName')}
-              type="text"
-              status={errors.lastName}
-              data-testid="last-name"
-            />
-          </S.InputOuter>
-          {errors.lastName ? <S.Message role="error">{errors.lastName.message}</S.Message> : <S.MessageSpacer />}
-        </P.Column>
-      </P.Row>
-
-      <S.InputLabel hasError={errors.jobTitle} htmlFor="jobTitle">
-        Job Title <F.OptionalLabel>Optional</F.OptionalLabel>
-      </S.InputLabel>
-      <S.InputOuter hasError={errors.jobTitle}>
-        <input
-          id="jobTitle"
+    <S.Form onSubmit={handleSubmit(onSubmit)} data-testid="finalize-profile-form">
+      <Controller
+        name="firstName"
+        control={control}
+        defaultValue=""
+        render={({ field }) => <TextField id="profile-first" label="First Name" {...field} />}
+      />
+      <Controller
+        name="lastName"
+        control={control}
+        defaultValue=""
+        render={({ field }) => <TextField id="profile-last" label="Last Name" {...field} />}
+      />
+      <S.FillRow>
+        <Controller
           name="jobTitle"
-          {...register('jobTitle')}
-          type="text"
-          status={errors.jobTitle}
-          data-testid="job-title"
+          control={control}
+          defaultValue=""
+          render={({ field }) => (
+            <TextField
+              id="profile-job-title"
+              fullWidth
+              label={
+                <>
+                  Job Title <S.FieldLabelOptional>Optional</S.FieldLabelOptional>
+                </>
+              }
+              {...field}
+            />
+          )}
         />
-      </S.InputOuter>
-      {errors.jobTitle ? <S.Message role="error">{errors.jobTitle.message}</S.Message> : <S.MessageSpacer />}
-      <S.InputLabel hasError={errors.companyName} htmlFor="companyName">
-        Company Name
-      </S.InputLabel>
-      <S.InputOuter hasError={errors.companyName}>
-        <input
-          id="companyName"
+      </S.FillRow>
+      <S.FillRow>
+        <Controller
           name="companyName"
-          {...register('companyName')}
-          type="text"
-          status={errors.companyName}
-          data-testid="company-name"
+          control={control}
+          defaultValue=""
+          render={({ field }) => <TextField fullWidth id="profile-company-name" label="Company Name" {...field} />}
         />
-      </S.InputOuter>
-      {errors.companyName ? <S.Message role="error">{errors.companyName.message}</S.Message> : <S.MessageSpacer />}
-
-      <S.InputLabel hasError={errors.companyTaxStatus} htmlFor="companyTaxStatus">
-        Company Tax Status
-      </S.InputLabel>
-      <S.InputOuter hasError={errors.companyTaxStatus}>
-        <P.Select
-          id="companyTaxStatus"
+      </S.FillRow>
+      <S.TaxStatusContainer>
+        <Controller
           name="companyTaxStatus"
-          {...register('companyTaxStatus')}
-          status={errors.companyTaxStatus}
-          data-testid="tax-status"
-        >
-          <option disabled={companyTaxStatus !== ''} value="">
-            Please select
-          </option>
-          <option value="nonprofit">Non-profit</option>
-          <option value="for-profit">For-profit</option>
-        </P.Select>
-        <P.SelectIcon aria-hidden>
-          <KeyboardArrowDown />
-        </P.SelectIcon>
-      </S.InputOuter>
-      {errors.companyTaxStatus ? (
-        <S.Message role="error">{errors.companyTaxStatus.message}</S.Message>
-      ) : (
-        <S.MessageSpacer />
-      )}
-      <S.Submit type="submit" disabled={disabled} name="Finalize Account">
-        Finalize Account
-      </S.Submit>
-    </form>
+          control={control}
+          defaultValue=""
+          render={({ field }) => (
+            <TextField fullWidth id="profile-company-tax-status" label="Company Tax Status" {...field} select>
+              <option disabled={companyTaxStatus !== ''} value="">
+                Select your status
+              </option>
+              <option value="nonprofit">Non-profit</option>
+              <option value="for-profit">For-profit</option>
+            </TextField>
+          )}
+        />
+        <S.TaxStatusInfoTooltip title="Your tax status determines the contribution fees charged through Stripe." />
+      </S.TaxStatusContainer>
+      <S.FillRow>
+        <Button disabled={disabled} fullWidth type="submit">
+          Finalize Account
+        </Button>
+      </S.FillRow>
+    </S.Form>
   );
 }
 

--- a/spa/src/components/account/Profile/ProfileForm.js
+++ b/spa/src/components/account/Profile/ProfileForm.js
@@ -4,11 +4,19 @@ import { Controller, useForm } from 'react-hook-form';
 import { FieldLabelOptional, FillRow, Form, TaxStatusContainer, TaxStatusInfoTooltip } from './ProfileForm.styled';
 
 function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
-  const { control, handleSubmit, watch } = useForm();
-  const firstName = watch('firstName', '');
-  const lastName = watch('lastName', '');
-  const companyName = watch('companyName', '');
-  const companyTaxStatus = watch('companyTaxStatus', '');
+  const { control, handleSubmit, watch } = useForm({
+    defaultValues: {
+      companyName: '',
+      companyTaxStatus: '',
+      firstName: '',
+      jobTitle: '',
+      lastName: ''
+    }
+  });
+  const firstName = watch('firstName');
+  const lastName = watch('lastName');
+  const companyName = watch('companyName');
+  const companyTaxStatus = watch('companyTaxStatus');
   const disabled = disabledProp || !firstName || !lastName || !companyName || !companyTaxStatus;
 
   const onSubmit = (formData) => {
@@ -19,20 +27,17 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
       <Controller
         name="firstName"
         control={control}
-        defaultValue=""
         render={({ field }) => <TextField id="profile-first" label="First Name" {...field} />}
       />
       <Controller
         name="lastName"
         control={control}
-        defaultValue=""
         render={({ field }) => <TextField id="profile-last" label="Last Name" {...field} />}
       />
       <FillRow>
         <Controller
           name="jobTitle"
           control={control}
-          defaultValue=""
           render={({ field }) => (
             <TextField
               id="profile-job-title"
@@ -51,7 +56,6 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
         <Controller
           name="companyName"
           control={control}
-          defaultValue=""
           render={({ field }) => <TextField fullWidth id="profile-company-name" label="Company Name" {...field} />}
         />
       </FillRow>
@@ -59,7 +63,6 @@ function ProfileForm({ disabled: disabledProp, onProfileSubmit }) {
         <Controller
           name="companyTaxStatus"
           control={control}
-          defaultValue=""
           render={({ field }) => (
             <TextField fullWidth id="profile-company-tax-status" label="Company Tax Status" {...field} select>
               <option disabled={companyTaxStatus !== ''} value="">

--- a/spa/src/components/account/Profile/ProfileForm.styled.js
+++ b/spa/src/components/account/Profile/ProfileForm.styled.js
@@ -1,8 +1,29 @@
 import styled from 'styled-components';
+import InfoTooltip from './InfoTooltip';
 
-export const OptionalLabel = styled('span')`
-  color: rgba(112, 112, 112);
+export const Form = styled('form')`
+  display: grid;
+  gap: 25px;
+  grid-template-columns: 1fr 1fr;
+`;
+
+export const FieldLabelOptional = styled('span')`
+  color: rgb(112, 112, 112);
   font-style: italic;
   font-weight: normal;
   padding-left: 8px;
+`;
+
+export const FillRow = styled('div')`
+  grid-column: 1 / span 2;
+`;
+
+export const TaxStatusContainer = styled('div')`
+  position: relative;
+`;
+
+export const TaxStatusInfoTooltip = styled(InfoTooltip)`
+  position: absolute;
+  top: 0;
+  right: 0;
 `;

--- a/spa/src/components/base/Button/Button.js
+++ b/spa/src/components/base/Button/Button.js
@@ -31,9 +31,7 @@ const StyledMuiButton = styled(MuiButton)`
 /**
  * @see https://v4.mui.com/api/button/
  */
-export const Button = forwardRef((props, ref) => (
-  <StyledMuiButton disableFocusRipple disableRipple ref={ref} variant="contained" {...props} />
-));
+export const Button = forwardRef((props, ref) => <StyledMuiButton ref={ref} variant="contained" {...props} />);
 
 Button.propTypes = MuiButton.propTypes;
 

--- a/spa/src/components/base/Button/Button.js
+++ b/spa/src/components/base/Button/Button.js
@@ -1,0 +1,40 @@
+import { Button as MuiButton } from '@material-ui/core';
+import { forwardRef } from 'react';
+import styled from 'styled-components';
+
+const StyledMuiButton = styled(MuiButton)`
+  && {
+    background-color: rgb(245, 255, 117);
+    box-shadow: 0px 0.3px 0.5px rgba(0, 0, 0, 0.1), 0px 2px 4px rgba(0, 0, 0, 0.2);
+    border: 1px solid rgb(230, 238, 132);
+    padding: 16px;
+
+    .MuiButton-label {
+      color: rgb(48, 36, 54);
+      font: 600 14px Roboto, sans-serif;
+    }
+  }
+
+  &&:hover {
+    background-color: rgb(245, 255, 117);
+  }
+
+  &&.Mui-disabled {
+    background-color: rgb(230, 238, 132);
+
+    .MuiButton-label {
+      color: rgb(138, 127, 143);
+    }
+  }
+`;
+
+/**
+ * @see https://v4.mui.com/api/button/
+ */
+export const Button = forwardRef((props, ref) => (
+  <StyledMuiButton disableFocusRipple disableRipple ref={ref} variant="contained" {...props} />
+));
+
+Button.propTypes = MuiButton.propTypes;
+
+export default Button;

--- a/spa/src/components/base/Button/Button.stories.js
+++ b/spa/src/components/base/Button/Button.stories.js
@@ -1,0 +1,25 @@
+import Button from './Button';
+
+const ButtonDemo = (props) => {
+  const { label, ...other } = props;
+
+  return <Button {...other}>{label}</Button>;
+};
+
+export default {
+  component: ButtonDemo,
+  title: 'Base/Button',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A MUI-based button. See [the API](https://v4.mui.com/api/button/) for more details.'
+      }
+    }
+  }
+};
+
+export const Default = ButtonDemo.bind({});
+Default.args = { label: 'Hello World' };
+
+export const Disabled = ButtonDemo.bind({});
+Disabled.args = { disabled: true, label: 'Hello World' };

--- a/spa/src/components/base/Button/Button.test.js
+++ b/spa/src/components/base/Button/Button.test.js
@@ -1,0 +1,20 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import Button from './Button';
+
+function tree(props) {
+  return render(<Button {...props}>mock-button-label</Button>);
+}
+
+describe('Button', () => {
+  it('displays a button', () => {
+    tree();
+    expect(screen.getByRole('button', { name: 'mock-button-label' })).toBeVisible();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/TextField/TextField.js
+++ b/spa/src/components/base/TextField/TextField.js
@@ -1,0 +1,89 @@
+import { TextField as MuiTextField } from '@material-ui/core';
+import { KeyboardArrowDown } from '@material-ui/icons';
+import { forwardRef } from 'react';
+import styled from 'styled-components';
+
+const StyledMuiTextField = styled(MuiTextField)`
+  && {
+    .MuiFormHelperText-root {
+      margin-top: 4px;
+
+      &.Mui-error {
+        background: rgba(200, 32, 63, 0.16);
+        border-radius: 2px;
+        color: rgb(60, 60, 60);
+        font-size: 12px;
+        padding: 4px;
+      }
+    }
+
+    .MuiInputLabel-shrink {
+      color: rgb(40, 40, 40);
+      font: 600 16px Roboto, sans-serif;
+      /*
+      MUI applies an absolute position and transform to shrink the label, but we
+      want it to look normal.
+      */
+      position: static;
+      transform: none;
+
+      &.Mui-error {
+        color: rgb(200, 32, 63);
+      }
+    }
+
+    .MuiInput-formControl {
+      margin-top: 6px;
+    }
+
+    .MuiInput-input {
+      border: 1.5px solid rgb(196, 196, 196);
+      border-radius: 4px;
+      font-size: 14px;
+      padding: 12px 16px;
+
+      &:focus {
+        border-color: rgb(0, 191, 223);
+      }
+    }
+
+    .Mui-error .MuiInput-input {
+      border-color: rgb(200, 32, 63);
+    }
+
+    .MuiSelect-icon {
+      right: 4px;
+    }
+
+    /* Disable focused state appearance changes. */
+
+    .MuiInput-underline::before,
+    .MuiInput-underline::after {
+      display: none;
+    }
+
+    .MuiSelect-select:focus {
+      background: none;
+    }
+  }
+`;
+
+/**
+ * @see https://v4.mui.com/api/text-field/
+ */
+export const TextField = forwardRef((props, ref) => (
+  <StyledMuiTextField
+    InputLabelProps={{ shrink: true }}
+    SelectProps={{
+      native: true,
+      IconComponent: KeyboardArrowDown
+    }}
+    ref={ref}
+    variant="standard"
+    {...props}
+  />
+));
+
+TextField.propTypes = MuiTextField.propTypes;
+
+export default TextField;

--- a/spa/src/components/base/TextField/TextField.stories.js
+++ b/spa/src/components/base/TextField/TextField.stories.js
@@ -1,0 +1,53 @@
+import TextField from './TextField';
+
+// Not sure why we need this indirection, but if we use TextField directly
+// stories don't show up.
+const TextFieldDemo = (props) => <TextField {...props} />;
+
+export default {
+  component: TextField,
+  title: 'Base/TextField',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A MUI-based text field. See [the API](https://v4.mui.com/api/text-field/) for more details.'
+      }
+    }
+  }
+};
+
+export const Default = TextFieldDemo.bind({});
+Default.args = { label: 'First Name', name: 'first-name' };
+
+export const Error = TextFieldDemo.bind({});
+Error.args = { error: true, helperText: 'This field is required', label: 'First Name', name: 'first-name' };
+
+export const Select = TextFieldDemo.bind({});
+Select.args = {
+  children: (
+    <>
+      <option value="red">Red</option>
+      <option value="green">Green</option>
+      <option value="blue">Blue</option>
+    </>
+  ),
+  label: 'Color',
+  name: 'color',
+  select: true
+};
+
+export const SelectError = TextFieldDemo.bind({});
+SelectError.args = {
+  children: (
+    <>
+      <option value="red">Red</option>
+      <option value="green">Green</option>
+      <option value="blue">Blue</option>
+    </>
+  ),
+  error: true,
+  helperText: 'This field is required',
+  label: 'Color',
+  name: 'color',
+  select: true
+};

--- a/spa/src/components/base/TextField/TextField.test.js
+++ b/spa/src/components/base/TextField/TextField.test.js
@@ -1,0 +1,20 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import TextField from './TextField';
+
+function tree(props) {
+  return render(<TextField id="mock-label" label="mock-label" {...props} />);
+}
+
+describe('TextField', () => {
+  it('displays a text input', () => {
+    tree();
+    expect(screen.getByRole('textbox')).toBeVisible();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/Tooltip/Tooltip.js
+++ b/spa/src/components/base/Tooltip/Tooltip.js
@@ -1,0 +1,34 @@
+import { Tooltip as MuiTooltip, TooltipProps as MuiTooltipProps } from '@material-ui/core';
+import propTypes from 'prop-types';
+import styled from 'styled-components';
+
+// See https://v4.mui.com/guides/interoperability/#portals
+
+const WrappedTooltip = ({ className, tooltipWidth, ...other }) => (
+  <MuiTooltip classes={{ tooltip: className }} {...other} />
+);
+
+/**
+ * @see https://v4.mui.com/components/tooltips/
+ */
+export const Tooltip = styled(WrappedTooltip)`
+  && {
+    background: rgb(50, 50, 50);
+    border-radius: 4px;
+    color: white;
+    font: 12px Roboto, sans-serif;
+    padding: 8px;
+    width: ${({ tooltipWidth }) => `${tooltipWidth}px` ?? 'auto'};
+  }
+`;
+
+Tooltip.propTypes = {
+  ...MuiTooltip.propTypes,
+  /**
+   * Width of the tooltip in pixels. If omitted, this lets MUI size it to what
+   * it thinks is appropriate.
+   */
+  tooltipWidth: propTypes.number
+};
+
+export default Tooltip;

--- a/spa/src/components/base/Tooltip/Tooltip.stories.js
+++ b/spa/src/components/base/Tooltip/Tooltip.stories.js
@@ -13,27 +13,25 @@ const ClickTooltipDemo = () => {
   const [open, setOpen] = useState(false);
 
   return (
-    <>
-      <ClickAwayListener onClickAway={() => setOpen(false)}>
-        <span>
-          <Tooltip
-            disableFocusListener
-            disableHoverListener
-            disableTouchListener
-            onClose={() => setOpen(false)}
-            open={open}
-            PopperProps={{
-              disablePortal: true
-            }}
-            title="Hello World"
-          >
-            <ButtonBase aria-label="Help" disableRipple disableTouchRipple onClick={() => setOpen(true)}>
-              <InfoOutlined />
-            </ButtonBase>
-          </Tooltip>
-        </span>
-      </ClickAwayListener>
-    </>
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <span>
+        <Tooltip
+          disableFocusListener
+          disableHoverListener
+          disableTouchListener
+          onClose={() => setOpen(false)}
+          open={open}
+          PopperProps={{
+            disablePortal: true
+          }}
+          title="Hello World"
+        >
+          <ButtonBase aria-label="Help" disableRipple disableTouchRipple onClick={() => setOpen(true)}>
+            <InfoOutlined />
+          </ButtonBase>
+        </Tooltip>
+      </span>
+    </ClickAwayListener>
   );
 };
 

--- a/spa/src/components/base/Tooltip/Tooltip.stories.js
+++ b/spa/src/components/base/Tooltip/Tooltip.stories.js
@@ -1,0 +1,55 @@
+import { ButtonBase, ClickAwayListener } from '@material-ui/core';
+import { InfoOutlined } from '@material-ui/icons';
+import { useState } from 'react';
+import Tooltip from './Tooltip';
+
+const TooltipDemo = (props) => (
+  <Tooltip {...props}>
+    <span>Tooltip Anchor</span>
+  </Tooltip>
+);
+
+const ClickTooltipDemo = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <ClickAwayListener onClickAway={() => setOpen(false)}>
+        <span>
+          <Tooltip
+            disableFocusListener
+            disableHoverListener
+            disableTouchListener
+            onClose={() => setOpen(false)}
+            open={open}
+            PopperProps={{
+              disablePortal: true
+            }}
+            title="Hello World"
+          >
+            <ButtonBase aria-label="Help" disableRipple disableTouchRipple onClick={() => setOpen(true)}>
+              <InfoOutlined />
+            </ButtonBase>
+          </Tooltip>
+        </span>
+      </ClickAwayListener>
+    </>
+  );
+};
+
+export default {
+  component: TooltipDemo,
+  title: 'Base/Tooltip',
+  parameters: {
+    docs: {
+      description: {
+        component: 'A MUI-based tooltip. See [the API](https://v4.mui.com/api/tooltip/) for more details.'
+      }
+    }
+  }
+};
+
+export const Static = TooltipDemo.bind({});
+Static.args = { title: 'Hello World', open: true };
+
+export const Clickable = ClickTooltipDemo.bind({});

--- a/spa/src/components/base/Tooltip/Tooltip.stories.js
+++ b/spa/src/components/base/Tooltip/Tooltip.stories.js
@@ -21,9 +21,6 @@ const ClickTooltipDemo = () => {
           disableTouchListener
           onClose={() => setOpen(false)}
           open={open}
-          PopperProps={{
-            disablePortal: true
-          }}
           title="Hello World"
         >
           <ButtonBase aria-label="Help" disableRipple disableTouchRipple onClick={() => setOpen(true)}>

--- a/spa/src/components/base/Tooltip/Tooltip.test.js
+++ b/spa/src/components/base/Tooltip/Tooltip.test.js
@@ -1,0 +1,26 @@
+import { act, render, screen } from 'test-utils';
+import { axe } from 'jest-axe';
+import Tooltip from './Tooltip';
+
+function tree() {
+  return render(
+    <Tooltip title="Tooltip text" open>
+      <span>Tooltip anchor</span>
+    </Tooltip>
+  );
+}
+
+describe('Tooltip', () => {
+  afterEach(async () => await act(() => Promise.resolve()));
+
+  it('displays a tooltip', async () => {
+    tree();
+    expect(screen.getByText('Tooltip text')).toBeVisible();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/index.js
+++ b/spa/src/components/base/index.js
@@ -1,0 +1,3 @@
+export * from './Button/Button';
+export * from './TextField/TextField';
+export * from './Tooltip/Tooltip';


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

This is stacked on DEV-2028 for clarity.

The headline feature here is that this adds an icon beside the Company Tax Status field that can be clicked to show more information. It also contains improvements to the form layout and controls so that they are closer to Figma.

Under the covers, I also added a new directory, `components/base`. These contain some basic building-block components that I use in this PR but I am hoping we can gradually adopt across the app. They have Storybook demos (`npm run storybook`) and should match Figma, and are definitely a first pass/not comprehensive for all possible uses.

#### Why are we doing this? How does it help us?

The tooltip is there to better inform users as to what implications choosing a tax status will have.

The new components have been added so we can gradually standardize how our basic components are used instead of using one-off styles. We have existing components that serve a similar purpose in `elements`, but they have a different appearance that what is in Figma for profile-related UI. I didn't want to touch the existing components right now, since they are used in many other parts of the app.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Go to https://dev-2387.revengine-review.org/create-account.
2. Fill out the form, use a +test or similar in your email address.
3. Click the link to verify your email address.
4. Once you do this, you should immediately see a modal to customize your profile.
5. The Company Tax Status field should read "Select your status".
6. After choosing a tax status, you should not be able to choose the "Select your status" value.
7. There should be a tooltip above the Company Tax Status field. Clicking it should show the text below. Clicking anywhere else should hide the tooltip.

> Your tax status determines the contribution fees charged through Stripe.

8. Confirm you can't close the modal by clicking outside it or pressing the Escape key.
9. Submit the modal and confirm in the Django admin that data was properly saved, a la DEV-2028.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

It gets the profile modal closer to Figma, so screenshots might need updating depending on when DEV-2028 is documented.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

I hardcoded a lot of fonts, font sizes, and colors in the base components for now. I didn't want to try to change the MUI global theme to avoid causing any appearance regressions elsewhere in the app.

I used `&&` selectors to win specificity over Material UI. Eventually, we should modify Material UI so [it inserts CSS after Styled Components](https://v4.mui.com/guides/interoperability/#controlling-priority-3) but the effects of a change like that are unpredictable and problems likely wouldn't show up in CI.

#### Has this been documented? If so, where?

n/a

#### What are the relevant tickets? Add a link to any relevant ones.

- https://news-revenue-hub.atlassian.net/browse/DEV-2387
- https://news-revenue-hub.atlassian.net/browse/DEV-2388

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

https://news-revenue-hub.atlassian.net/browse/DEV-2390