### PR TITLE
DEV-2699 | fix donor_selected_amount in Stripe metadata

### DIFF
--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -284,6 +284,7 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
     captcha_token = serializers.CharField(max_length=2550, allow_blank=True, write_only=True)
     provider_client_secret_id = serializers.CharField(read_only=True)
     email_hash = serializers.CharField(read_only=True)
+    donor_selected_amount = serializers.FloatField(write_only=True)
 
     def validate_tribute_type(self, value):
         """Ensure there are no unexpected values for tribute_type"""
@@ -407,7 +408,7 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
             "schema_version": settings.METADATA_SCHEMA_VERSION,
             "contributor_id": contributor.id,
             "agreed_to_pay_fees": validated_data["agreed_to_pay_fees"],
-            "donor_selected_amount": validated_data["amount"],
+            "donor_selected_amount": validated_data["donor_selected_amount"],
             "reason_for_giving": validated_data["reason_for_giving"],
             "honoree": validated_data.get("honoree"),
             "in_memory_of": validated_data.get("in_memory_of"),

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -314,7 +314,8 @@ def minimally_valid_data(donation_page):
     a payment. If a page has configured to include elements like phone number, reason for giving, etc.,
     then the request data will contain additional fields."""
     return {
-        "amount": 120.1,
+        "amount": 123.01,
+        "donor_selected_amount": 120.0,
         "email": "foo@bar.com",
         "page": donation_page.id,
         "interval": "one_time",
@@ -744,7 +745,7 @@ class TestBaseCreatePaymentSerializer:
             "schema_version": settings.METADATA_SCHEMA_VERSION,
             "contributor_id": contributor.id,
             "agreed_to_pay_fees": serializer.validated_data["agreed_to_pay_fees"],
-            "donor_selected_amount": serializer.validated_data["amount"],
+            "donor_selected_amount": serializer.validated_data["donor_selected_amount"],
             "reason_for_giving": serializer.validated_data["reason_for_giving"],
             "honoree": serializer.validated_data.get("honoree"),
             "in_memory_of": serializer.validated_data.get("in_memory_of"),

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -952,7 +952,9 @@ def donation_page():
 @pytest.fixture
 def valid_data(donation_page):
     return {
-        "amount": "120",
+        "amount": 123.01,
+        "donor_selected_amount": 120,
+        "agreed_to_pay_fees": True,
         "interval": "one_time",
         "first_name": "Bill",
         "last_name": "Smith",


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Fixes a bug where the total amount (that is, donor selected amount + fee amount in case of agreeing to pay fees) was being recorded as value for `donor_selected_amount` whereas it should be the selected amount without fee tacked on.

#### Why are we doing this? How does it help us?

Fixes Salesforce reporting

#### How should this be manually tested? Please include detailed step-by-step instructions.

Make a contribution and agree to pay fees.

In Django admin, you should see that the contribution amount includes pay fees.

Look at the payment intent or subscription in Stripe. Its metadata should have a `donor_selected_amount` value, which should be the amount without fee included.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes. Existing ones have been updated to ensure this field has correct value.

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2699

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A