### PR TITLE
DEV 2650 | style not appearing after clicking new style button reload

### DIFF
--- a/spa/cypress/e2e/09-styles.cy.js
+++ b/spa/cypress/e2e/09-styles.cy.js
@@ -1,7 +1,7 @@
 import { getEndpoint } from '../support/util';
 import { CUSTOMIZE_SLUG } from 'routes';
 
-import { REVENUE_PROGRAMS, LIST_FONTS, USER, PATCH_PAGE, LIST_STYLES } from 'ajax/endpoints';
+import { REVENUE_PROGRAMS, LIST_FONTS, USER, LIST_STYLES } from 'ajax/endpoints';
 import orgAdmin from '../fixtures/user/login-success-org-admin.json';
 import stripeVerifiedOrgAdmin from '../fixtures/user/self-service-user-stripe-verified.json';
 
@@ -24,14 +24,19 @@ describe('Styles view', () => {
   });
 
   it('has prototypical first-time self-service user flow', () => {
+    const styleName = 'my style';
     cy.visit(CUSTOMIZE_SLUG);
     cy.url().should('include', CUSTOMIZE_SLUG);
     cy.wait('@listStyles');
     cy.getByTestId('new-style-button').click();
-    cy.getByTestId('style-name-input').type('my style');
+    cy.getByTestId('style-name-input').type(styleName);
     cy.get('#downshift-1-toggle-button').click();
     cy.getByTestId('select-item-0').click();
     cy.getByTestId('save-styles-button').click();
     cy.wait('@createStyle');
+    // we take this as evidence that the new style will be displayed on the page.
+    // we don't mock the server response to test this here because it doesn't provide
+    // any additional confidence beyond what we already know (that a request is made again)
+    cy.wait('@listStyles');
   });
 });

--- a/spa/src/components/content/Customize.js
+++ b/spa/src/components/content/Customize.js
@@ -9,7 +9,7 @@ import useStyleList from 'hooks/useStyleList';
 function Customize() {
   const [showEditStylesModal, setShowEditStylesModal] = useState(false);
   const [styleToEdit, setStyleToEdit] = useState(null);
-  const { styles, handleStylesUpdate } = useStyleList();
+  const { styles, refetch } = useStyleList();
 
   const handleCloseEditStylesModal = () => {
     setShowEditStylesModal(false);
@@ -25,7 +25,7 @@ function Customize() {
           styleToEdit={styleToEdit}
           isOpen={showEditStylesModal}
           closeModal={handleCloseEditStylesModal}
-          onStylesUpdated={handleStylesUpdate}
+          onStylesUpdated={refetch}
         />
       )}
     </>

--- a/spa/src/components/content/Customize.js
+++ b/spa/src/components/content/Customize.js
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 
 // Children
 import Styles from 'components/content/styles/Styles';
@@ -10,8 +9,7 @@ import useStyleList from 'hooks/useStyleList';
 function Customize() {
   const [showEditStylesModal, setShowEditStylesModal] = useState(false);
   const [styleToEdit, setStyleToEdit] = useState(null);
-  const { styles } = useStyleList();
-  const queryClient = useQueryClient();
+  const { styles, handleStylesUpdate } = useStyleList();
 
   const handleCloseEditStylesModal = () => {
     setShowEditStylesModal(false);
@@ -27,7 +25,7 @@ function Customize() {
           styleToEdit={styleToEdit}
           isOpen={showEditStylesModal}
           closeModal={handleCloseEditStylesModal}
-          onStylesUpdated={() => queryClient.invalidateQueries('styles')}
+          onStylesUpdated={handleStylesUpdate}
         />
       )}
     </>

--- a/spa/src/components/content/Customize.js
+++ b/spa/src/components/content/Customize.js
@@ -1,61 +1,33 @@
-import { useState, useCallback } from 'react';
-
-// AJAX
-import useRequest from 'hooks/useRequest';
-import { LIST_STYLES } from 'ajax/endpoints';
-import { GENERIC_ERROR } from 'constants/textConstants';
-
-// Deps
-import { useAlert } from 'react-alert';
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 // Children
 import Styles from 'components/content/styles/Styles';
 import EditStylesModal from 'components/content/styles/EditStylesModal';
 import PageTitle from 'elements/PageTitle';
+import useStyleList from 'hooks/useStyleList';
 
 function Customize() {
-  const alert = useAlert();
-  const requestGetStyles = useRequest();
   const [showEditStylesModal, setShowEditStylesModal] = useState(false);
   const [styleToEdit, setStyleToEdit] = useState(null);
-  const [styles, setStyles] = useState([]);
+  const { styles } = useStyleList();
+  const queryClient = useQueryClient();
 
   const handleCloseEditStylesModal = () => {
     setShowEditStylesModal(false);
     setStyleToEdit(null);
   };
 
-  const fetchStyles = useCallback(() => {
-    requestGetStyles(
-      { method: 'GET', url: LIST_STYLES },
-      {
-        onSuccess: ({ data }) => {
-          setStyles(
-            data.map(({ styles, id, revenue_program, name, used_live }) => {
-              return { ...styles, id, revenue_program, name, used_live };
-            })
-          );
-        },
-        onFailure: () => alert.error(GENERIC_ERROR)
-      }
-    );
-  }, [alert, requestGetStyles]);
-
   return (
     <>
       <PageTitle title="Customize" />
-      <Styles
-        setShowEditStylesModal={setShowEditStylesModal}
-        setStyleToEdit={setStyleToEdit}
-        fetchStyles={fetchStyles}
-        styles={styles}
-      />
+      <Styles setShowEditStylesModal={setShowEditStylesModal} setStyleToEdit={setStyleToEdit} styles={styles} />
       {showEditStylesModal && (
         <EditStylesModal
           styleToEdit={styleToEdit}
           isOpen={showEditStylesModal}
           closeModal={handleCloseEditStylesModal}
-          onStylesUpdated={fetchStyles}
+          onStylesUpdated={() => queryClient.invalidateQueries('styles')}
         />
       )}
     </>

--- a/spa/src/components/content/styles/Styles.js
+++ b/spa/src/components/content/styles/Styles.js
@@ -54,7 +54,7 @@ function Styles({ setShowEditStylesModal, setStyleToEdit }) {
     setShowEditStylesModal(true);
   };
 
-  const stylesFiltered = styles ? filterStyles(styles, styleSearchQuery) : [];
+  const stylesFiltered = filterStyles(styles, styleSearchQuery);
 
   const addStyleButtonShouldBeDisabled = () => {
     if ([USER_ROLE_HUB_ADMIN_TYPE, USER_SUPERUSER_TYPE].includes(user?.role_type?.[0])) {

--- a/spa/src/components/content/styles/Styles.js
+++ b/spa/src/components/content/styles/Styles.js
@@ -54,7 +54,7 @@ function Styles({ setShowEditStylesModal, setStyleToEdit }) {
     setShowEditStylesModal(true);
   };
 
-  const stylesFiltered = filterStyles(styles, styleSearchQuery);
+  const stylesFiltered = styles ? filterStyles(styles, styleSearchQuery) : [];
 
   const addStyleButtonShouldBeDisabled = () => {
     if ([USER_ROLE_HUB_ADMIN_TYPE, USER_SUPERUSER_TYPE].includes(user?.role_type?.[0])) {

--- a/spa/src/components/content/styles/Styles.test.js
+++ b/spa/src/components/content/styles/Styles.test.js
@@ -42,8 +42,8 @@ describe('New style button behavior given org plan and user role', () => {
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Style');
-    expect(newPageButton).not.toBeDisabled();
+    const newStyleButton = screen.getByLabelText('New Style');
+    expect(newStyleButton).not.toBeDisabled();
   });
   test('when user is hub admin can always add', async () => {
     useUser.mockImplementation(() => ({ user: hubAdmin }));
@@ -52,8 +52,8 @@ describe('New style button behavior given org plan and user role', () => {
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Style');
-    expect(newPageButton).not.toBeDisabled();
+    const newStyleButton = screen.getByLabelText('New Style');
+    expect(newStyleButton).not.toBeDisabled();
   });
   test('typical self-onboarded user who has not added a style can add one', async () => {
     useUser.mockImplementation(() => ({ user: orgAdminUser }));
@@ -62,8 +62,8 @@ describe('New style button behavior given org plan and user role', () => {
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Style');
-    expect(newPageButton).not.toBeDisabled();
+    const newStyleButton = screen.getByLabelText('New Style');
+    expect(newStyleButton).not.toBeDisabled();
   });
   test('typical self-onboarded user who has added a page cannot add one', async () => {
     useUser.mockImplementation(() => ({ user: orgAdminUser }));
@@ -72,7 +72,7 @@ describe('New style button behavior given org plan and user role', () => {
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(1);
     });
-    const newPageButton = screen.getByLabelText('New Style');
-    expect(newPageButton).toBeDisabled();
+    const newStyleButton = screen.getByLabelText('New Style');
+    expect(newStyleButton).toBeDisabled();
   });
 });

--- a/spa/src/hooks/useStyleList.test.tsx
+++ b/spa/src/hooks/useStyleList.test.tsx
@@ -1,0 +1,129 @@
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import * as reactQuery from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react-hooks';
+import MockAdapter from 'axios-mock-adapter';
+import { ReactChild } from 'react';
+
+import axios from 'ajax/axios';
+import { SIGN_IN } from 'routes';
+import { LIST_STYLES } from 'ajax/endpoints';
+import useStyleList from "./useStyleList";
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    push: mockHistoryPush
+  }),
+}));
+
+
+jest.mock('react-alert', () => ({
+  ...jest.requireActual('react-alert'),
+  useAlert: () => ({ error: jest.fn() })
+}));
+
+
+// jest.mock('@tanstack/react-query', () => ({
+//   ...jest.requireActual('@tanstack/react-query'),
+//   useQuery: jest.fn()
+// }))
+
+
+const axiosMock = new MockAdapter(axios);
+
+
+describe('useStyleList hook', () => {
+
+  const wrapper = ({ children }: { children: ReactChild }) => (
+    <QueryClientProvider client={new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })}>{children}</QueryClientProvider>
+  );
+
+  const stylesList = [
+    { id: 1, styles: { foo: 'bar' } },
+    { id: 2, styles: { bizz: 'bang' } },
+  ];
+
+  beforeEach(() => {
+    jest.resetModules();
+    axiosMock.onGet(LIST_STYLES).reply(
+      function (config) {
+        return new Promise(function (resolve, reject) {
+          setTimeout(function () {
+            resolve([200, [...stylesList]]);
+          }, 100);
+        });
+      });
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  it.each`
+    queryLoadingState
+    ${false}
+    ${true}
+    `('hook returns `isLoading: $queryLoadingState` when query isLoading is $queryLoadingState', async ({ queryLoadingState }) => {
+    const mockUseQuery = useQuery as jest.Mock;
+    mockUseQuery.mockReturnValue({ isLoading: queryLoadingState });
+    const { result, } = renderHook(() => useStyleList(), { wrapper });
+    expect(result.current.isLoading).toBe(queryLoadingState);
+  });
+
+  it.each`
+    queryErrorState,
+    ${false}
+    ${true}
+    `('hook returns `isError: $queryErrorState` when query isError is $queryErrorState', async ({ queryErrorState }) => {
+    const mockUseQuery = useQuery as jest.Mock;
+    mockUseQuery.mockReturnValue({ isError: queryErrorState });
+    const { result } = renderHook(() => useStyleList(), { wrapper });
+    expect(result.current.isLoading).toBe(queryErrorState);
+  });
+
+  it('returns a `refetch` function that invalidates the styles query', () => {
+    reactQuery.useQuery = { ...jest.requireActual('@tanstack/react-query') };
+    const mockInvalidateQueries = jest.fn();
+    jest.spyOn(reactQuery, 'useQueryClient').mockImplementation(() => {
+      return {
+        invalidateQueries: mockInvalidateQueries
+      };
+    });
+    const { result: { current: { refetch } } } = renderHook(() => useStyleList(), { wrapper });
+    expect(typeof refetch).toBe('function');
+    refetch();
+    expect(mockInvalidateQueries).toHaveBeenCalledWith(['styles'])
+  });
+
+  it('returns the styles furnished by the styles API endpoint', async () => {
+    const { waitForValueToChange, result } = renderHook(() => useStyleList(), { wrapper });
+    await waitForValueToChange(() => result.current.styles);
+    expect(result.current.styles).toEqual(stylesList);
+  });
+
+  it('console.errors and alerts when there is a network error', async () => {
+    axiosMock.reset();
+    axiosMock.onGet(LIST_STYLES).networkError();
+    const { waitForValueToChange, result } = renderHook(() => useStyleList(), { wrapper });
+    await waitForValueToChange(() => result.current.isError);
+
+  });
+
+  it.only('redirects user to log in when auth error', async () => {
+    axiosMock.reset();
+    axiosMock.onGet(LIST_STYLES).reply((function (config) {
+      return Promise.reject({name: 'AuthenticationError'});
+    }));
+    const { waitForValueToChange, result } = renderHook(() => useStyleList(), { wrapper });
+    await waitForValueToChange(() => result.current.isError);
+    expect(mockHistoryPush).toHaveBeenCalledTimes(1);
+    expect(mockHistoryPush).toHaveBeenCalledWith(SIGN_IN)
+  });
+});

--- a/spa/src/hooks/useStyleList.test.tsx
+++ b/spa/src/hooks/useStyleList.test.tsx
@@ -69,8 +69,7 @@ describe('useStyleList hook', () => {
 
   it('returns the styles furnished by the styles API endpoint', async () => {
     const { waitForValueToChange, result } = renderHook(() => useStyleList(), { wrapper });
-    expect(result.current.isLoading).toBe(true)
-    await waitForValueToChange(() => result.current.isLoading);
+    await waitForValueToChange(() => result.current.styles);
     expect(result.current.styles).toEqual(stylesList);
   });
 

--- a/spa/src/hooks/useStyleList.test.tsx
+++ b/spa/src/hooks/useStyleList.test.tsx
@@ -64,7 +64,7 @@ describe('useStyleList hook', () => {
     const { result: { current: { refetch } } } = renderHook(() => useStyleList(), { wrapper });
     expect(typeof refetch).toBe('function');
     refetch();
-      expect(mockInvalidateQueries).toHaveBeenCalledWith(['styles']);
+    expect(mockInvalidateQueries).toHaveBeenCalledWith(['styles']);
   });
 
   it('returns the styles furnished by the styles API endpoint', async () => {

--- a/spa/src/hooks/useStyleList.test.tsx
+++ b/spa/src/hooks/useStyleList.test.tsx
@@ -57,12 +57,13 @@ describe('useStyleList hook', () => {
 
   it('returns a `refetch` function that invalidates the styles query', () => {
     const mockInvalidateQueries = jest.fn();
-    jest.spyOn(reactQuery, 'useQueryClient');
-    (useQueryClient as jest.MockedFunction<typeof useQueryClient>).mockReturnValue({invalidateQueries: mockInvalidateQueries});
+    const spy = jest.spyOn(reactQuery, 'useQueryClient');
+    // @ts-expect-error
+    spy.mockReturnValue({invalidateQueries: mockInvalidateQueries})
     const { result: { current: { refetch } } } = renderHook(() => useStyleList(), { wrapper });
     expect(typeof refetch).toBe('function');
     refetch();
-    expect(mockInvalidateQueries).toHaveBeenCalledWith(['styles'])
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(['styles']);
   });
 
   it('returns the styles furnished by the styles API endpoint', async () => {

--- a/spa/src/hooks/useStyleList.test.tsx
+++ b/spa/src/hooks/useStyleList.test.tsx
@@ -72,7 +72,6 @@ describe('useStyleList hook', () => {
     expect(result.current.isLoading).toBe(true)
     await waitForValueToChange(() => result.current.isLoading);
     expect(result.current.styles).toEqual(stylesList);
-    console.log(result.current.styles);
   });
 
   it('console.errors and alerts when there is a network error', async () => {

--- a/spa/src/hooks/useStyleList.test.tsx
+++ b/spa/src/hooks/useStyleList.test.tsx
@@ -58,8 +58,9 @@ describe('useStyleList hook', () => {
   it('returns a `refetch` function that invalidates the styles query', () => {
     const mockInvalidateQueries = jest.fn();
     const spy = jest.spyOn(reactQuery, 'useQueryClient');
-    // @ts-expect-error
-    spy.mockReturnValue({invalidateQueries: mockInvalidateQueries})
+    // cast this to `as any` so we don't have to provide all 33 params that are in returned
+    // queryClient in real implementation
+    spy.mockReturnValue({invalidateQueries: mockInvalidateQueries} as any)
     const { result: { current: { refetch } } } = renderHook(() => useStyleList(), { wrapper });
     expect(typeof refetch).toBe('function');
     refetch();

--- a/spa/src/hooks/useStyleList.ts
+++ b/spa/src/hooks/useStyleList.ts
@@ -43,6 +43,7 @@ function useStyleList():UseStyleListResult {
     isLoading,
     isError,
   } = useQuery(['styles'], fetchStyles, {
+    initialData: [],
     onError: (err:Error) => {
       if (err?.name === 'AuthenticationError') {
         history.push(SIGN_IN);

--- a/spa/src/hooks/useStyleList.ts
+++ b/spa/src/hooks/useStyleList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQueryClient, useQuery } from '@tanstack/react-query';
 import { useAlert } from 'react-alert';
 import { useHistory } from 'react-router-dom';
 
@@ -15,6 +15,7 @@ async function fetchStyles() {
 function useStyleList() {
   const alert = useAlert();
   const history = useHistory();
+  const queryClient = useQueryClient();
 
   const {
     data: styles,
@@ -36,7 +37,9 @@ function useStyleList() {
       }
     }
   });
-  return { styles, isLoading, isError };
+  return { styles, isLoading, isError, handleStylesUpdate: () => {
+    queryClient.invalidateQueries(['styles']);
+  }};
 }
 
 export default useStyleList;

--- a/spa/src/hooks/useStyleList.ts
+++ b/spa/src/hooks/useStyleList.ts
@@ -17,6 +17,7 @@ function useStyleList() {
   const history = useHistory();
   const queryClient = useQueryClient();
 
+
   const {
     data: styles,
     isLoading,
@@ -37,7 +38,8 @@ function useStyleList() {
       }
     }
   });
-  return { styles, isLoading, isError, handleStylesUpdate: () => {
+
+  return { styles, isLoading, isError, refetch: () => {
     queryClient.invalidateQueries(['styles']);
   }};
 }

--- a/spa/src/hooks/useStyleList.ts
+++ b/spa/src/hooks/useStyleList.ts
@@ -26,7 +26,7 @@ function useStyleList() {
     initialData: [],
     // if it's an authentication error, we don't want to retry. if it's some other
     // error we'll retry up to 1 time.
-    retry: (failureCount, error:any) => {
+    retry: (failureCount: number, error:Error) => {
       return error.name !== 'AuthenticationError' && failureCount < 1;
     },
     onError: (err) => {

--- a/spa/src/hooks/useStyleList.ts
+++ b/spa/src/hooks/useStyleList.ts
@@ -29,8 +29,8 @@ interface Style {
 export interface UseStyleListResult {
   isLoading: UseQueryResult['isLoading'];
   isError: UseQueryResult['isError'];
-  styles: Style[],
-  refetch: Function
+  styles: Style[];
+  refetch: Function;
 }
 
 
@@ -43,12 +43,10 @@ function useStyleList():UseStyleListResult {
     isLoading,
     isError,
   } = useQuery(['styles'], fetchStyles, {
-    initialData: [],
     onError: (err:Error) => {
       if (err?.name === 'AuthenticationError') {
         history.push(SIGN_IN);
       } else {
-        // this triggers a Sentry error
         console.error(err);
         alert.error(GENERIC_ERROR);
       }

--- a/spa/src/hooks/useStyleList.ts
+++ b/spa/src/hooks/useStyleList.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAlert } from 'react-alert';
+import { useHistory } from 'react-router-dom';
+
+import { LIST_STYLES } from 'ajax/endpoints';
+import axios from 'ajax/axios';
+import { GENERIC_ERROR } from 'constants/textConstants';
+import { SIGN_IN } from 'routes';
+
+async function fetchStyles() {
+  const { data } = await axios.get(LIST_STYLES);
+  return data;
+}
+
+function useStyleList() {
+  const alert = useAlert();
+  const history = useHistory();
+
+  const {
+    data: styles,
+    isLoading,
+    isError
+  } = useQuery(['styles'], fetchStyles, {
+    initialData: [],
+    // if it's an authentication error, we don't want to retry. if it's some other
+    // error we'll retry up to 1 time.
+    retry: (failureCount, error:any) => {
+      return error.name !== 'AuthenticationError' && failureCount < 1;
+    },
+    onError: (err) => {
+      if (err?.name === 'AuthenticationError') {
+        history.push(SIGN_IN);
+      } else {
+        console.error(err);
+        alert.error(GENERIC_ERROR);
+      }
+    }
+  });
+  return { styles, isLoading, isError };
+}
+
+export default useStyleList;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

Fixes a bug revealed in QA of DEV-1865.  Base for this PR is DEV-1863-restrict-page-creation-via-org-plan, which itself is queued up to be merged into main.

#### What's this PR do?

Ensures that new styles appear in Customize page list view after creation

- Adds a new hook `useStyleList` that follows pattern from `usePageList` and uses that hook in place of pre-existing AJAX functionality to retrieve styles
- After a style is created, invalidates the styles list query, causing them to be re-retrieved.


#### Why are we doing this? How does it help us?

Fixes bug and allows us to release DEV-1863 and DEV-1865

#### How should this be manually tested? Please include detailed step-by-step instructions.


Create a style in review app and you should immediately see it reflected in the customize list view without refreshing.


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

N/A

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2650

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

As noted above, parent PR of DEV-1863 into main will need to be merged.