### PR TITLE
DEV-2440: only send slack notification when payment information was c…

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -243,7 +243,7 @@ class Contribution(IndexedTimeStampedModel, RoleAssignmentResourceModelMixin):
     def save(self, *args, **kwargs):
         # Calling save with kwargs "slack_notification" causes save method to trigger slack notifications
         slack_notification = kwargs.pop("slack_notification", None)
-        if slack_notification:
+        if slack_notification and self.provider_payment_method_id:
             self.send_slack_notifications(slack_notification)
 
         # Check if we should update stripe payment method details


### PR DESCRIPTION
…ompleted

Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

N/A

#### What's this PR do?

- Fixes bug where slack notification was sent too early, before payment method was submitted

#### Why are we doing this? How does it help us?

Payments should not fire notifications the user submits their credit card payment and submits payment

#### How should this be manually tested? Please include detailed step-by-step instructions.

- Try to create a donation but do not enter credit card data
- Navigate to slack and assert that notifications were not fired

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

N/A

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

N/A

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2440]

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

N/A

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A


[DEV-2440]: https://news-revenue-hub.atlassian.net/browse/DEV-2440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ