### PR TITLE
DEV-2633 | Add revenue program to contribution serializer

### DIFF
--- a/apps/contributions/filters.py
+++ b/apps/contributions/filters.py
@@ -29,6 +29,7 @@ class ContributionFilter(django_filters.FilterSet):
             ("status__not", "status__not"),
             ("interval", "interval"),
             ("auto_accept_on", "auto_accept_on"),
+            ("donation_page__revenue_program__name", "revenue_program__name"),
         )
     )
 

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -20,6 +20,7 @@ from apps.contributions.models import (
     PaymentType,
 )
 from apps.contributions.utils import format_ambiguous_currency, get_sha256_hash
+from apps.organizations.serializers import RevenueProgramSerializer
 from apps.pages.models import DonationPage
 
 from .bad_actor import BadActorAPIError, make_bad_actor_request
@@ -57,6 +58,7 @@ class ContributionSerializer(serializers.ModelSerializer):
     provider_payment_url = serializers.SerializerMethodField()
     provider_subscription_url = serializers.SerializerMethodField()
     provider_customer_url = serializers.SerializerMethodField()
+    revenue_program = RevenueProgramSerializer(read_only=True)
 
     def get_auto_accepted_on(self, obj):
         """
@@ -106,22 +108,23 @@ class ContributionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Contribution
         fields = [
-            "id",
+            "amount",
+            "auto_accepted_on",
+            "bad_actor_score",
             "contributor_email",
             "created",
-            "amount",
             "currency",
+            "donation_page_id",
+            "flagged_date",
+            "formatted_payment_provider_used",
+            "id",
             "interval",
             "last_payment_date",
-            "bad_actor_score",
-            "flagged_date",
-            "auto_accepted_on",
-            "formatted_payment_provider_used",
+            "provider_customer_url",
             "provider_payment_url",
             "provider_subscription_url",
-            "provider_customer_url",
+            "revenue_program",
             "status",
-            "donation_page_id",
         ]
 
 

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -30,16 +30,22 @@ from apps.pages.tests.factories import DonationPageFactory
 
 class ContributionSerializer(TestCase):
     expected_fields = [
-        "id",
+        "amount",
+        "auto_accepted_on",
+        "bad_actor_score",
         "contributor_email",
         "created",
-        "amount",
         "currency",
+        "donation_page_id",
+        "flagged_date",
+        "formatted_payment_provider_used",
+        "id",
         "interval",
         "last_payment_date",
-        "bad_actor_score",
-        "flagged_date",
-        "auto_accepted_on",
+        "provider_customer_url",
+        "provider_payment_url",
+        "provider_subscription_url",
+        "revenue_program",
         "status",
     ]
 
@@ -52,8 +58,7 @@ class ContributionSerializer(TestCase):
 
     def test_returned_fields(self):
         data = self.serializer(self.contribution).data
-        for field in self.expected_fields:
-            self.assertIn(field, data)
+        assert set(data.keys()) == set(self.expected_fields)
 
     def test_get_auto_accepted_on(self):
         # Should return null if empty


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

This small PR makes backend changes to support required front end changes in parent ticket ([DEV-1332 | Add Revenue Program to the contributions table display](https://news-revenue-hub.atlassian.net/browse/DEV-1332)).

UAT will happen in DEV-1332, and the base for this ticket is DEV-1332, which will later be merged into main. 

#### What's this PR do?

Adds revenue program as a property to `ContributionSerializer`, using inlined `RevenueProgramSerializer`, which exposes id, name, and slug . Via parent ticket (DEV-1332) the contributions table in SPA is meant to display RP name for each row, in certain situations, so this representation of the RP will provide everything needed.

Also makes contributions sortable by revenue program name.

#### Why are we doing this? How does it help us?

Make it easier for admins of multi-RP Orgs and staff members with access to multiple RPs to navigate contributions table in dashboard.

#### How should this be manually tested? Please include detailed step-by-step instructions.

UAT will happen in parent ticket. In mean time, you can load the contributions table in the review app. If you open dev tools and have a look at the data returned by the `/contributions/` endpoint, each contribution should have a `revenue_program` attribute.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Updates an existing serializer test to account for revenue program being present (and also makes the test stricter so that it proves that the set of of expected keys in serialized contribution is identical to set of actual keys).

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2633 | Add Revenue Program to serializer(https://news-revenue-hub.atlassian.net/browse/DEV-2633)
[DEV-1332 | Add Revenue Program to the contributions table display](https://news-revenue-hub.atlassian.net/browse/DEV-1332)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

[DEV-1332 | Add Revenue Program to the contributions table display](https://news-revenue-hub.atlassian.net/browse/DEV-1332)
