### PR TITLE
DEV-2764: put page in editable state after loading

### DIFF
--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -81,7 +81,14 @@ describe('Contribution page edit', () => {
     cy.getByTestId('delete-page-button');
   });
 
+  it('should default to the edit interface once a page has loaded', () => {
+    cy.getByTestId('edit-interface');
+  });
+
   it('should open edit interface when clicking edit button', () => {
+    // Toggle out of edit mode.
+
+    cy.getByTestId('preview-page-button').click();
     cy.getByTestId('edit-page-button').click();
     cy.getByTestId('edit-interface');
   });

--- a/spa/cypress/fixtures/pages/live-page-element-validation.json
+++ b/spa/cypress/fixtures/pages/live-page-element-validation.json
@@ -2,6 +2,9 @@
   "id": 50,
   "name": "Page 1",
   "styles": null,
+  "plan": {
+    "custom_thank_you_enabled": true
+  },
   "revenue_program": {
     "id": 3,
     "name": "Fooo",

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -166,6 +166,7 @@ function PageEditor() {
         setPage(data);
         setPageContext(data);
         setLoading(false);
+        handleEdit();
       },
       onFailure: handleGetPageFailure //() => setLoading(false)
     });


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Puts the page editor into the edit state after loading the page. It can't be in edit mode absolutely immediately because the page is loading initially.

#### Why are we doing this? How does it help us?

Improves UX.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit an existing page from the admin dashboard. Confirm the page starts in edit mode.
2. Create a new page from the admin dashboard. Confirm the page starts in edit mode.
3. Confirm that toggling between edit mode and preview works.
4. Confirm that toggling between preview mode and edit works.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

We might need to change docs around page editing to reflect that users don't need to go into edit mode.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a?

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2764

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.