### PR TITLE
Dev 2767 move new block button to top

### DIFF
--- a/spa/src/components/pageEditor/editInterface/EditTabHeader.stories.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditTabHeader.stories.tsx
@@ -1,0 +1,22 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import EditTabHeader from './EditTabHeader';
+
+export default {
+  component: EditTabHeader,
+  title: 'Page Editor/EditTabHeader'
+} as ComponentMeta<typeof EditTabHeader>;
+
+const Template: ComponentStory<typeof EditTabHeader> = (props) => <EditTabHeader {...props} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  addButtonLabel: 'Add Block',
+  prompt: 'This is the prompt text.'
+};
+
+export const NoButton = Template.bind({});
+
+NoButton.args = {
+  prompt: "This header doesn't have a button."
+};

--- a/spa/src/components/pageEditor/editInterface/EditTabHeader.styles.ts
+++ b/spa/src/components/pageEditor/editInterface/EditTabHeader.styles.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
-export const Prompt = styled('span')`
-  color: #707070;
-  font-size: 14px;
+export const Prompt = styled.span`
+  color: ${({ theme }) => theme.colors.muiGrey['600']};
+  font-size: ${({ theme }) => theme.fontSizesUpdated.sm};
 `;
 
-export const Root = styled('div')`
+export const Root = styled.div`
   align-items: center;
   display: flex;
   justify-content: space-between;

--- a/spa/src/components/pageEditor/editInterface/EditTabHeader.styles.ts
+++ b/spa/src/components/pageEditor/editInterface/EditTabHeader.styles.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Prompt = styled('span')`
+  color: #707070;
+  font-size: 14px;
+`;
+
+export const Root = styled('div')`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto;
+  padding-top: 20px;
+  width: 90%; /* mimicking content container */
+`;

--- a/spa/src/components/pageEditor/editInterface/EditTabHeader.test.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditTabHeader.test.tsx
@@ -1,0 +1,47 @@
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import EditTabHeader, { EditTabHeaderProps } from './EditTabHeader';
+
+function tree(props?: Partial<EditTabHeaderProps>) {
+  return render(<EditTabHeader prompt="mock-prompt" {...props} />);
+}
+
+describe('EditTabHeader', () => {
+  it('displays the prompt', () => {
+    tree({ prompt: 'test-prompt' });
+    expect(screen.getByText('test-prompt')).toBeVisible();
+  });
+
+  it("doesn't display an add button if the onAdd prop is omitted", () => {
+    tree({ addButtonLabel: 'test-label' });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it("doesn't display an add button if the addButtonLabel prop is omitted", () => {
+    tree({ onAdd: jest.fn() });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  describe('When both addButtonLabel and onAdd props are provided', () => {
+    it('displays a button with the addButtonLabel text', () => {
+      tree({ addButtonLabel: 'test-label', onAdd: jest.fn() });
+      expect(screen.getByRole('button', { name: 'test-label' })).toBeInTheDocument();
+    });
+
+    it('calls onAdd when the button is clicked', () => {
+      const onAdd = jest.fn();
+
+      tree({ onAdd, addButtonLabel: 'test-label' });
+      expect(onAdd).not.toBeCalled();
+      userEvent.click(screen.getByRole('button', { name: 'test-label' }));
+      expect(onAdd).toBeCalledTimes(1);
+    });
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/pageEditor/editInterface/EditTabHeader.test.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditTabHeader.test.tsx
@@ -37,6 +37,12 @@ describe('EditTabHeader', () => {
       userEvent.click(screen.getByRole('button', { name: 'test-label' }));
       expect(onAdd).toBeCalledTimes(1);
     });
+
+    it('is accessible', async () => {
+      const { container } = tree({ addButtonLabel: 'test-label', onAdd: jest.fn() });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 
   it('is accessible', async () => {

--- a/spa/src/components/pageEditor/editInterface/EditTabHeader.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditTabHeader.tsx
@@ -1,0 +1,33 @@
+import { Add } from '@material-ui/icons';
+import { Button } from 'components/base';
+import PropTypes, { InferProps } from 'prop-types';
+import { Prompt, Root } from './EditTabHeader.styles';
+
+const EditTabHeaderPropTypes = {
+  addButtonLabel: PropTypes.string,
+  onAdd: PropTypes.func,
+  prompt: PropTypes.string.isRequired
+};
+
+export interface EditTabHeaderProps extends InferProps<typeof EditTabHeaderPropTypes> {
+  onAdd?: () => void;
+}
+
+/**
+ * Displays a prompt to the user and optionally a button to add new content.
+ */
+export function EditTabHeader({ addButtonLabel, onAdd, prompt }: EditTabHeaderProps) {
+  return (
+    <Root>
+      <Prompt>{prompt}</Prompt>
+      {addButtonLabel && onAdd && (
+        <Button color="information" startIcon={<Add />} onClick={onAdd}>
+          {addButtonLabel}
+        </Button>
+      )}
+    </Root>
+  );
+}
+
+EditTabHeader.propTypes = EditTabHeaderPropTypes;
+export default EditTabHeader;

--- a/spa/src/components/pageEditor/editInterface/pageElements/PageElements.js
+++ b/spa/src/components/pageEditor/editInterface/pageElements/PageElements.js
@@ -1,13 +1,12 @@
 import * as S from './PageElements.styled';
 
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
-
 // Context
 import { useEditInterfaceContext } from 'components/pageEditor/editInterface/EditInterface';
 
 // Children
 import DraggableList from 'elements/draggable/DraggableList';
 import ScrollBox from 'elements/ScrollBox';
+import EditTabHeader from '../EditTabHeader';
 
 /**
  * PageElements
@@ -22,7 +21,12 @@ function PageElements({ openAddElementModal, goToProperties, handleRemoveElement
 
   return (
     <S.PageElements>
-      {elements && elements?.length > 0 ? (
+      <EditTabHeader
+        addButtonLabel="Add Block"
+        onAdd={openAddElementModal}
+        prompt="Add, edit, and rearrange page sections."
+      />
+      {elements && elements?.length > 0 && (
         <ScrollBox>
           <DraggableList
             elements={elements}
@@ -31,18 +35,9 @@ function PageElements({ openAddElementModal, goToProperties, handleRemoveElement
             handleItemDelete={(element) => handleRemoveElement(element, 'layout')}
           />
         </ScrollBox>
-      ) : (
-        <EmptyElements />
       )}
-      <S.AddElementButton onClick={openAddElementModal} data-testid="add-page-element-button">
-        <S.AddElementIcon icon={faPlus} />
-      </S.AddElementButton>
     </S.PageElements>
   );
 }
 
 export default PageElements;
-
-export function EmptyElements() {
-  return <S.EmptyElements>Click the "plus" button below to start adding page elements</S.EmptyElements>;
-}

--- a/spa/src/components/pageEditor/editInterface/pageSidebarElements/PageSidebarElements.js
+++ b/spa/src/components/pageEditor/editInterface/pageSidebarElements/PageSidebarElements.js
@@ -1,21 +1,24 @@
 import * as S from './PageSidebarElements.styled';
 
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
-
 // Context
 import { useEditInterfaceContext } from 'components/pageEditor/editInterface/EditInterface';
 
 // Children
 import ScrollBox from 'elements/ScrollBox';
 import DraggableList from 'elements/draggable/DraggableList';
-import { EmptyElements } from '../pageElements/PageElements';
+import EditTabHeader from '../EditTabHeader';
 
 function PageSidebarElements({ openAddElementModal, goToProperties, handleRemoveElement }) {
   const { sidebarElements, setSidebarElements } = useEditInterfaceContext();
 
   return (
     <S.PageSidebarElements data-testid="page-sidebar">
-      {sidebarElements && sidebarElements?.length > 0 ? (
+      <EditTabHeader
+        addButtonLabel="Add Block"
+        onAdd={openAddElementModal}
+        prompt="Add, edit, and rearrange sidebar sections."
+      />
+      {sidebarElements && sidebarElements?.length > 0 && (
         <ScrollBox>
           <DraggableList
             elements={sidebarElements}
@@ -24,12 +27,7 @@ function PageSidebarElements({ openAddElementModal, goToProperties, handleRemove
             handleItemDelete={(element) => handleRemoveElement(element, 'sidebar')}
           />
         </ScrollBox>
-      ) : (
-        <EmptyElements />
       )}
-      <S.AddElementButton onClick={openAddElementModal} data-testid="add-sidebar-element-button">
-        <S.AddElementIcon icon={faPlus} />
-      </S.AddElementButton>
     </S.PageSidebarElements>
   );
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Removes the floating + buttons on the two block editing tabs in favor of a labelled button up top. Also removed the "Click the plus button" prompt when a content area is blank.

Because of weirdness I saw working with the page editor Cypress tests, I did some editing there to make tests independent of each other, to make debugging failing tests easier.

#### Why are we doing this? How does it help us?

Clearer UX for the button. It's a [Cypress best practice](https://docs.cypress.io/guides/references/best-practices#Having-tests-rely-on-the-state-of-previous-tests) (and generally a testing best practice) to keep tests independent.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit a contribution page.
2. Add a block to the main content and confirm it saves properly.
3. Add a block to the sidebar and confirm it saves properly.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Yes. Any screenshots showing the page editor tabs should update, and directions will need to change.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

Maybe an updated screenshot?

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2767

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

Related stories for incremental UI updates:
- https://news-revenue-hub.atlassian.net/browse/DEV-2761
- https://news-revenue-hub.atlassian.net/browse/DEV-2763