### PR TITLE
DEV-2861 | Fix integrity error bug for sidebar elements

### DIFF
--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -173,7 +173,29 @@ class PageViewSet(RevisionMixin, viewsets.ModelViewSet, FilterQuerySetByUserMixi
 
     def partial_update(self, request, *args, **kwargs):
         response = super().partial_update(request, *args, **kwargs)
-        if request.FILES and response.data.get("sidebar_elements", None):
+        # The `all` condtion below is quirky, but necessary for now because this view is dealing with
+        # multipart form data in order to support file upload.
+        #
+        # If the environment is set up to capture page screenshots, then request.FILES will always be truthy
+        # because a page screenshot will always be there. But in case where the user has added an image element
+        # to sidebar elements, request.FILES will also contain that data. So one case we need to support is
+        # when user patches the page to add an image to sidebar elements — this is the scenario presupposed by the
+        # call to `MediaImage.create_from_request` below (although that will also run even if no image is present).
+        #
+        # Another scenario we need to support is when a user is trying to set sidebar_elements to be an empty list, and
+        # this is why we need to include `request.data.get('sidebar_elements')` in the `all` condition below.
+        # Uf the user is setting sidebar_elements to be empty, then the value for sidebar elements in the request data will
+        # be the string value '[]', representing an empty list. The reason this value will be an empty string is because
+        # this endpoint is supporting file upload, and therefore form data instead of JSON is submitted. If we know
+        # that `sidebar_elements` are being patched, we then need to look at `response.data.sidebar_elements` because this
+        # contains the value for that field after the serializer has converted the validated data to a list (in this cae, an empty one).
+        #
+        #
+        # Yet another scenario we need to support is when the page already has an image sidebar element, but elements other
+        # than sidebar_elements are being patched. In that case, we do NOT want the conditional block below to run because
+        # it will cause an error because `data = MediaImage.create_from_request(request.POST, request.FILES, kwargs["pk"])` will
+        # yield `None` and the db will raise an integrity error when we attempt to set that field to None when saving.
+        if all([request.FILES, request.data.get("sidebar_elements"), response.data.get("sidebar_elements", None)]):
             # Link up thumbs and MediaImages
             data = MediaImage.create_from_request(request.POST, request.FILES, kwargs["pk"])
             response.data["sidebar_elements"] = data.get("sidebar_elements")

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -184,7 +184,7 @@ class PageViewSet(RevisionMixin, viewsets.ModelViewSet, FilterQuerySetByUserMixi
         #
         # Another scenario we need to support is when a user is trying to set sidebar_elements to be an empty list, and
         # this is why we need to include `request.data.get('sidebar_elements')` in the `all` condition below.
-        # Uf the user is setting sidebar_elements to be empty, then the value for sidebar elements in the request data will
+        # If the user is setting sidebar_elements to be empty, then the value for sidebar elements in the request data will
         # be the string value '[]', representing an empty list. The reason this value will be an empty string is because
         # this endpoint is supporting file upload, and therefore form data instead of JSON is submitted. If we know
         # that `sidebar_elements` are being patched, we then need to look at `response.data.sidebar_elements` because this
@@ -194,7 +194,8 @@ class PageViewSet(RevisionMixin, viewsets.ModelViewSet, FilterQuerySetByUserMixi
         # Yet another scenario we need to support is when the page already has an image sidebar element, but elements other
         # than sidebar_elements are being patched. In that case, we do NOT want the conditional block below to run because
         # it will cause an error because `data = MediaImage.create_from_request(request.POST, request.FILES, kwargs["pk"])` will
-        # yield `None` and the db will raise an integrity error when we attempt to set that field to None when saving.
+        # yield `None` and the db will raise an integrity error when we attempt to set that field to None when saving. This scenario
+        # was the cause of a bug captured in [DEV-2861](https://news-revenue-hub.atlassian.net/browse/DEV-2861)
         if all([request.FILES, request.data.get("sidebar_elements"), response.data.get("sidebar_elements", None)]):
             # Link up thumbs and MediaImages
             data = MediaImage.create_from_request(request.POST, request.FILES, kwargs["pk"])


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This fixes a bug that caused an integrity error when a user edited page elements on an existing page that already had an Image element in sidebar elements.

There is a [long explanatory comment in the code](https://github.com/newsrevenuehub/rev-engine/pull/829/files#diff-44087ac156d7cc64c8aaf6cf545f87cf3de6289c2cafdb02f7047ed160da226bR176-R197) that provides context for the cause of the bug.

In addition to fixing the bug, this PR adds a test for the specific edge case that caused the bug. If you keep that test in place but revert the change to the view code, you will get a test failure with the integrity error we saw "in the wild".

#### Why are we doing this? How does it help us?

Makes page editor functional.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit a page, adding an image to sidebar elements and save.
2. Edit the page a second time, but this time edit a page element (say a rich text block or pay fees, or similar). Save.
3. There should be no error.

For comparison's sake, if you follow these same steps in staging or test ahead of merging this PR, after step 2 you should see an error in sentry / the dev tools console, and the page will not be updated.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

There's probably a better way to be handling file uploads vis-a-vis our page serializer, but that will require some digging. I don't like that we have to look at both raw request data and converted request data (i.e., data that has been validated and converted to internal representation via the serializer), but there are oddities around file upload + nested serialization in DRF.

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2861

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A
