### PR TITLE
DEV-1863 and DEV-1864 | Restrict page and style creation via plan management 

### DIFF
--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -39,6 +39,7 @@ class Plan:
     name: str
     label: str
     page_limit: int = 1
+    style_limit: int = 1
 
 
 FreePlan = Plan(
@@ -51,6 +52,7 @@ PlusPlan = Plan(
     label="Plus",
     # If this limit gets hit, it can be dealt with as a customer service issue.
     page_limit=UNLIMITED_CEILING,
+    style_limit=UNLIMITED_CEILING,
 )
 
 

--- a/apps/organizations/serializers.py
+++ b/apps/organizations/serializers.py
@@ -36,9 +36,14 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 
 class OrganizationInlineSerializer(serializers.ModelSerializer):
+    plan = serializers.SerializerMethodField()
+
     class Meta:
         model = Organization
-        fields = ["id", "name", "slug"]
+        fields = ["id", "name", "slug", "plan"]
+
+    def get_plan(self, obj):
+        return asdict(obj.get_plan_data())
 
 
 class RevenueProgramListInlineSerializer(serializers.ModelSerializer):

--- a/apps/users/tests/test_serializers.py
+++ b/apps/users/tests/test_serializers.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from unittest import mock
 
 from django.contrib.auth import get_user_model
@@ -6,7 +7,7 @@ import pytest
 from rest_framework.test import APIRequestFactory, APITestCase
 from waffle import get_waffle_flag_model
 
-from apps.organizations.models import Organization, RevenueProgram
+from apps.organizations.models import Organization, Plan, RevenueProgram
 from apps.organizations.tests.factories import OrganizationFactory, RevenueProgramFactory
 from apps.users import serializers
 from apps.users.choices import Roles
@@ -73,6 +74,9 @@ class UserSerializerTest(APITestCase):
         assert len(data["revenue_programs"]) >= 1
         for rp in data["revenue_programs"]:
             assert set(rp.keys()) == expect_rp_fields
+        assert len(data["organizations"])
+        for org in data["organizations"]:
+            assert set(org["plan"].keys()) == set(asdict(Plan(name="", label="")).keys())
 
     def test_get_role_type(self):
         super_user_role = self._get_serialized_data_for_user(self.superuser_user)["role_type"]

--- a/spa/src/components/common/Button/NewButton/NewButton.js
+++ b/spa/src/components/common/Button/NewButton/NewButton.js
@@ -5,15 +5,15 @@ import { Flex, Button, Label } from './NewButton.styled';
 import AddIcon from 'assets/icons/add.svg';
 import { BUTTON_TYPE } from 'constants/buttonConstants';
 
-const NewButton = ({ type, onClick, className }) => {
+const NewButton = ({ type, onClick, className, disabled }) => {
   const buttonLabel = {
     [BUTTON_TYPE.PAGE]: 'New Page',
     [BUTTON_TYPE.STYLE]: 'New Style'
   }[type];
 
   return (
-    <Flex className={className}>
-      <Button type={type} onClick={onClick} aria-label={buttonLabel}>
+    <Flex className={className} disabled={disabled}>
+      <Button type={type} onClick={onClick} aria-label={buttonLabel} disabled={disabled}>
         <img src={AddIcon} alt={`add ${type}`} />
       </Button>
       <Label>{buttonLabel}</Label>
@@ -24,12 +24,14 @@ const NewButton = ({ type, onClick, className }) => {
 NewButton.propTypes = {
   type: PropTypes.oneOf(Object.values(BUTTON_TYPE)),
   onClick: PropTypes.func.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  disabled: PropTypes.bool.isRequired
 };
 
 NewButton.defaultProps = {
   type: BUTTON_TYPE.PAGE,
-  className: ''
+  className: '',
+  disabled: false
 };
 
 export default NewButton;

--- a/spa/src/components/common/Button/NewButton/NewButton.stories.js
+++ b/spa/src/components/common/Button/NewButton/NewButton.stories.js
@@ -20,3 +20,6 @@ export const Style = NewButton.bind({});
 Style.args = {
   type: BUTTON_TYPE.STYLE
 };
+
+export const Disabled = NewButton.bind({});
+Disabled.args = { ...Default.args, disabled: true };

--- a/spa/src/components/common/Button/NewButton/NewButton.styled.js
+++ b/spa/src/components/common/Button/NewButton/NewButton.styled.js
@@ -6,13 +6,16 @@ export const Flex = styled.div`
   flex-direction: column;
   align-items: start;
   font-family: ${(props) => props.theme.systemFont};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+  color: ${(props) => (props.disabled ? '#AFAFAF' : 'inherit')};
 `;
 
 export const Button = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${(props) => props.theme.colors.muiLightBlue[800]};
+  background-color: ${(props) =>
+    props.disabled ? props.theme.colors.status.processing : props.theme.colors.muiLightBlue[800]};
   height: ${(props) => (props.type === 'page' ? '120px' : '70px')};
   width: 168px;
   font-size: ${(props) => props.theme.fontSizesUpdated.h1};

--- a/spa/src/components/content/pages/Pages.js
+++ b/spa/src/components/content/pages/Pages.js
@@ -66,7 +66,6 @@ function Pages() {
   const [pageSearchQuery, setPageSearchQuery] = useState([]);
   const { open: showAddPageModal, handleClose, handleOpen } = useModal();
   const { user, isLoading: userLoading } = useUser();
-
   const { data: pages, isLoading: pagesLoading } = useQuery(['pages'], () => fetchPages(), {
     onError: () => alert.error(GENERIC_ERROR),
     // we have existing code that expects pages to be iterable, so we provide default empty array val
@@ -84,7 +83,7 @@ function Pages() {
 
   const addPageButtonShouldBeDisabled = () => {
     if ([USER_ROLE_HUB_ADMIN_TYPE, USER_SUPERUSER_TYPE].includes(user?.role_type?.[0])) {
-      return true;
+      return false;
     }
     const pageLimit = user?.organizations?.[0]?.plan?.page_limit ?? 0;
     return pages.length + 1 > pageLimit;

--- a/spa/src/components/content/pages/Pages.test.js
+++ b/spa/src/components/content/pages/Pages.test.js
@@ -1,6 +1,37 @@
-import { render } from 'test-utils';
+import { render, screen, waitFor } from 'test-utils';
+import MockAdapter from 'axios-mock-adapter';
 
-import { pagesbyRP } from './Pages';
+import { pagesbyRP, default as Pages } from './Pages';
+import useUser from '../../../hooks/useUser';
+import { USER_ROLE_ORG_ADMIN_TYPE, USER_SUPERUSER_TYPE } from 'constants/authConstants';
+
+import { LIST_PAGES } from 'ajax/endpoints';
+import Axios from 'ajax/axios';
+import axios from 'axios';
+
+const orgAdminUser = {
+  role_type: ['org_admin'],
+  organizations: [{ plan: { page_limit: 1 } }]
+};
+
+const superUser = {
+  ...orgAdminUser,
+  role_type: ['superuser']
+};
+
+const hubAdmin = {
+  // ...orgAdminUser,
+  role_type: ['hub_admin']
+};
+
+jest.mock('../../../hooks/useUser', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
 
 describe('Given pages list', () => {
   let result;
@@ -32,5 +63,54 @@ describe('Given pages list having a page with a null rp', () => {
 
   it('should not throw an error and exclude the page with null rp from pagesByRevProgram', () => {
     expect(result.length).toEqual(2);
+  });
+});
+
+describe('New page button behavior given org plan and user role', () => {
+  const axiosMock = new MockAdapter(Axios);
+  afterEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+  afterAll(() => axiosMock.restore());
+  test('when user is super user can always add', async () => {
+    useUser.mockImplementation(() => ({ user: superUser }));
+    axiosMock.onGet(LIST_PAGES).reply(200, [{}, {}, {}]);
+    render(<Pages />);
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+    const newPageButton = screen.getByLabelText('New Page');
+    expect(newPageButton).not.toBeDisabled();
+  });
+  test('when user is hub admin can always add', async () => {
+    useUser.mockImplementation(() => ({ user: hubAdmin }));
+    axiosMock.onGet(LIST_PAGES).reply(200, [{}, {}, {}]);
+    render(<Pages />);
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+    const newPageButton = screen.getByLabelText('New Page');
+    expect(newPageButton).not.toBeDisabled();
+  });
+  test('typical self-onboarded user who has not added a page can add one', async () => {
+    useUser.mockImplementation(() => ({ user: orgAdminUser }));
+    axiosMock.onGet(LIST_PAGES).reply(200, []);
+    render(<Pages />);
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+    const newPageButton = screen.getByLabelText('New Page');
+    expect(newPageButton).not.toBeDisabled();
+  });
+  test('typical self-onboarded user who has added a page cannot add one', async () => {
+    useUser.mockImplementation(() => ({ user: orgAdminUser }));
+    axiosMock.onGet(LIST_PAGES).reply(200, [{}]);
+    render(<Pages />);
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+    const newPageButton = screen.getByLabelText('New Page');
+    expect(newPageButton).toBeDisabled();
   });
 });

--- a/spa/src/components/content/styles/Styles.test.js
+++ b/spa/src/components/content/styles/Styles.test.js
@@ -1,16 +1,16 @@
 import { render, screen, waitFor } from 'test-utils';
 import MockAdapter from 'axios-mock-adapter';
 
-import { pagesbyRP, default as Pages } from './Pages';
+import Styles from './Styles';
 import useUser from '../../../hooks/useUser';
 import { USER_ROLE_ORG_ADMIN_TYPE, USER_ROLE_HUB_ADMIN_TYPE, USER_SUPERUSER_TYPE } from 'constants/authConstants';
 
-import { LIST_PAGES } from 'ajax/endpoints';
+import { LIST_STYLES } from 'ajax/endpoints';
 import Axios from 'ajax/axios';
 
 const orgAdminUser = {
   role_type: [USER_ROLE_ORG_ADMIN_TYPE],
-  organizations: [{ plan: { page_limit: 1 } }]
+  organizations: [{ plan: { style_limit: 1 } }]
 };
 
 const superUser = {
@@ -32,40 +32,7 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe('Given pages list', () => {
-  let result;
-  beforeEach(async () => {
-    const inp = [
-      { id: 'first', revenue_program: { id: 1, name: 'rp1' } },
-      { id: 'second', revenue_program: { id: 2, name: 'rp2' } },
-      { id: 'third', revenue_program: { id: 2, name: 'rp2' } }
-    ];
-    result = await pagesbyRP(inp);
-  });
-
-  it('should group pages by RevenueProgram in pagesByRevProgram ', () => {
-    expect(result.length).toEqual(2);
-  });
-});
-
-describe('Given pages list having a page with a null rp', () => {
-  let result;
-
-  beforeEach(async () => {
-    const inp = [
-      { id: 'first', revenue_program: { id: 1, name: 'rp1' } },
-      { id: 'second', revenue_program: { id: 2, name: 'rp2' } },
-      { id: 'third', revenue_program: null }
-    ];
-    result = await pagesbyRP(inp);
-  });
-
-  it('should not throw an error and exclude the page with null rp from pagesByRevProgram', () => {
-    expect(result.length).toEqual(2);
-  });
-});
-
-describe('New page button behavior given org plan and user role', () => {
+describe('New style button behavior given org plan and user role', () => {
   const axiosMock = new MockAdapter(Axios);
   afterEach(() => {
     axiosMock.reset();
@@ -74,42 +41,42 @@ describe('New page button behavior given org plan and user role', () => {
   afterAll(() => axiosMock.restore());
   test('when user is super user can always add', async () => {
     useUser.mockImplementation(() => ({ user: superUser }));
-    axiosMock.onGet(LIST_PAGES).reply(200, [{}, {}, {}]);
-    render(<Pages />);
+    axiosMock.onGet(LIST_STYLES).reply(200, [{ name: '' }, { name: '' }, { name: '' }]);
+    render(<Styles />);
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Page');
+    const newPageButton = screen.getByLabelText('New Style');
     expect(newPageButton).not.toBeDisabled();
   });
   test('when user is hub admin can always add', async () => {
     useUser.mockImplementation(() => ({ user: hubAdmin }));
-    axiosMock.onGet(LIST_PAGES).reply(200, [{}, {}, {}]);
-    render(<Pages />);
+    axiosMock.onGet(LIST_STYLES).reply(200, [{ name: '' }, { name: '' }, { name: '' }]);
+    render(<Styles />);
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Page');
+    const newPageButton = screen.getByLabelText('New Style');
     expect(newPageButton).not.toBeDisabled();
   });
-  test('typical self-onboarded user who has not added a page can add one', async () => {
+  test('typical self-onboarded user who has not added a style can add one', async () => {
     useUser.mockImplementation(() => ({ user: orgAdminUser }));
-    axiosMock.onGet(LIST_PAGES).reply(200, []);
-    render(<Pages />);
+    axiosMock.onGet(LIST_STYLES).reply(200, []);
+    render(<Styles />);
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Page');
+    const newPageButton = screen.getByLabelText('New Style');
     expect(newPageButton).not.toBeDisabled();
   });
   test('typical self-onboarded user who has added a page cannot add one', async () => {
     useUser.mockImplementation(() => ({ user: orgAdminUser }));
-    axiosMock.onGet(LIST_PAGES).reply(200, [{}]);
-    render(<Pages />);
+    axiosMock.onGet(LIST_STYLES).reply(200, [{ name: '' }]);
+    render(<Styles />);
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Page');
+    const newPageButton = screen.getByLabelText('New Style');
     expect(newPageButton).toBeDisabled();
   });
 });


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR solves for two tickets: [DEV-1863 | Restrict Page Creation via Org plan](https://news-revenue-hub.atlassian.net/browse/DEV-1863) and [DEV-1865 | Restrict Style Creation via Org Plan](https://news-revenue-hub.atlassian.net/browse/DEV-1865)




#### Why are we doing this? How does it help us?

As part of self-service onboarding and restricting users who are on the free plan.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. In the Django admin, set an org to the free plan
2. Log in to the dashboard as an org user whose org is the one you set in step 1. Ideally, you can use an existing org that is already Stripe verified, etc. to avoid going through that flow, but if need be, go through onboarding flow.
3. Assuming there are no pages, create a page.
4. Now note that the "New Page" button is disabled.
5. Back in the Django admin, change the org to plus plan.
6. Back in the dashboard, the "New Page" should no longer be disabled, and you should be able to create a new page.
7.  Log out of the dashboard.
8. In the Django admin, change the org back to free plan.
9. If one is not already available, set up a hub admin user.
10. Log in to the dashboard as the hub admin user. 
11. The "New Page" button should not be disabled. If you click "New Page", it should take you to the page creation modal, but if you submit, you'll get an error message displayed that the org is at its limit (note this error message is pre-existing functionality).
12. Finally, do the equivalent flow for the "Styles" page. You shouldn't need to create a new user or role assignment or anything like that, but you can swap between the free plan, which is limited to 1 style, and the plus plan which is limited to 200. 

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A


#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-1863 | Restrict Page Creation via Org plan](https://news-revenue-hub.atlassian.net/browse/DEV-1863)
- [DEV-1865 | Restrict Style Creation via Org Plan](https://news-revenue-hub.atlassian.net/browse/DEV-1865)


#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.
