### PR TITLE
DEV-2595: Fix redirect link and update error handling

### DIFF
--- a/spa/cypress/e2e/03-donationPageList.cy.js
+++ b/spa/cypress/e2e/03-donationPageList.cy.js
@@ -124,6 +124,43 @@ describe('Donation page list', () => {
           });
         });
       });
+
+      it('redirects user to newly created page', () => {
+        cy.forceLogin(orgAdmin);
+        cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: orgAdminWithContentFlagAndOneRP });
+        cy.intercept(
+          { method: 'POST', pathname: getEndpoint(LIST_PAGES) },
+          {
+            body: {
+              slug: 'page-1',
+              revenue_program: {
+                slug: 'rp-1'
+              }
+            },
+            statusCode: 200
+          }
+        ).as('createNewPage');
+        cy.visit(CONTENT_SLUG);
+        cy.get('button[aria-label="New Page"]').click();
+        cy.wait('@createNewPage');
+        cy.url().should('include', 'rp-1/page-1');
+      });
+
+      it('shows error when create page fails', () => {
+        cy.forceLogin(orgAdmin);
+        cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: orgAdminWithContentFlagAndOneRP });
+        cy.intercept(
+          { method: 'POST', pathname: getEndpoint(LIST_PAGES) },
+          {
+            body: ['Create page error'],
+            statusCode: 400
+          }
+        ).as('createNewPage');
+        cy.visit(CONTENT_SLUG);
+        cy.get('button[aria-label="New Page"]').click();
+        cy.wait('@createNewPage');
+        cy.contains('Create page error');
+      });
     });
   });
 });

--- a/spa/src/components/common/Button/GrabLink/GrabLink.js
+++ b/spa/src/components/common/Button/GrabLink/GrabLink.js
@@ -7,6 +7,7 @@ import LinkIcon from '@material-ui/icons/Link';
 import CopyInputButton from 'components/common/Button/CopyInputButton';
 import { pageLink, portalLink } from 'utilities/getPageLinks';
 import { Flex, Button, Popover, Text } from './GrabLink.styled';
+import { PagePropTypes } from 'constants/proptypes';
 
 const GrabLink = ({ page, className }) => {
   const [copied, setCopied] = useState('');
@@ -62,17 +63,12 @@ const GrabLink = ({ page, className }) => {
 
 GrabLink.propTypes = {
   className: PropTypes.string,
-  page: PropTypes.shape({
-    revenue_program: PropTypes.shape({
-      slug: PropTypes.string
-    }).isRequired,
-    slug: PropTypes.string.isRequired,
-    published_date: PropTypes.string
-  }).isRequired
+  page: PropTypes.shape(PagePropTypes)
 };
 
 GrabLink.defaultProps = {
-  className: ''
+  className: '',
+  page: undefined
 };
 
 export default GrabLink;

--- a/spa/src/components/common/Button/PublishButton/PublishButton.js
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.js
@@ -172,14 +172,15 @@ const PublishButton = ({ page, setPage, className, alert, requestPatchPage }) =>
 
 PublishButton.propTypes = {
   className: PropTypes.string,
-  page: PropTypes.shape(PagePropTypes).isRequired,
+  page: PropTypes.shape(PagePropTypes),
   setPage: PropTypes.func,
   alert: PropTypes.any,
   requestPatchPage: PropTypes.func
 };
 
 PublishButton.defaultProps = {
-  className: ''
+  className: '',
+  page: undefined
 };
 
 export default PublishButton;

--- a/spa/src/components/content/pages/AddPageModal.js
+++ b/spa/src/components/content/pages/AddPageModal.js
@@ -54,7 +54,11 @@ function AddPageModal({ isOpen, closeModal, pagesByRevenueProgram }) {
     (e) => {
       setLoading(false);
       if (e.response?.data) {
-        setErrors(e.response.data);
+        if (revenuePrograms?.length === 1) {
+          alert.error(Object.values(e.response.data));
+        } else {
+          setErrors(e.response.data);
+        }
       } else {
         alert.error('There was an error and we could not create your new page. We have been notified.');
       }
@@ -84,7 +88,7 @@ function AddPageModal({ isOpen, closeModal, pagesByRevenueProgram }) {
           onSuccess: ({ data }) => {
             setLoading(false);
             history.push({
-              pathname: join([EDITOR_ROUTE, revenueProgram.slug, slug, '/']),
+              pathname: join([EDITOR_ROUTE, data.revenue_program.slug, data.slug, '/']),
               state: { pageId: data.id }
             });
           },
@@ -92,7 +96,7 @@ function AddPageModal({ isOpen, closeModal, pagesByRevenueProgram }) {
         }
       );
     },
-    [canSavePage, createPage, handleSaveFailure, history, name, revenueProgram.id, revenueProgram.slug, slug]
+    [canSavePage, createPage, handleSaveFailure, history, name, revenueProgram.id, slug]
   );
 
   const handleDiscard = () => {


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a

#### What's this PR do?
Fixes bug in which Org Admin user doesn't redirected to new page on page creation

#### Why are we doing this? How does it help us?
 Fixes the Create new page flow

#### How should this be manually tested? Please include detailed step-by-step instructions.
- Create a new account
- Verify email and fill in profile inputs
- Create new page
- Make sure the flow works as expected (page gets created and user is redirected to edit page)
- User cannot create a second page and error pops up for the user to know what happened

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
No

#### Have automated unit tests been added? If not, why?
No, the create page modal/flow will be updated in the next ticket (DEV-2299 Update and Enhance "New page" modal)

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
Create Page modal/flow isn't really well written. Will be addressed in DEV-2299

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-2595

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
https://news-revenue-hub.atlassian.net/browse/DEV-2299
