### PR TITLE
DEV-2390: Add progress indicator to setup modals

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -48,6 +48,7 @@ jobs:
           build: npx cypress info
           start: npm run start:subdomains
           wait-on: http://localhost:3000
+          wait-on-timeout: 120
           # because of "record" and "parallel" parameters
           # these containers will load balance all found tests among themselves
           record: true

--- a/spa/src/components/account/Profile/Profile.js
+++ b/spa/src/components/account/Profile/Profile.js
@@ -17,6 +17,7 @@ import useModal from 'hooks/useModal';
 import { useConfigureAnalytics } from 'components/analytics';
 
 import ProfileForm from './ProfileForm';
+import { OffscreenText, StepperDots } from 'components/base';
 
 function Profile() {
   const { open } = useModal(true);
@@ -58,6 +59,7 @@ function Profile() {
   return (
     <S.Modal open={open} aria-labelledby="profile-modal-title" data-testid="finalize-profile-modal">
       <S.Profile>
+        <OffscreenText>Step 1 of 2</OffscreenText>
         <S.h1 id="profile-modal-title">Let's Customize Your Account</S.h1>
         <S.Description>Help us create your personalized experience!</S.Description>
         <ProfileForm onProfileSubmit={onProfileSubmit} disabled={profileState.loading} />
@@ -66,6 +68,7 @@ function Profile() {
         ) : (
           <A.MessageSpacer />
         )}
+        <StepperDots aria-hidden activeStep={0} steps={2} />
       </S.Profile>
     </S.Modal>
   );

--- a/spa/src/components/account/Profile/Profile.test.js
+++ b/spa/src/components/account/Profile/Profile.test.js
@@ -34,6 +34,11 @@ describe('Profile', () => {
 
   afterAll(() => axiosMock.restore());
 
+  it('includes step information for users of assistive technology', () => {
+    tree();
+    expect(screen.getByText('Step 1 of 2')).toBeInTheDocument();
+  });
+
   it('displays the profile form', () => {
     tree();
     expect(screen.getByTestId('mock-profile-form')).toBeInTheDocument();

--- a/spa/src/components/base/OffscreenText/OffscreenText.js
+++ b/spa/src/components/base/OffscreenText/OffscreenText.js
@@ -1,0 +1,9 @@
+import { Typography } from '@material-ui/core';
+
+/**
+ * Text that is perceiveable only by assistive technology. Where possible, use ARIA instead.
+ * @see https://v4.mui.com/api/typography/
+ */
+export const OffscreenText = ({ children }) => <Typography variant="srOnly">{children}</Typography>;
+
+export default OffscreenText;

--- a/spa/src/components/base/OffscreenText/OffscreenText.stories.js
+++ b/spa/src/components/base/OffscreenText/OffscreenText.stories.js
@@ -1,0 +1,19 @@
+import OffscreenText from './OffscreenText';
+
+function OffscreenTextDemo({ text }) {
+  return (
+    <>
+      <OffscreenText>{text}</OffscreenText>
+      <p>Turn on assistive technology like VoiceOver to hear the text.</p>
+    </>
+  );
+}
+
+export default {
+  component: OffscreenTextDemo,
+  title: 'Base/OffscreenText'
+};
+
+export const Default = OffscreenTextDemo.bind({});
+
+Default.args = { text: 'This text is only perceivable by assistive technology.' };

--- a/spa/src/components/base/OffscreenText/OffscreenText.test.js
+++ b/spa/src/components/base/OffscreenText/OffscreenText.test.js
@@ -1,0 +1,20 @@
+import { act, render, screen } from 'test-utils';
+import { axe } from 'jest-axe';
+import OffscreenText from './OffscreenText';
+
+function tree(text) {
+  return render(<OffscreenText>{text}</OffscreenText>);
+}
+
+describe('OffscreenText', () => {
+  it('displays the text in children', () => {
+    tree('test');
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree('test');
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/Stepper/StepperDots.js
+++ b/spa/src/components/base/Stepper/StepperDots.js
@@ -8,7 +8,7 @@ const StyledMobileStepper = styled(MobileStepper)`
     padding: 0;
 
     .MuiMobileStepper-dot {
-      background-color: rgb(221, 203, 231);
+      background-color: rgb(82, 58, 94);
       height: 16px;
       margin: 0;
       position: relative;
@@ -32,8 +32,8 @@ const StyledMobileStepper = styled(MobileStepper)`
       }
     }
 
-    .MuiMobileStepper-dotActive {
-      background-color: rgb(82, 58, 94);
+    .MuiMobileStepper-dotActive ~ .MuiMobileStepper-dot {
+      background-color: rgb(221, 203, 231);
     }
   }
 `;

--- a/spa/src/components/base/Stepper/StepperDots.js
+++ b/spa/src/components/base/Stepper/StepperDots.js
@@ -1,0 +1,49 @@
+import { MobileStepper } from '@material-ui/core';
+import styled from 'styled-components';
+
+const StyledMobileStepper = styled(MobileStepper)`
+  && {
+    background: none;
+    justify-content: center;
+    padding: 0;
+
+    .MuiMobileStepper-dot {
+      background-color: rgb(221, 203, 231);
+      height: 16px;
+      margin: 0;
+      position: relative;
+      width: 16px;
+
+      + .MuiMobileStepper-dot {
+        margin-left: 14px;
+
+        &::before {
+          /* Line between dots. */
+          background: rgb(221, 203, 231);
+          border-radius: 4px;
+          content: '';
+          display: block;
+          height: 2px;
+          left: -12px;
+          position: absolute;
+          top: 7px;
+          width: 10px;
+        }
+      }
+    }
+
+    .MuiMobileStepper-dotActive {
+      background-color: rgb(82, 58, 94);
+    }
+  }
+`;
+
+/**
+ * A set of noninteractive dots indicating progress through a multi-step process.
+ * @see https://v4.mui.com/api/mobile-stepper/
+ */
+export const StepperDots = (props) => <StyledMobileStepper position="static" variant="dots" {...props} />;
+
+StepperDots.propTypes = MobileStepper.propTypes;
+
+export default StepperDots;

--- a/spa/src/components/base/Stepper/StepperDots.stories.js
+++ b/spa/src/components/base/Stepper/StepperDots.stories.js
@@ -1,0 +1,14 @@
+import StepperDots from './StepperDots';
+
+const StepperDotsDemo = (props) => <StepperDots {...props} />;
+
+export default {
+  title: 'Base/StepperDots',
+  component: StepperDots
+};
+
+export const Default = StepperDotsDemo.bind({});
+Default.args = {
+  activeStep: 0,
+  steps: 5
+};

--- a/spa/src/components/base/Stepper/StepperDots.test.js
+++ b/spa/src/components/base/Stepper/StepperDots.test.js
@@ -1,0 +1,20 @@
+import StepperDots from './StepperDots';
+import { render, screen } from 'test-utils';
+import { axe } from 'jest-axe';
+
+function tree(props) {
+  return render(<StepperDots activeStep={0} steps={2} {...props} />);
+}
+
+describe('StepperDots', () => {
+  it('uses the ARIA label passed', () => {
+    tree({ 'aria-label': '2 of 3 steps' });
+    expect(screen.getByLabelText('2 of 3 steps')).toBeInTheDocument();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/Stepper/index.js
+++ b/spa/src/components/base/Stepper/index.js
@@ -1,0 +1,1 @@
+export * from './StepperDots';

--- a/spa/src/components/base/index.js
+++ b/spa/src/components/base/index.js
@@ -1,3 +1,5 @@
 export * from './Button/Button';
+export * from './OffscreenText/OffscreenText';
+export * from './Stepper';
 export * from './TextField/TextField';
 export * from './Tooltip/Tooltip';

--- a/spa/src/components/dashboard/connectStripe/ConnectStripeElements.js
+++ b/spa/src/components/dashboard/connectStripe/ConnectStripeElements.js
@@ -13,6 +13,7 @@ import useConnectStripeAccount from 'hooks/useConnectStripeAccount';
 import Cookies from 'universal-cookie';
 
 import { CONNECT_STRIPE_COOKIE_NAME, CONNECT_STRIPE_FAQ_LINK } from 'constants/textConstants';
+import { OffscreenText } from 'components/base';
 
 const ConnectStripeModal = () => {
   const { open, handleClose } = useModal(true);
@@ -30,6 +31,7 @@ const ConnectStripeModal = () => {
   return (
     <S.Modal open={open} aria-labelledby="Connect Stripe Modal">
       <S.ConnectStripeModal data-testid="connect-stripe-modal">
+        <OffscreenText>Step 2 of 2</OffscreenText>
         <S.StripeLogo src={StripeLogo} />
         <S.h1>Connect to Stripe</S.h1>
         <S.Description>
@@ -48,6 +50,7 @@ const ConnectStripeModal = () => {
           <span>I’ll connect to Stripe later</span>
           <ChevronRightIcon />
         </S.Anchor>
+        <S.BottomStepper aria-hidden activeStep={1} steps={2} />
       </S.ConnectStripeModal>
     </S.Modal>
   );

--- a/spa/src/components/dashboard/connectStripe/ConnectStripeElements.styled.js
+++ b/spa/src/components/dashboard/connectStripe/ConnectStripeElements.styled.js
@@ -1,5 +1,6 @@
 import { Button as MuiButton, Modal as MuiModal } from '@material-ui/core';
 import styled from 'styled-components';
+import { StepperDots } from 'components/base';
 //import lighten from 'styles/utils/lighten';
 
 export const ConnectStripeModal = styled.div`
@@ -112,4 +113,8 @@ export const StripeLogo = styled.img`
 export const BottomNav = styled.img`
   width: 42px;
   margin: 34px auto 0px;
+`;
+
+export const BottomStepper = styled(StepperDots)`
+  margin-top: 40px;
 `;

--- a/spa/src/components/dashboard/connectStripe/ConnectStripeElements.styled.js
+++ b/spa/src/components/dashboard/connectStripe/ConnectStripeElements.styled.js
@@ -40,6 +40,7 @@ export const Modal = styled(MuiModal)`
 export const h1 = styled.h1`
   margin-top: 0px;
   font-weight: 700;
+  font-family: Roboto, sans-serif;
   font-size: ${(props) => props.theme.fontSizesUpdated['lgx']};
   line-height: ${(props) => props.theme.fontSizesUpdated['lg2x']};
   color: ${(props) => props.theme.colors.purple};
@@ -57,6 +58,7 @@ export const Description = styled.div`
 
 export const Bold = styled.div`
   font-weight: 600;
+  font-family: Roboto, sans-serif;
   margin: 17px 0px 8px;
 `;
 

--- a/spa/src/components/dashboard/connectStripe/ConnectStripeElements.test.js
+++ b/spa/src/components/dashboard/connectStripe/ConnectStripeElements.test.js
@@ -5,6 +5,11 @@ import ConnectStripeElements from './ConnectStripeElements';
 import { CONNECT_STRIPE_COOKIE_NAME, CONNECT_STRIPE_FAQ_LINK } from 'constants/textConstants';
 
 describe('ConnectStripeElements', () => {
+  it('includes step information for users of assistive technology', () => {
+    render(<ConnectStripeElements />);
+    expect(screen.getByText('Step 2 of 2')).toBeInTheDocument();
+  });
+
   it('should have enabled button for connectToStripe', () => {
     render(<ConnectStripeElements />);
     const connectToStripeButton = screen.getByRole('button', { name: 'Connect to Stripe' });


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Adds a `<StepperDots>` component that is noninteractive and shows progress through a process.
- Adds a `<OffscreenText>` component for wrapping text that should be perceivable through assistive technology only.
- Puts progress indicators on the profile finalization and Stripe setup modals.

#### Why are we doing this? How does it help us?

The progress indicators were part of the original design for these modals, and give users a sense of where they are in the setup process.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Create a new account and verify its email.
2. Confirm that the design of the profile finalization modal that appears once you've confirmed your email matches Figma.
3. (if you have a Mac or have other assistive technology available) Turn on VoiceOver/AX tech and confirm that the modal reads "Step 1 of 2" before all other content.
4. Fill out the profile finalization modal.
5. Confirm that the Stripe setup modal that appears after completing this modal matches Figma.
6. (If you have a Mac or assistive technology available) Turn on VoiceOver/AX tech and confirm that the modal reads "Step 2 of 2" before all other content.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

n/a

#### Has this been documented? If so, where?

n/a

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2390

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.