### PR TITLE
DEV-2755 |  contribution_metadata not being added to contribution instances

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
@@ -345,3 +346,24 @@ class Contribution(IndexedTimeStampedModel, RoleAssignmentResourceModelMixin):
                     "org_name": self.revenue_program.organization.name,
                 },
             )
+
+    @staticmethod
+    def stripe_metadata(contributor, validated_data, referer):
+        """Generate dict of metadata to be sent to Stripe when creating a PaymentIntent or Subscription"""
+        return {
+            "source": settings.METADATA_SOURCE,
+            "schema_version": settings.METADATA_SCHEMA_VERSION,
+            "contributor_id": contributor.id,
+            "agreed_to_pay_fees": validated_data["agreed_to_pay_fees"],
+            "donor_selected_amount": validated_data["donor_selected_amount"],
+            "reason_for_giving": validated_data["reason_for_giving"],
+            "honoree": validated_data.get("honoree"),
+            "in_memory_of": validated_data.get("in_memory_of"),
+            "comp_subscription": validated_data.get("comp_subscription"),
+            "swag_opt_out": validated_data.get("swag_opt_out"),
+            "swag_choice": validated_data.get("swag_choice"),
+            "referer": referer,
+            "revenue_program_id": validated_data["page"].revenue_program.id,
+            "revenue_program_slug": validated_data["page"].revenue_program.slug,
+            "sf_campaign_id": validated_data.get("sf_campaign_id"),
+        }

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -401,26 +401,6 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
         """Determine if bad actor score should lead to contribution being flagged"""
         return bad_actor_score >= settings.BAD_ACTOR_FAILURE_THRESHOLD
 
-    def get_stripe_payment_metadata(self, contributor, validated_data):
-        """Generate dict of metadata to be sent to Stripe when creating a PaymentIntent or Subscription"""
-        return {
-            "source": settings.METADATA_SOURCE,
-            "schema_version": settings.METADATA_SCHEMA_VERSION,
-            "contributor_id": contributor.id,
-            "agreed_to_pay_fees": validated_data["agreed_to_pay_fees"],
-            "donor_selected_amount": validated_data["donor_selected_amount"],
-            "reason_for_giving": validated_data["reason_for_giving"],
-            "honoree": validated_data.get("honoree"),
-            "in_memory_of": validated_data.get("in_memory_of"),
-            "comp_subscription": validated_data.get("comp_subscription"),
-            "swag_opt_out": validated_data.get("swag_opt_out"),
-            "swag_choice": validated_data.get("swag_choice"),
-            "referer": self.context["request"].META.get("HTTP_REFERER"),
-            "revenue_program_id": validated_data["page"].revenue_program.id,
-            "revenue_program_slug": validated_data["page"].revenue_program.slug,
-            "sf_campaign_id": validated_data.get("sf_campaign_id"),
-        }
-
     def create_stripe_customer(self, contributor, validated_data):
         """Create a Stripe customer using validated data"""
         return contributor.create_stripe_customer(
@@ -449,6 +429,9 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
             "donation_page": validated_data["page"],
             "contributor": contributor,
             "payment_provider_used": "Stripe",
+            "contributor_meta_data": Contribution.stripe_metadata(
+                contributor, validated_data, self.context["request"].META.get("HTTP_REFERER")
+            ),
         }
         if bad_actor_response:
             contribution_data["bad_actor_score"] = bad_actor_response["overall_judgment"]
@@ -497,7 +480,7 @@ class CreateOneTimePaymentSerializer(BaseCreatePaymentSerializer):
         try:
             payment_intent = contribution.create_stripe_one_time_payment_intent(
                 stripe_customer_id=customer["id"],
-                metadata=self.get_stripe_payment_metadata(contributor, validated_data),
+                metadata=contribution.contribution_metadata,
             )
         except StripeError:
             logger.exception(
@@ -552,7 +535,7 @@ class CreateRecurringPaymentSerializer(BaseCreatePaymentSerializer):
         try:
             subscription = contribution.create_stripe_subscription(
                 stripe_customer_id=customer["id"],
-                metadata=self.get_stripe_payment_metadata(contributor, validated_data),
+                metadata=contribution.contribution_metadata,
             )
         except StripeError:
             logger.exception(

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -429,7 +429,7 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
             "donation_page": validated_data["page"],
             "contributor": contributor,
             "payment_provider_used": "Stripe",
-            "contributor_meta_data": Contribution.stripe_metadata(
+            "contribution_metadata": Contribution.stripe_metadata(
                 contributor, validated_data, self.context["request"].META.get("HTTP_REFERER")
             ),
         }

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -1,11 +1,12 @@
 import datetime
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from apps.contributions.models import Contribution, ContributionStatus, Contributor
-from apps.contributions.tests.factories import ContributorFactory
+from apps.contributions.tests.factories import ContributionFactory, ContributorFactory
 from apps.organizations.tests.factories import (
     OrganizationFactory,
     PaymentProviderFactory,
@@ -273,3 +274,37 @@ class ContributionTest(TestCase):
         self.org.save()
         self.contribution.handle_thank_you_email()
         mock_send_email.assert_not_called()
+
+    def test_stripe_metadata(self):
+        referer = "https://somewhere.com"
+        campaign_id = "some-id"
+        contribution = ContributionFactory()
+        validated_data = {
+            "agreed_to_pay_fees": True,
+            "donor_selected_amount": "120",
+            "reason_for_giving": "reason",
+            "honoree": None,
+            "in_memory_of": None,
+            "comp_subscription": False,
+            "swag_opt_out": True,
+            "swag_choice": None,
+            "page": contribution.donation_page,
+            "sf_campaign_id": campaign_id,
+        }
+        assert Contribution.stripe_metadata(contribution.contributor, validated_data, referer) == {
+            "source": settings.METADATA_SOURCE,
+            "schema_version": settings.METADATA_SCHEMA_VERSION,
+            "contributor_id": contribution.contributor.id,
+            "agreed_to_pay_fees": validated_data["agreed_to_pay_fees"],
+            "donor_selected_amount": validated_data["donor_selected_amount"],
+            "reason_for_giving": validated_data["reason_for_giving"],
+            "honoree": validated_data["honoree"],
+            "in_memory_of": validated_data["in_memory_of"],
+            "comp_subscription": validated_data["comp_subscription"],
+            "swag_opt_out": validated_data["swag_opt_out"],
+            "swag_choice": validated_data["swag_choice"],
+            "referer": referer,
+            "revenue_program_id": validated_data["page"].revenue_program.id,
+            "revenue_program_slug": validated_data["page"].revenue_program.slug,
+            "sf_campaign_id": validated_data["sf_campaign_id"],
+        }

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -733,31 +733,6 @@ class TestBaseCreatePaymentSerializer:
         serializer = self.serializer_class(data=minimally_valid_data)
         assert serializer.should_flag(score) is should_fail
 
-    def test_get_stripe_payment_metadata_happy_path(self, minimally_valid_data):
-        contributor = ContributorFactory()
-        referer = "https://www.google.com"
-        request = APIRequestFactory(HTTP_REFERER=referer).post("", {}, format="json")
-        serializer = self.serializer_class(data=minimally_valid_data, context={"request": request})
-        assert serializer.is_valid() is True
-        metadata = serializer.get_stripe_payment_metadata(contributor, serializer.validated_data)
-        assert metadata == {
-            "source": settings.METADATA_SOURCE,
-            "schema_version": settings.METADATA_SCHEMA_VERSION,
-            "contributor_id": contributor.id,
-            "agreed_to_pay_fees": serializer.validated_data["agreed_to_pay_fees"],
-            "donor_selected_amount": serializer.validated_data["donor_selected_amount"],
-            "reason_for_giving": serializer.validated_data["reason_for_giving"],
-            "honoree": serializer.validated_data.get("honoree"),
-            "in_memory_of": serializer.validated_data.get("in_memory_of"),
-            "comp_subscription": serializer.validated_data.get("comp_subscription"),
-            "swag_opt_out": serializer.validated_data.get("swag_opt_out"),
-            "swag_choice": serializer.validated_data.get("swag_choice"),
-            "referer": referer,
-            "revenue_program_id": serializer.validated_data["page"].revenue_program.id,
-            "revenue_program_slug": serializer.validated_data["page"].revenue_program.slug,
-            "sf_campaign_id": serializer.validated_data.get("sf_campaign_id"),
-        }
-
     def test_create_stripe_customer(self, minimally_valid_data, monkeypatch):
         """Show that the `.create_stripe_customer` method calls `Contributor.create_stripe_customer` with
 
@@ -792,7 +767,8 @@ class TestBaseCreatePaymentSerializer:
         contribution_count = Contribution.objects.count()
         bad_actor_data = {"overall_judgment": settings.BAD_ACTOR_FAILURE_THRESHOLD - 1}
         contributor = ContributorFactory()
-        serializer = self.serializer_class(data=minimally_valid_data)
+
+        serializer = self.serializer_class(data=minimally_valid_data, context={"request": APIRequestFactory().post("")})
         assert serializer.is_valid() is True
         contribution = serializer.create_contribution(contributor, serializer.validated_data, bad_actor_data)
         assert Contribution.objects.count() == contribution_count + 1
@@ -815,7 +791,7 @@ class TestBaseCreatePaymentSerializer:
         contribution_count = Contribution.objects.count()
         bad_actor_data = {"overall_judgment": settings.BAD_ACTOR_FAILURE_THRESHOLD}
         contributor = ContributorFactory()
-        serializer = self.serializer_class(data=minimally_valid_data)
+        serializer = self.serializer_class(data=minimally_valid_data, context={"request": APIRequestFactory().post("")})
         assert serializer.is_valid() is True
         contribution = serializer.create_contribution(contributor, serializer.validated_data, bad_actor_data)
         assert Contribution.objects.count() == contribution_count + 1
@@ -838,7 +814,7 @@ class TestBaseCreatePaymentSerializer:
         contribution_count = Contribution.objects.count()
         bad_actor_data = None
         contributor = ContributorFactory()
-        serializer = self.serializer_class(data=minimally_valid_data)
+        serializer = self.serializer_class(data=minimally_valid_data, context={"request": APIRequestFactory().post("")})
         assert serializer.is_valid() is True
         contribution = serializer.create_contribution(contributor, serializer.validated_data, bad_actor_data)
         assert Contribution.objects.count() == contribution_count + 1
@@ -883,7 +859,7 @@ class TestCreateOneTimePaymentSerializer:
         Namely, it should:
 
         - create a contributor
-        - create a contribution
+        - create a contribution that has contribution_metadata
         - add bad actor score to contribution
         - not flag the contribution
         - Create a Stripe Customer
@@ -922,6 +898,7 @@ class TestCreateOneTimePaymentSerializer:
         assert contribution.status == ContributionStatus.PROCESSING
         assert contribution.flagged_date is None
         assert contribution.bad_actor_response == MockBadActorResponseObjectNotBad.mock_bad_actor_response_json
+        assert contribution.contribution_metadata is not None
 
     def test_when_stripe_errors_creating_payment_intent(self, minimally_valid_data, monkeypatch):
         """Demonstrate `.create` when there's a Stripe error when creating payment intent
@@ -953,6 +930,7 @@ class TestCreateOneTimePaymentSerializer:
         assert contributor.contribution_set.count() == 1
         contribution = contributor.contribution_set.first()
         assert contribution.status == ContributionStatus.PROCESSING
+        assert contribution.contribution_metadata is not None
 
     def test_when_stripe_errors_creating_customer(self, minimally_valid_data, monkeypatch):
         """Demonstrate `.create` when there's a Stripe error when creating customer
@@ -982,6 +960,7 @@ class TestCreateOneTimePaymentSerializer:
         assert contributor.contribution_set.count() == 1
         contribution = contributor.contribution_set.first()
         assert contribution.status == ContributionStatus.PROCESSING
+        assert contribution.contribution_metadata is not None
 
     def test_when_contribution_is_flagged(self, minimally_valid_data, monkeypatch):
         """Demonstrate `.create` when the contribution gets flagged
@@ -1016,6 +995,7 @@ class TestCreateOneTimePaymentSerializer:
         # we take the next two assertions as evidence that Stripe PaymentIntent not created
         assert contribution.provider_client_secret_id is None
         assert contribution.provider_payment_id is None
+        assert contribution.contribution_metadata is not None
 
 
 @pytest.mark.django_db
@@ -1037,7 +1017,7 @@ class TestCreateRecurringPaymentSerializer:
         Namely, it should:
 
         - create a contributor
-        - create a contribution
+        - create a contribution that has contribution_metadata
         - add bad actor score to contribution
         - not flag the contribution
         - create a Stripe Customer
@@ -1078,6 +1058,7 @@ class TestCreateRecurringPaymentSerializer:
         assert contribution.bad_actor_response == MockBadActorResponseObjectNotBad.mock_bad_actor_response_json
         assert contribution.payment_provider_data == mock_create_stripe_subscription.return_value
         assert contribution.provider_subscription_id == mock_create_stripe_subscription.return_value["id"]
+        assert contribution.contribution_metadata is not None
 
     def test_when_stripe_errors_creating_subscription(self, minimally_valid_data, monkeypatch):
         """Demonstrate `.create` when there's a Stripe error when creating subscription
@@ -1112,6 +1093,7 @@ class TestCreateRecurringPaymentSerializer:
         assert contribution.provider_subscription_id is None
         assert contribution.provider_client_secret_id is None
         assert contribution.payment_provider_data is None
+        assert contribution.contribution_metadata is not None
 
     def test_when_stripe_errors_creating_customer(self, monkeypatch, minimally_valid_data):
         """Demonstrate `.create` when there's a Stripe error when creating customer
@@ -1145,6 +1127,7 @@ class TestCreateRecurringPaymentSerializer:
         assert contribution.provider_subscription_id is None
         assert contribution.provider_client_secret_id is None
         assert contribution.payment_provider_data is None
+        assert contribution.contribution_metadata is not None
 
     def test_when_contribution_is_flagged(self, minimally_valid_data, monkeypatch):
         """Demonstrate `.create` when the contribution gets flagged.
@@ -1179,6 +1162,7 @@ class TestCreateRecurringPaymentSerializer:
         assert contribution.provider_subscription_id is None
         assert contribution.provider_client_secret_id is None
         assert contribution.payment_provider_data is None
+        assert contribution.contribution_metadata is not None
 
 
 class SubscriptionsSerializer(TestCase):


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Fixes a bug that was causing the `contribution.contribution_metadata` field to be empty in Django admin. The underlying cause was that we simply weren't saving `contribution_metadata`, which probably happened with the far-reaching changes that accompanied supporting the new checkout flow using the Stripe Payment element.

This PR adds a `Contribution.stripe_metadata` static method that can be used to generate metadata that gets attached to Stripe payment intent and subscription and gets set as the `contribution_metadata` field on `Contribution` instances.

#### Why are we doing this? How does it help us?

Make it easier to compare Stripe entities and their NRE contribution counterparts.

#### How should this be manually tested? Please include detailed step-by-step instructions.

In the review app, go through checkout flow to create a new contribution.

Log in to the Django admin and find your new contribution. It should have a JSON blob as value for `contribution_metadata` field.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-2755 | metadata showing as blank on Django Admin contribution detail page](https://news-revenue-hub.atlassian.net/browse/DEV-2755)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A
