### PR TITLE
DEV-2880 | Fix bug preventing rejecting flagged recurring contributions (via DEV-2342) 

### DIFF
--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -58,6 +58,7 @@ class ContributionAdmin(RevEngineBaseAdmin, VersionAdmin):
                     "payment_provider_data",
                     "provider_payment_method_id",
                     "provider_payment_method_details",
+                    "provider_setup_intent_id",
                 ),
             },
         ),

--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -54,11 +54,11 @@ class ContributionAdmin(RevEngineBaseAdmin, VersionAdmin):
                     "payment_provider_used",
                     "provider_payment_link",
                     "provider_subscription_link",
+                    "provider_setup_intent_id",
                     "provider_customer_link",
                     "payment_provider_data",
                     "provider_payment_method_id",
                     "provider_payment_method_details",
-                    "provider_setup_intent_id",
                 ),
             },
         ),
@@ -122,6 +122,7 @@ class ContributionAdmin(RevEngineBaseAdmin, VersionAdmin):
         "payment_provider_data",
         "flagged_date",
         "provider_payment_method_details",
+        "provider_setup_intent_id",
     )
 
     actions = (

--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -371,10 +371,10 @@ class Contribution(IndexedTimeStampedModel, RoleAssignmentResourceModelMixin):
                 stripe_account=self.donation_page.revenue_program.stripe_account_id,
             )
         elif self.status == ContributionStatus.FLAGGED:
-            stripe.SetupIntent.cancel(
-                self.provider_setup_intent_id,
+            stripe.PaymentMethod.retrieve(
+                self.provider_payment_method_id,
                 stripe_account=self.donation_page.revenue_program.stripe_account_id,
-            )
+            ).detach()
 
         self.status = ContributionStatus.CANCELED
         self.save()

--- a/apps/contributions/payment_managers.py
+++ b/apps/contributions/payment_managers.py
@@ -128,10 +128,10 @@ class StripePaymentManager(PaymentManager):
     def complete_recurring_payment(self, reject=False):
         if reject:
             try:
-                stripe.SetupIntent.cancel(
-                    self.contribution.provider_setup_intent_id,
-                    stripe_account=self.contribution.donation_page.revenue_program.payment_provider.stripe_account_id,
-                )
+                stripe.PaymentMethod.retrieve(
+                    self.contribution.provider_payment_method_id,
+                    stripe_account=self.contribution.donation_page.revenue_program.stripe_account_id,
+                ).detach()
 
             except stripe.error.StripeError:
                 logger.exception(

--- a/apps/contributions/tests/fixtures/payment-method-attached-webhook.json
+++ b/apps/contributions/tests/fixtures/payment-method-attached-webhook.json
@@ -1,0 +1,61 @@
+{
+  "account": "acct_fakeaccountid",
+  "api_version": "2020-08-27",
+  "created": 1669147991,
+  "data": {
+    "object": {
+      "billing_details": {
+        "address": {
+          "city": "Townville",
+          "country": "US",
+          "line1": "123 Avenue Street",
+          "line2": "",
+          "postal_code": "12345",
+          "state": "Ohio"
+        },
+        "email": "foof@fundjournalism.org",
+        "name": "Foo Bar",
+        "phone": "555-555-5555"
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": "pass",
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "exp_month": 12,
+        "exp_year": 2023,
+        "fingerprint": "t3Nk1zg9IfbJoyRi",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": ["visa"],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1669147991,
+      "customer": "cus_fakeid",
+      "id": "pm_fakeid",
+      "livemode": false,
+      "metadata": {},
+      "object": "payment_method",
+      "type": "card"
+    }
+  },
+  "id": "evt_1M72qCPbhdfvD1kVTDfE0KWp",
+  "livemode": false,
+  "object": "event",
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_O5s4YBlklNH3To",
+    "idempotency_key": "bdd43f79-0d86-491b-9b8c-d309df714a21"
+  },
+  "type": "payment_method.attached"
+}

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -1179,3 +1179,17 @@ def test_payment_success_view():
     url = reverse("payment-success", args=(str(contribution.uuid),))
     response = client.patch(url, {})
     assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.fixture
+def payment_method_attached_event():
+    pass
+
+
+@pytest.mark.django_db
+class TestStripeWebhooksViews:
+    def test_payment_method_attached_happy_path(self, client):
+        pass
+
+    def test_payment_method_attached_when_contribution_not_found(self, client):
+        pass

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -37,7 +37,7 @@ from apps.contributions.stripe_contributions_provider import (
     SubscriptionsCacheProvider,
 )
 from apps.contributions.tasks import task_pull_serialized_stripe_contributions_to_cache
-from apps.contributions.webhooks import StripeWebhookProcessor
+from apps.contributions.webhooks import StripeMetadataError, StripeWebhookProcessor
 from apps.organizations.models import PaymentProvider, RevenueProgram
 from apps.public.permissions import IsActiveSuperUser
 from apps.users.views import FilterQuerySetByUserMixin
@@ -174,7 +174,7 @@ def process_stripe_webhook_view(request):
         logger.info("Processing event.")
         processor = StripeWebhookProcessor(event)
         processor.process()
-    except ValueError:
+    except (StripeMetadataError, ValueError):
         logger.exception()
     except Contribution.DoesNotExist:
         logger.exception("Could not find contribution matching provider_payment_id")

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -37,7 +37,7 @@ from apps.contributions.stripe_contributions_provider import (
     SubscriptionsCacheProvider,
 )
 from apps.contributions.tasks import task_pull_serialized_stripe_contributions_to_cache
-from apps.contributions.webhooks import StripeMetadataError, StripeWebhookProcessor
+from apps.contributions.webhooks import StripeWebhookProcessor
 from apps.organizations.models import PaymentProvider, RevenueProgram
 from apps.public.permissions import IsActiveSuperUser
 from apps.users.views import FilterQuerySetByUserMixin
@@ -174,7 +174,7 @@ def process_stripe_webhook_view(request):
         logger.info("Processing event.")
         processor = StripeWebhookProcessor(event)
         processor.process()
-    except (StripeMetadataError, ValueError):
+    except ValueError:
         logger.exception("Something went wrong processing webhook")
     except Contribution.DoesNotExist:
         logger.exception("Could not find contribution matching provider_payment_id")

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -175,7 +175,7 @@ def process_stripe_webhook_view(request):
         processor = StripeWebhookProcessor(event)
         processor.process()
     except (StripeMetadataError, ValueError):
-        logger.exception()
+        logger.exception("Something went wrong processing webhook")
     except Contribution.DoesNotExist:
         logger.exception("Could not find contribution matching provider_payment_id")
 

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -10,28 +10,11 @@ from apps.slack.models import SlackNotificationTypes
 logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 
-class StripeMetadataError(Exception):
-    pass
-
-
 class StripeWebhookProcessor:
     def __init__(self, event):
         logger.info("StripeWebhookProcessor initialized with event data: %s", event)
         self.event = event
         self.obj_data = self.event.data["object"]
-        self.validate_event_metadata(self.event)
-
-    @staticmethod
-    def validate_event_metadata(event):
-        """ """
-        try:
-            version = event["data"]["object"]["metadata"]["schema_version"]
-        except KeyError:
-            version = None
-        if version != (expected := settings.METADATA_SCHEMA_VERSION):
-            raise StripeMetadataError(
-                f"Unpermitted metadata version in even ({version}) while settings requires {expected}"
-            )
 
     def get_contribution_from_event(self):
         if (event_type := self.obj_data["object"]) == "subscription":

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -152,5 +152,4 @@ class StripeWebhookProcessor:
         if self.event.type == "payment_method.attached":
             contribution = Contribution.objects.get(provider_customer_id=self.obj_data["customer"])
             contribution.provider_payment_method_id = self.obj_data["id"]
-            contribution.provider_payment_method_details = self.obj_data
             contribution.save()

--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -407,6 +407,7 @@ STRIPE_WEBHOOK_EVENTS = [
     "payment_intent.succeeded",
     "customer.subscription.updated",
     "customer.subscription.deleted",
+    "payment_method.attached",
 ]
 
 ### django-healthcheck Settings


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

This PR fixes a bug that was identified in UAT for DEV-2342, which is also the base for this PR.

Once the code here has been approved, and UAT passes, this should be merged into DEV-2342 which — barring any additional bugs being identified — should be ready to merge into `main`.

#### What's this PR do?

The underlying cause of the bug stemmed from the `Contribution.cancel` method ([here](https://github.com/newsrevenuehub/rev-engine/pull/801/files#diff-80bc4fbf647c521d99e0b1e9e38a568c928ed7477e600e7bd110a8e9bc870ae1R373-R377)) as refactored in DEV-2342. As it turns out, you cannot cancel a `SetupIntent` whose status is processing (which is what the setup intents we create have as status after user supplies payment method and confirms payment in Stripe Payment Element in SPA).

The intention with the mistaken SetupIntent.cancel call was (perhaps out of an overabundance of caution) to ensure that no future charge can be made via the flagged-then-rejected contribution’s SetupIntent. 


After consulting a Stripe Dev in their Discord, the suggested back practice is a.) to simply refrain from making a charge to the `SetupIntent`s payment method, or b.) to be more stringent, detach the payment method from the Stripe customer object associated with the transaction.

With this in mind, we’ll pursue option _b_.

For this to strategy to work, I needed to add additional functionality to our Stripe Webhook receiver. Specifically, we now listen for `payment_method.attached` events. These occur when a user completes the Stripe payment form after the revengine API has flagged the related contribution. For flagged contributions, we create Stripe SetupIntent instead of a Stripe Subscription. When the user successfully completes the checkout flow in this case, their payment method is attached to the Setup Intent, and Stripe sends a webhook to our system. We respond to this webhook by attaching the payment method's id to the contribution (as `provider_payment_method_id`).

In turn, this allows us to reject flagged recurring contributions from the Django admin. We can retrieve the payment intent from Stripe (via `provider_payment_method_id`) and use call `detach()` to remove the Stripe customer, which will preclude any future charges.

Additionally, in running this issue down, I realized that I failed to expose provider_setup_intent_id in the Django admin, and that’s a useful bit of information to expose there, so solution for this bug will include that change as well.

#### Why are we doing this? How does it help us?

To unblock DEV-2342

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. In the review app, create a flagged recurring contribution by using the `+flagged` suffix in the email address.
2. Find the contribution in the Django admin, and reject it. This step should be reported as successful in the Django admin.
3. Inspect the contribution's status in the Django admin. It should now be "rejected".
4. Click on the "Provider customer link" for the contribution in the Django admin. This will take you to the Stripe customer in the Stripe dashboard. You should see that the customer does not have a payment method attached to it.


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-2880](https://news-revenue-hub.atlassian.net/browse/DEV-2880)
- [DEV-2342](https://news-revenue-hub.atlassian.net/browse/DEV-2342)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A