### PR TITLE
DEV-2487 | Fix integrity error on donation page patch

### DIFF
--- a/apps/pages/tests/test_viewsets.py
+++ b/apps/pages/tests/test_viewsets.py
@@ -5,7 +5,6 @@ import os
 from django.conf import settings
 from django.utils import timezone
 
-import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
@@ -185,13 +184,13 @@ class PageViewSetTest(RevEngineApiAbstractTestCase):
 
     ########
     # Update
-    @pytest.mark.xfail
     def test_update_with_sidebar_elements(self):
         # TODO: DEV-2327 How to test partial_update with request.FILES
         page = DonationPage.objects.filter().first()
-        sidebar_elements = {}
-        self.assert_superuser_can_patch(
-            f"/api/v0/pages/{page.pk}/", {"sidebar_elements": sidebar_elements}, format="multipart"
+        sidebar_elements = []
+        self.assert_org_admin_can_patch(
+            f"/api/v1/pages/{page.pk}/",
+            {"sidebar_elements": sidebar_elements},
         )
         page.refresh_from_db()
         assert page.sidebar_elements == sidebar_elements

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -173,7 +173,7 @@ class PageViewSet(RevisionMixin, viewsets.ModelViewSet, FilterQuerySetByUserMixi
 
     def partial_update(self, request, *args, **kwargs):
         response = super().partial_update(request, *args, **kwargs)
-        if request.FILES and request.data.get("sidebar_elements", None):
+        if request.FILES and response.data.get("sidebar_elements", None):
             # Link up thumbs and MediaImages
             data = MediaImage.create_from_request(request.POST, request.FILES, kwargs["pk"])
             response.data["sidebar_elements"] = data.get("sidebar_elements")


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR fixes a bug that was causing the API to respond with a 500 when the SPA attempted to patch a donation page, sending an empty list as the value for `sidebar_elements`.

The cause of the bug was this line of code in `apps.pages.views.PageViewSet.partial_udpate`:

```
if request.FILES and request.data.get("sidebar_elements", None):
```

That conditional block was being triggered even when an empty list was being sent whereas the intention was for an empty list to not meet the condition. This is because instead of looking at the serialized value for `sidebar_elements` as created in the immediately preceding line of code, the raw request data was being looked at, in which case the empty list was "stringified" as `'[]'`, which is truthy, vs. `[]`, which is falsy.


#### Why are we doing this? How does it help us?

Fixes a bug that blocks users from updating sidebar elements to have no items.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Log in to the review app.
2. Create a new page, and in the page editor, add at least one item sidebar elements.
3. Save the page.
4. Now update the page again to remove all elements from the sidebar.
5. Save the page. There should be no errors, and the page should be updated as expected.

Before this fix, at step 5, you would get an error that would prevent saving the page.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Sort of. A test marked with `pytest.xfail` was updated to remove the `pytest.xfail`, and this test proves that it's possible to patch a page with `[]` as the value for `sidebar_elements`.

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2487](https://news-revenue-hub.atlassian.net/browse/DEV-2847)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No