### PR TITLE
DEV-2524 | Create payment provider as part of account customization step

### DIFF
--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -724,6 +724,8 @@ class TestUserViewSet(APITestCase):
         self.assertTrue(
             RevenueProgram.objects.filter(name=self.customize_account_request["organization_name"]).exists()
         )
+        rp = RevenueProgram.objects.filter(name=self.customize_account_request["organization_name"]).first()
+        assert rp.payment_provider
         self.assertTrue(
             RoleAssignment.objects.filter(
                 user=user,

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -36,7 +36,7 @@ from apps.common.utils import get_original_ip_from_request
 from apps.contributions.bad_actor import BadActorAPIError, make_bad_actor_request
 from apps.contributions.utils import get_sha256_hash
 from apps.emails.tasks import send_templated_email
-from apps.organizations.models import Organization, RevenueProgram
+from apps.organizations.models import Organization, PaymentProvider, RevenueProgram
 from apps.public.permissions import IsActiveSuperUser
 from apps.users.choices import Roles
 from apps.users.constants import (
@@ -310,11 +310,13 @@ class UserViewset(
             organization_name = f"{organization_name}-{counter}"
 
         organization = Organization.objects.create(name=organization_name, slug=slugify(organization_name))
+        payment_provider = PaymentProvider.objects.create()
         revenue_program = RevenueProgram.objects.create(
             name=organization_name,
             organization=organization,
             slug=slugify(organization_name),
             non_profit=True if organization_tax_status == "nonprofit" else False,
+            payment_provider=payment_provider,
         )
         RoleAssignment.objects.create(user=user, role_type=Roles.ORG_ADMIN, organization=organization)
         logger.info(


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)


#### What's this PR do?

Fixes acute bug described in ticket whereby org users were getting an error message after returning from stripe account connect flow. 

The underlying cause was that while we were creating an org, an rp, and a role assignment, we were not creating a payment provider.

We now create a payment provider and attach it to the RP at account customization time.

There is also a test that asserts this is so.

#### Why are we doing this? How does it help us?

Fixes a blocking bug for self service onboarding

#### How should this be manually tested? Please include detailed step-by-step instructions.

Do the Stripe onboarding flow. After creating steps on Stripe, when you get back to the site, you shouldn't see an error, and apps should work as expected.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No


#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2524](https://news-revenue-hub.atlassian.net/jira/software/c/projects/DEV/boards/3?modal=detail&selectedIssue=DEV-2524)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No
