### PR TITLE
DEV-2750 | Stripe onboarding modal transition is delayed

### DIFF
--- a/spa/src/components/dashboard/Dashboard.js
+++ b/spa/src/components/dashboard/Dashboard.js
@@ -1,5 +1,6 @@
 import { Redirect, Switch, useLocation } from 'react-router-dom';
 
+import GlobalLoading from 'elements/GlobalLoading';
 import * as S from './Dashboard.styled';
 
 // Routing
@@ -40,7 +41,7 @@ function Dashboard() {
   const { flags } = useFeatureFlags();
   const { page, setPage, updatedPage } = usePageContext();
   const { user } = useUser();
-  const { requiresVerification } = useConnectStripeAccount();
+  const { requiresVerification, isLoading } = useConnectStripeAccount();
 
   const hasContributionsSectionAccess = user?.role_type && hasContributionsDashboardAccessToUser(flags);
   const hasContentSectionAccess = user?.role_type && flagIsActiveForUser(CONTENT_SECTION_ACCESS_FLAG_NAME, flags);
@@ -54,7 +55,9 @@ function Dashboard() {
   const { pathname } = useLocation();
   const isEditPage = pathname.includes(EDITOR_ROUTE);
 
-  return (
+  return isLoading ? (
+    <GlobalLoading />
+  ) : (
     <S.Outer>
       {requiresVerification ? <ConnectStripeElements /> : ''}
       <DashboardTopbar isEditPage={isEditPage} page={page} setPage={setPage} user={user} updatedPage={updatedPage} />

--- a/spa/src/components/dashboard/Dashboard.test.tsx
+++ b/spa/src/components/dashboard/Dashboard.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from 'test-utils';
+
+import Dashboard from './Dashboard';
+import useConnectStripeAccount from 'hooks/useConnectStripeAccount';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useUser from 'hooks/useUser';
+
+jest.mock('elements/GlobalLoading');
+jest.mock('hooks/useConnectStripeAccount');
+jest.mock('hooks/useFeatureFlags');
+jest.mock('hooks/useUser');
+
+describe('Dashboard', () => {
+  const useConnectStripeAccountMock = useConnectStripeAccount as jest.Mock;
+  const useFeatureFlagsMock = useFeatureFlags as jest.Mock;
+  const useUserMock = useUser as jest.Mock;
+
+  beforeEach(() => {
+    useFeatureFlagsMock.mockReturnValue({
+      flags: [],
+      isLoading: false,
+      isError: false
+    });
+    useUserMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn()
+    });
+  });
+  it('shows a loading status when Stripe account link status is loading', () => {
+    useConnectStripeAccountMock.mockReturnValue({ isLoading: true });
+    render(<Dashboard />);
+    expect(screen.getByTestId('mock-global-loading')).toBeInTheDocument();
+  });
+});

--- a/spa/src/components/dashboard/Dashboard.test.tsx
+++ b/spa/src/components/dashboard/Dashboard.test.tsx
@@ -9,6 +9,7 @@ jest.mock('elements/GlobalLoading');
 jest.mock('hooks/useConnectStripeAccount');
 jest.mock('hooks/useFeatureFlags');
 jest.mock('hooks/useUser');
+jest.mock('hooks/useRequest');
 
 describe('Dashboard', () => {
   const useConnectStripeAccountMock = useConnectStripeAccount as jest.Mock;
@@ -31,5 +32,11 @@ describe('Dashboard', () => {
     useConnectStripeAccountMock.mockReturnValue({ isLoading: true });
     render(<Dashboard />);
     expect(screen.getByTestId('mock-global-loading')).toBeInTheDocument();
+  });
+
+  it('does not show a loading status when Stripe account link status is not loading', () => {
+    useConnectStripeAccountMock.mockReturnValue({ isLoading: false });
+    render(<Dashboard />);
+    expect(screen.queryByTestId('mock-global-loading')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR makes a minor change such that `Dashboard`'s displays the `GlobalLoading` component instead of the main body if `useConnectStripeAccount`'s return value for `isLoading` is `true`.  This solves for the issue in the ticket — namely, it ensures that the display of the 'Connect to Stripe' modal and toast is not delayed, and instead displays immediately on load of the main body of `Dashboard` (assuming that the account is indeed in need of Stripe connection).

#### Why are we doing this? How does it help us?

Better UX for self-onboarded users.

#### How should this be manually tested? Please include detailed step-by-step instructions.

Create a new account [here in the review app](https://dev-2750.revengine-review.org/sign-in/). 

After going through the account customization step, when taken to the `Dashboard`, you should immediately see the "Connect to Stripe" modal (assuming that you don't have a cookie set to hide it). 

As you go through subsequent Stripe connection steps (up until connecion success), the Stripe Connect toast should be immediately displayed. 

If you sign out and sign back in to the dashboard, it should also display immediately.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes, it adds a very minimal test that shows that `Dashboard` displays the loading component if `useConnectStripeAccount` is loading the account link status from the server.  This is the first and only unit test for the `Dashboard` component. 

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2750](https://news-revenue-hub.atlassian.net/browse/DEV-2750)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No