### PR TITLE
DEV-2530: Fix bug with fees at page load

### DIFF
--- a/spa/package.json
+++ b/spa/package.json
@@ -86,8 +86,9 @@
       "**/?(*.)+(test).[jt]s?(x)"
     ],
     "collectCoverageFrom": [
-      "**/*.test.{js,jsx}",
+      "**/*.{js,jsx}",
       "!**/node_modules/**",
+      "!**/*.stories.js",
       "!**/*.styled.js"
     ],
     "transformIgnorePatterns": [

--- a/spa/src/components/donationPage/DonationPage.js
+++ b/spa/src/components/donationPage/DonationPage.js
@@ -9,7 +9,7 @@ import useQueryString from 'hooks/useQueryString';
 import useErrorFocus from 'hooks/useErrorFocus';
 import useClearbit from 'hooks/useClearbit';
 import * as getters from 'components/donationPage/pageGetters';
-import { getDefaultAmountForFreq } from 'components/donationPage/pageContent/DAmount';
+import { getDefaultAmountForFreq } from './amountUtils';
 import { frequencySort } from 'components/donationPage/pageContent/DFrequency';
 import {
   GRECAPTCHA_SITE_KEY,

--- a/spa/src/components/donationPage/amountUtils.js
+++ b/spa/src/components/donationPage/amountUtils.js
@@ -1,0 +1,60 @@
+/**
+ * Returns the index of an amount in a list of frequency page. If none can be
+ * found, this returns -1.
+ * @param {Object} page page object
+ * @param {number | string} amount to search for
+ * @param {string} frequency frequency code
+ * @returns {number} index of amount
+ */
+export function getAmountIndex(page, amount, frequency) {
+  const amountElement = page?.elements?.find((el) => el.type === 'DAmount');
+
+  if (!amountElement) {
+    return -1;
+  }
+
+  const parsedAmount = parseFloat(amount);
+  const { options } = amountElement?.content;
+
+  if (!options[frequency]) {
+    return -1;
+  }
+
+  return options[frequency].findIndex((option) => parseFloat(option) === parsedAmount);
+}
+
+/**
+ * Returns the default contribution amount for a frequency, as configured in a
+ * page. If none is configured for the frequency, then the first one listed is
+ * returned. If there are no amounts at all configured, this returns undefined.
+ * @param {string} frequency - frequency code
+ * @param {Object} page - page object
+ * @returns {Number} numeric donation
+ */
+export function getDefaultAmountForFreq(frequency, page) {
+  const amountElement = page?.elements?.find(({ type }) => type === 'DAmount');
+
+  if (!amountElement) {
+    return;
+  }
+
+  const { defaults, options } = amountElement?.content;
+
+  if (!options[frequency]) {
+    return;
+  }
+
+  // If the default is defined and exists in options, return it. We coerce
+  // values to numbers in case the data is malformed, using quoted values
+  // instead of numbers.
+
+  const defaultAmount = parseFloat(defaults?.[frequency]);
+
+  if (Number.isFinite(defaultAmount) && getAmountIndex(page, defaultAmount, frequency) !== -1) {
+    return defaultAmount;
+  }
+
+  // Otherwise, return the first frequency in options.
+
+  return parseFloat(options[frequency]?.[0]);
+}

--- a/spa/src/components/donationPage/amountUtils.js
+++ b/spa/src/components/donationPage/amountUtils.js
@@ -1,9 +1,9 @@
 /**
  * Returns the index of an amount in a list of frequency page. If none can be
  * found, this returns -1.
- * @param {Object} page page object
- * @param {number | string} amount to search for
- * @param {string} frequency frequency code
+ * @param {Object} page - page object
+ * @param {number | string} amount - amount to search for
+ * @param {string} frequency - frequency code
  * @returns {number} index of amount
  */
 export function getAmountIndex(page, amount, frequency) {

--- a/spa/src/components/donationPage/amountUtils.test.js
+++ b/spa/src/components/donationPage/amountUtils.test.js
@@ -1,0 +1,75 @@
+import { getAmountIndex, getDefaultAmountForFreq } from './amountUtils';
+
+const mockElement = {
+  type: 'DAmount',
+  content: {
+    defaults: {
+      mockFrequency: 200
+    },
+    options: {
+      mockFrequency: [100, 200, 300]
+    }
+  }
+};
+
+const mockStringElement = {
+  type: 'DAmount',
+  content: {
+    defaults: {
+      mockFrequency: '200'
+    },
+    options: {
+      mockFrequency: ['100', '200', '300']
+    }
+  }
+};
+
+describe('getAmountIndex', () => {
+  it('returns the index of the amount in a frequency list', () =>
+    expect(getAmountIndex({ elements: [mockElement] }, 200, 'mockFrequency')).toBe(1));
+
+  it('coerces string values to numbers', () => {
+    expect(getAmountIndex({ elements: [mockStringElement] }, 200, 'mockFrequency')).toBe(1);
+    expect(getAmountIndex({ elements: [mockStringElement] }, '200', 'mockFrequency')).toBe(1);
+    expect(getAmountIndex({ elements: [mockElement] }, '200', 'mockFrequency')).toBe(1);
+  });
+
+  it('returns -1 if there is no matching amount', () =>
+    expect(getAmountIndex({ elements: [mockStringElement] }, 0, 'mockFrequency')).toBe(-1));
+
+  it('returns -1 if there is no matching frequency', () =>
+    expect(getAmountIndex({ elements: [mockStringElement] }, 100, 'nonexistent')).toBe(-1));
+
+  it('returns -1 if there are no DAmount elements in the page', () =>
+    expect(getAmountIndex({ elements: [] }, 100, 'mockFrequency')).toBe(-1));
+
+  it('returns -1 if the page object is malformed', () => expect(getAmountIndex({}, 100, 'mockFrequency')).toBe(-1));
+});
+
+describe('getDefaultAmountForFreq', () => {
+  it('returns the default amount for a given frequency', () =>
+    expect(getDefaultAmountForFreq('mockFrequency', { elements: [mockElement] })).toBe(200));
+
+  it('coerces string values to numbers', () =>
+    expect(getDefaultAmountForFreq('mockFrequency', { elements: [mockStringElement] })).toBe(200));
+
+  it('returns the first amount if no default is set', () =>
+    expect(
+      getDefaultAmountForFreq('mockFrequency', {
+        elements: [{ ...mockElement, content: { ...mockElement.content, defaults: { otherFrequency: 200 } } }]
+      })
+    ).toBe(100));
+
+  it('returns undefined if no amounts are available for the frequency requested', () =>
+    expect(
+      getDefaultAmountForFreq('nonexistent', {
+        elements: [mockElement]
+      })
+    ).toBeUndefined());
+
+  it('returns undefined if there are no DAmount elements in the page', () =>
+    expect(getDefaultAmountForFreq('mockFrequency', { elements: [] })).toBeUndefined());
+
+  it('returns undefined if the page object is malformed', () =>
+    expect(getDefaultAmountForFreq('mockFrequency', {})).toBeUndefined());
+});

--- a/spa/src/components/donationPage/pageContent/DAmount.js
+++ b/spa/src/components/donationPage/pageContent/DAmount.js
@@ -5,6 +5,7 @@ import * as S from './DAmount.styled';
 // Util
 import validateInputPositiveFloat from 'utilities/validateInputPositiveFloat';
 import { getFrequencyAdjective, getFrequencyRate } from 'utilities/parseFrequency';
+import { getAmountIndex } from '../amountUtils';
 
 // Context
 import { usePage } from '../DonationPage';
@@ -125,31 +126,3 @@ DAmount.required = true;
 DAmount.unique = true;
 
 export default DAmount;
-
-function getAmountIndex(page, amount, frequency) {
-  const amountElement = page?.elements?.find((el) => el.type === 'DAmount');
-  const amounts = amountElement?.content?.options;
-  const amountsForFreq = amounts && amounts[frequency]?.map((amnt) => parseFloat(amnt));
-
-  if (amountsForFreq) {
-    return amounts[frequency]?.findIndex((num) => parseFloat(num) === parseFloat(amount));
-  }
-}
-
-export function getDefaultAmountForFreq(frequency, page) {
-  const amountElement = page?.elements?.find((el) => el.type === 'DAmount');
-  const amounts = amountElement?.content?.options;
-  const amountsForFreq = amounts ? amounts[frequency]?.map((amnt) => parseFloat(amnt)) : {};
-  const defaults = amountElement?.content?.defaults;
-
-  // If defaults are defined, and a default is defined for this frequency, and the default defined is a valid amount...
-  if (defaults && defaults[frequency] && amountsForFreq?.includes(parseFloat(defaults[frequency]))) {
-    // ... return the default amount for this frequency.
-    return defaults[frequency];
-  }
-  // Otherwise we have any amounts for this frequency...
-  else if (amountsForFreq) {
-    // ... return the first frequency in the list.
-    return amountsForFreq[0];
-  }
-}

--- a/spa/src/components/donationPage/pageContent/DFrequency.js
+++ b/spa/src/components/donationPage/pageContent/DFrequency.js
@@ -5,7 +5,7 @@ import * as S from './DFrequency.styled';
 import { usePage } from '../DonationPage';
 
 // Util
-import { getDefaultAmountForFreq } from 'components/donationPage/pageContent/DAmount';
+import { getDefaultAmountForFreq } from '../amountUtils';
 
 // Children
 import DElement, { DynamicElementPropTypes } from 'components/donationPage/pageContent/DElement';


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

This fixes a bug with how fee calculation works on a contribution page at pageload. This bug only affects older contribution pages that have contribution amounts stored as strings.

I refactored out two contribution amount-related utility functions into a separate module to help with testability. I tried leaving them in the `<DAmount>` component but Jest does not like importing a module named `constants` because our own module conflicts with one in node_modules, and this also helps start to detangle some circular dependencies we have in our code (I think).

I also fixed the `npm run test:coverage` command so it outputs accurate info.

#### Why are we doing this? How does it help us?

Fixes a bug with older donation pages.

#### How should this be manually tested? Please include detailed step-by-step instructions.

Repeat the steps below with the following contribution pages. I looked in the Django admin to find an example of a page that uses quoted values vs. one that uses numbers.
- https://newsrevenuehub-dev-2530.revengine-review.org/donate (old, quoted values)
- https://shawarma-dev-2530.revengine-review.org/donate (new, unquoted values)

1. Go to the contribution page.
2. Confirm that a button is selected in the contribution amounts.
3. Confirm that the Stripe fee looks accurate (e.g. not super high).
4. Confirm that the submit button at the bottom of the page shows the correct amount.
5. Fill out the rest of the fields and confirm that the payment amount requested is correct.
6. Complete steps 1-5 but choose a recurring contribution.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2530

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

Subtasked https://news-revenue-hub.atlassian.net/browse/DEV-2584 for database cleanup.