### PR TITLE
DEV-2761: Improve save/cancel buttons

### DIFF
--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -150,8 +150,7 @@ describe('Contribution page edit', () => {
 
     it('should render element detail when edit item is clicked', () => {
       cy.editElement('DRichText');
-      cy.getByTestId('element-properties');
-      cy.getByTestId('discard-element-changes-button').click();
+      cy.getByTestId('element-properties').should('exist');
     });
 
     describe('Frequency editor', () => {
@@ -165,7 +164,7 @@ describe('Contribution page edit', () => {
       it('should validate frequency', () => {
         // Uncheck all the frequencies
         cy.getByTestId('frequency-toggle').click({ multiple: true });
-        cy.getByTestId('keep-element-changes-button').click({ force: true });
+        cy.findByRole('button', { name: 'Update' }).click();
         cy.getByTestId('alert').contains('You must have at least');
       });
 
@@ -175,7 +174,7 @@ describe('Contribution page edit', () => {
         // Make a change and save it.
         cy.getByTestId('frequency-toggle').click({ multiple: true });
         cy.getByTestId('frequency-toggle').contains('One time').click();
-        cy.getByTestId('keep-element-changes-button').click({ force: true });
+        cy.findByRole('button', { name: 'Update' }).click();
 
         // Contribution page should only show item checked, and nothing else.
         cy.getByTestId('d-frequency').contains('One time');
@@ -194,7 +193,7 @@ describe('Contribution page edit', () => {
       cy.editElement('DFrequency');
       cy.getByTestId('frequency-editor').find('li').first().click();
       cy.getByTestId('frequency-editor').find('li').click({ multiple: true });
-      cy.getByTestId('keep-element-changes-button').click({ force: true });
+      cy.findByRole('button', { name: 'Update' }).click();
       cy.editElement('DAmount');
     });
 
@@ -249,7 +248,7 @@ describe('Contribution page edit', () => {
         });
 
       cy.contains('One time').siblings('ul').children();
-      cy.getByTestId('discard-element-changes-button').click();
+      cy.findByRole('button', { name: 'Undo' }).click();
     });
   });
 
@@ -257,7 +256,6 @@ describe('Contribution page edit', () => {
     it('should render the DonorInfoEditor', () => {
       cy.editElement('DDonorInfo');
       cy.getByTestId('donor-info-editor').should('exist');
-      cy.getByTestId('discard-element-changes-button').click();
     });
   });
 
@@ -265,7 +263,6 @@ describe('Contribution page edit', () => {
     it('should render the DonorAmountEditor', () => {
       cy.editElement('DDonorAddress');
       cy.getByTestId('donor-address-editor').should('exist');
-      cy.getByTestId('discard-element-changes-button').click();
     });
   });
 
@@ -275,14 +272,12 @@ describe('Contribution page edit', () => {
     it('should render the PaymentEditor', () => {
       cy.editElement('DPayment');
       cy.getByTestId('payment-editor').should('exist');
-      cy.getByTestId('discard-element-changes-button').click();
     });
 
     it('should disable the checkbox to default paying fees if paying fees is turned off', () => {
       cy.editElement('DPayment');
       cy.getByTestId('payment-editor').get('.checkbox').first().click();
       cy.getByTestId('pay-fees-by-default').get('input[type="checkbox"]').should('be.disabled');
-      cy.getByTestId('discard-element-changes-button').click();
     });
   });
 
@@ -361,7 +356,7 @@ describe('Contribution page edit', () => {
       cy.editElement('DRichText');
 
       // Accept changes
-      cy.getByTestId('keep-element-changes-button').click({ force: true });
+      cy.findByRole('button', { name: 'Update' }).click({ force: true });
 
       // Save changes
       cy.getByTestId('save-page-button').click();
@@ -383,9 +378,7 @@ describe('Contribution page edit', () => {
       cy.getByTestId('edit-page-button').click();
       cy.getByTestId('edit-setup-tab').click({ force: true });
       cy.getByTestId('thank-you-redirect-link-input').type('not a valid url');
-      cy.get('#edit-setup-tab-panel').within(() =>
-        cy.getByTestId('keep-element-changes-button').click({ force: true })
-      );
+      cy.get('#edit-setup-tab-panel').within(() => cy.findByRole('button', { name: 'Update' }).click({ force: true }));
 
       // Before we save, let's close the tab so we can more meaningfully assert its presence later.
       cy.getByTestId('preview-page-button').click({ force: true });
@@ -453,10 +446,10 @@ describe('Contribution page edit', () => {
       cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_STYLES) }, {});
 
       cy.getByTestId('edit-page-button').click({ force: true });
-      cy.findByRole('tab', { name: 'Sidebar' }).click();
+      cy.findByRole('tab', { name: 'Sidebar' }).click({ force: true });
       cy.editElement('DRichText');
       cy.get('[class=DraftEditor-editorContainer]').type('New Rich Text');
-      cy.getByTestId('keep-element-changes-button').click();
+      cy.findByRole('button', { name: 'Update' }).click();
       cy.getByTestId('preview-page-button').click();
       cy.get('[data-testid=donation-page__sidebar] > ul > li')
         .should('have.length', 2)
@@ -508,10 +501,8 @@ describe('Edit interface: Setup', () => {
 
     cy.getByTestId('s-page-heading').contains(previousHeading);
     cy.getByTestId('setup-heading-input').clear();
-    cy.getByTestId('setup-heading-input').type(newHeading);
-    cy.get('#edit-setup-tab-panel').within(() =>
-      cy.getByTestId('keep-element-changes-button').scrollIntoView().click()
-    );
+    cy.getByTestId('setup-heading-input').type(newHeading, { force: true });
+    cy.get('#edit-setup-tab-panel').within(() => cy.findByRole('button', { name: 'Update' }).scrollIntoView().click());
     cy.getByTestId('s-page-heading').contains(previousHeading).should('not.exist');
     cy.getByTestId('s-page-heading').contains(newHeading);
 
@@ -527,7 +518,7 @@ describe('Edit interface: Setup', () => {
 
   it('should show a warning when updating a live page', () => {
     cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_STYLES) }, {});
-    cy.getByTestId('edit-layout-tab').click();
+    cy.getByTestId('edit-layout-tab').click({ force: true });
     cy.getByTestId('trash-button').first().click();
     cy.getByTestId('save-page-button').click();
     cy.getByTestId('confirmation-modal').contains("You're making changes to a live contribution page. Continue?");
@@ -592,6 +583,7 @@ describe('Contribution page delete', () => {
     cy.intercept({ method: 'DELETE', pathname: getEndpoint(`${DELETE_PAGE}*/`) }, { statusCode: 204 }).as('deletePage');
     cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_PAGES) }, { body: [], statusCode: 200 });
   });
+
   it('should delete an unpublished page when delete button is pushed', () => {
     cy.intercept(
       { method: 'GET', pathname: getEndpoint(DRAFT_PAGE_DETAIL) },
@@ -608,6 +600,7 @@ describe('Contribution page delete', () => {
     });
     cy.location('pathname').should('eq', CONTENT_SLUG);
   });
+
   it('should show a confirmation modal and delete a published page when delete button is pushed', () => {
     cy.intercept(
       { method: 'GET', pathname: getEndpoint(DRAFT_PAGE_DETAIL) },
@@ -642,6 +635,7 @@ describe('Page load side effects', () => {
     cy.url().should('include', testEditPageUrl);
     cy.wait('@getPageDetail');
   });
+
   it('should NOT contain clearbit.js script in body', () => {
     cy.get('head').find(`script[src*="${CLEARBIT_SCRIPT_SRC}"]`).should('have.length', 0);
   });
@@ -681,7 +675,6 @@ describe('ReasonEditor', () => {
         expect($input).to.be.checked;
       });
     cy.getByTestId('create-reasons').should('exist');
-
     cy.getByTestId('ask-reason').click();
     cy.getByTestId('create-reasons').should('not.exist');
   });

--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -248,7 +248,7 @@ describe('Contribution page edit', () => {
         });
 
       cy.contains('One time').siblings('ul').children();
-      cy.findByRole('button', { name: 'Undo' }).click();
+      cy.findByRole('button', { name: 'Cancel' }).click();
     });
   });
 

--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -550,6 +550,25 @@ describe('Edit interface: Styles', () => {
     cy.getByTestId('edit-style-tab').click({ force: true });
   });
 
+  it("disables the Undo button if the user hasn't made a change", () => {
+    cy.findByRole('button', { name: 'Undo' }).should('be.disabled');
+  });
+
+  it('enables the Undo button when the user makes a change', () => {
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).click();
+    cy.findByText('----none----').click();
+    cy.findByRole('button', { name: 'Undo' }).should('not.be.disabled');
+  });
+
+  it('resets changes when the Undo button is clicked', () => {
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).should('have.value', 'mock-style');
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).click();
+    cy.findByText('----none----').click();
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).should('have.value', '----none----');
+    cy.findByRole('button', { name: 'Undo' }).click();
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).should('have.value', 'mock-style');
+  });
+
   describe('When creating a new style', () => {
     beforeEach(() => {
       cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_FONTS) }, { body: [] });

--- a/spa/cypress/fixtures/pages/live-page-1.json
+++ b/spa/cypress/fixtures/pages/live-page-1.json
@@ -138,6 +138,7 @@
       "inputBackground": "#fff",
       "inputBorder": "#c3c3c3"
     },
+    "name": "mock-style",
     "ruleStyle": "dotted"
   },
   "revenue_program": {

--- a/spa/cypress/fixtures/pages/live-page-1.json
+++ b/spa/cypress/fixtures/pages/live-page-1.json
@@ -2,6 +2,7 @@
   "id": 99,
   "name": "Test Page 1",
   "heading": "Test Heading 1",
+  "post_thank_you_redirect": "https://fundjournalism.org",
   "published_date": "2020-09-17T00:00:00",
   "revenue_program_is_nonprofit": true,
   "plan": {

--- a/spa/src/components/base/ImageUpload/ImageUpload.stories.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import ImageUpload from './ImageUpload';
+
+export default {
+  component: ImageUpload,
+  title: 'Base/ImageUpload'
+} as ComponentMeta<typeof ImageUpload>;
+
+const sampleImageSrc = `
+  <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <defs>
+      <radialGradient id="a"><stop offset="0%" stop-color="green"/><stop offset="200%" stop-color="#00f"/>
+      </radialGradient>
+    </defs>
+    <path fill="url(#a)" d="M0 0h100v100H0z"/>
+  </svg>`;
+
+const sampleImageUri = `data:image/svg+xml;base64,${window.btoa(sampleImageSrc)}`;
+const sampleImageBlob = new Blob([sampleImageSrc], { type: 'image/svg+xml' });
+const sampleImage = new File([sampleImageBlob], 'uploaded-file.svg', { type: 'image/svg+xml' });
+
+const Template: ComponentStory<typeof ImageUpload> = (props) => <ImageUpload {...props} />;
+
+export const Empty = Template.bind({});
+Empty.args = { label: 'Input label', prompt: 'Choose an image' };
+
+export const WithThumbnailOnly = Template.bind({});
+WithThumbnailOnly.args = {
+  label: 'Input label',
+  thumbnailUrl: sampleImageUri
+};
+
+export const WithImage = Template.bind({});
+WithImage.args = {
+  label: 'Input label',
+  thumbnailUrl: sampleImageUri,
+  value: sampleImage
+};

--- a/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
+++ b/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
@@ -1,0 +1,70 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconButton as MuiIconButton } from '@material-ui/core';
+import styled from 'styled-components';
+
+export const IconButton = styled(MuiIconButton)`
+  && {
+    height: 50px;
+    max-height: 50px;
+    max-width: 50px;
+    width: 50px;
+
+    svg {
+      height: auto;
+      width: 12px;
+    }
+
+    &.Mui-disabled {
+      opacity: 0.5;
+    }
+  }
+`;
+
+export const Label = styled.label`
+  font-size: 16px;
+  font-weight: 500;
+  padding-bottom: 0.5rem;
+  grid-area: label;
+`;
+
+export const Preview = styled.div`
+  cursor: pointer;
+  grid-area: preview;
+  height: 100%;
+  position: relative;
+`;
+
+export const Prompt = styled.div`
+  align-items: center;
+  border: 1px solid ${({ theme }) => theme.colors.grey[0]};
+  display: flex;
+  font-size: ${({ theme }) => theme.fontSizesUpdated.sm};
+  height: 100%;
+  justify-content: center;
+`;
+
+export const RemoveIcon = styled(FontAwesomeIcon)`
+  color: ${(props) => props.theme.colors.caution};
+`;
+
+export const Root = styled.div`
+  display: grid;
+  grid-template-areas:
+    'label label'
+    'preview upload'
+    'preview remove';
+  grid-template-columns: 1fr 50px;
+  max-height: 125px;
+`;
+
+export const Thumbnail = styled.img`
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`;
+
+export const UploadIcon = styled(FontAwesomeIcon)`
+  color: ${(props) => props.theme.colors.primary};
+`;

--- a/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
+++ b/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
@@ -21,7 +21,7 @@ export const IconButton = styled(MuiIconButton)`
 `;
 
 export const Label = styled.label`
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
   font-weight: 500;
   padding-bottom: 0.5rem;
   grid-area: label;

--- a/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
+++ b/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
@@ -27,7 +27,9 @@ export const Label = styled.label`
   grid-area: label;
 `;
 
-export const Preview = styled.div`
+export const Preview = styled.button`
+  background: none;
+  border: none;
   cursor: pointer;
   grid-area: preview;
   height: 100%;

--- a/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
@@ -1,0 +1,125 @@
+import { axe } from 'jest-axe';
+import { fireEvent, render, screen, waitFor } from 'test-utils';
+import ImageUpload, { ImageUploadProps } from './ImageUpload';
+
+const mockFile = new File([], 'test.jpeg');
+
+function tree(props?: Partial<ImageUploadProps>) {
+  return render(<ImageUpload id="mock-id" label="mock-label" onChange={jest.fn()} prompt="mock-prompt" {...props} />);
+}
+
+describe('ImageUpload', () => {
+  function changeFile() {
+    // Need to fire the event directly on the input.
+
+    fireEvent.change(document.querySelector('input[type="file"]')!, { target: { files: [mockFile] } });
+  }
+
+  describe('When no image or thumbnail is set', () => {
+    it('displays the prompt prop', () => {
+      tree({ prompt: 'test-prompt' });
+      expect(screen.getByText('test-prompt')).toBeVisible();
+    });
+
+    it('sets the accept property of the file input based on the accept prop', () => {
+      tree({ accept: 'test-accept' });
+      expect(document.querySelector('input[type="file"]')).toHaveAttribute('accept', 'test-accept');
+    });
+
+    it('only accepts a single file', () => {
+      tree();
+      expect(document.querySelector('input[type="file"]')).not.toHaveAttribute('multiple');
+    });
+
+    it('calls the onChange prop with the file and a generated thumbnail when the file input is changed', async () => {
+      const onChange = jest.fn();
+
+      tree({ onChange });
+      expect(onChange).not.toBeCalled();
+      changeFile();
+      await waitFor(() => expect(onChange).toBeCalled());
+      expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
+    });
+
+    it('disables the remove button', () => {
+      tree({});
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree();
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('When only a thumbnail is set', () => {
+    it("doesn't show a prompt", () => {
+      tree({ prompt: 'test-prompt', thumbnailUrl: 'mock-thumbnail' });
+      expect(screen.queryByText('test-prompt')).not.toBeInTheDocument();
+    });
+
+    it('displays an image with the thumbnail', () => {
+      tree({ prompt: 'test-prompt', thumbnailUrl: 'mock-thumbnail' });
+      expect(screen.getByRole('img')).toHaveAttribute('src', 'mock-thumbnail');
+    });
+
+    it('calls the onChange prop with the file and a generated thumbnail when the file input is changed', async () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail' });
+      expect(onChange).not.toBeCalled();
+      changeFile();
+      await waitFor(() => expect(onChange).toBeCalled());
+      expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
+    });
+
+    it('disables the remove button', () => {
+      tree({ thumbnailUrl: 'mock-thumbnail' });
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ thumbnailUrl: 'mock-thumbnail' });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('When both a thumbnail and value is set', () => {
+    it("doesn't show a prompt", () => {
+      tree({ prompt: 'test-prompt', thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(screen.queryByText('test-prompt')).not.toBeInTheDocument();
+    });
+
+    it('calls the onChange prop with the file and a generated thumbnail when the file input is changed', async () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(onChange).not.toBeCalled();
+      changeFile();
+      await waitFor(() => expect(onChange).toBeCalled());
+      expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
+    });
+
+    it('enables the remove button', () => {
+      tree({ thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeEnabled();
+    });
+
+    it('calls the onChange prop with no arguments when the remove button is clicked', () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(onChange).not.toBeCalled();
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(onChange.mock.calls).toEqual([[]]);
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ thumbnailUrl: 'mock-thumbnail', value: mockFile });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
@@ -74,9 +74,18 @@ describe('ImageUpload', () => {
       expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
     });
 
-    it('disables the remove button', () => {
+    it('enables the remove button', () => {
       tree({ thumbnailUrl: 'mock-thumbnail' });
-      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Remove' })).not.toBeDisabled();
+    });
+
+    it('calls the onChange prop with no arguments when the remove button is clicked', () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail' });
+      expect(onChange).not.toBeCalled();
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(onChange.mock.calls).toEqual([[]]);
     });
 
     it('is accessible', async () => {

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -22,6 +22,17 @@ export interface ImageUploadProps extends InferProps<typeof ImageUploadPropTypes
   onChange: (value?: File, thumbnailUrl?: string) => void;
 }
 
+/**
+ * A form control allowing the user to choose an image. The value that the user
+ * sees is fully controlled, but there is a DOM input used to manage changes
+ * whose state may not reflect the value. (This can cause confusion when writing
+ * E2E tests.)
+ *
+ * In most cases, `value` and `thumbnailUrl` should either both be provided or
+ * neither. However, you can specify just a `thumbnailUrl` if you want the
+ * preview of the input to match a state previously saved to the back end. The
+ * remove button will be enabled in this case.
+ */
 export function ImageUpload(props: ImageUploadProps) {
   const {
     accept = 'image/gif,image/jpeg,image/png,image/svg+xml,image/webp',
@@ -71,7 +82,7 @@ export function ImageUpload(props: ImageUploadProps) {
       <IconButton onClick={clickOnHiddenInput} aria-label="Change">
         <UploadIcon icon={faFileUpload} />
       </IconButton>
-      <IconButton disabled={!value} onClick={() => onChange()} aria-label="Remove">
+      <IconButton disabled={!thumbnailUrl && !value} onClick={() => onChange()} aria-label="Remove">
         <RemoveIcon icon={faTimes} />
       </IconButton>
     </Root>

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -66,9 +66,6 @@ export function ImageUpload(props: ImageUploadProps) {
       };
 
       fileReader.readAsDataURL(image);
-    } else {
-      // User didn't select a file, perhaps?
-      onChange();
     }
   }
 

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -72,9 +72,9 @@ export function ImageUpload(props: ImageUploadProps) {
   return (
     <Root className={className!}>
       <Label htmlFor={id}>{label}</Label>
-      <Preview>
-        <input accept={accept!} hidden id={id} onChange={handleChange} ref={inputRef} type="file" />
-        {thumbnailUrl ? <Thumbnail src={thumbnailUrl} alt={value?.name ?? ''} /> : <Prompt>{prompt}</Prompt>}
+      <input accept={accept!} hidden id={id} onChange={handleChange} ref={inputRef} type="file" />
+      <Preview onClick={clickOnHiddenInput}>
+        {thumbnailUrl ? <Thumbnail src={thumbnailUrl} alt={value?.name ?? prompt} /> : <Prompt>{prompt}</Prompt>}
       </Preview>
       <IconButton onClick={clickOnHiddenInput} aria-label="Change">
         <UploadIcon icon={faFileUpload} />

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -1,0 +1,83 @@
+import { faFileUpload, faTimes } from '@fortawesome/free-solid-svg-icons';
+import PropTypes, { InferProps } from 'prop-types';
+import { ChangeEvent, useRef } from 'react';
+import { IconButton, Label, Preview, Prompt, RemoveIcon, Root, Thumbnail, UploadIcon } from './ImageUpload.styled';
+
+const ImageUploadPropTypes = {
+  accept: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  prompt: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  thumbnailUrl: PropTypes.string,
+  value: PropTypes.instanceOf(File)
+};
+
+export interface ImageUploadProps extends InferProps<typeof ImageUploadPropTypes> {
+  /**
+   * Called when the user changes the image. If both arguments are undefined,
+   * the user removed the image.
+   */
+  onChange: (value?: File, thumbnailUrl?: string) => void;
+}
+
+export function ImageUpload(props: ImageUploadProps) {
+  const {
+    accept = 'image/gif,image/jpeg,image/png,image/svg+xml,image/webp',
+    className,
+    id,
+    label,
+    onChange,
+    prompt,
+    thumbnailUrl,
+    value
+  } = props;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function clickOnHiddenInput() {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  }
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    if (event.target.files) {
+      const image = event.target.files[0];
+      const fileReader = new FileReader();
+
+      fileReader.onload = (event) => {
+        if (!event.target) {
+          throw new Error('Creating an image thumbnail failed');
+        }
+
+        onChange(image, event.target.result as string);
+      };
+
+      fileReader.readAsDataURL(image);
+    } else {
+      // User didn't select a file, perhaps?
+      onChange();
+    }
+  }
+
+  return (
+    <Root className={className!}>
+      <Label htmlFor={id}>{label}</Label>
+      <Preview>
+        <input accept={accept!} hidden id={id} onChange={handleChange} ref={inputRef} type="file" />
+        {thumbnailUrl ? <Thumbnail src={thumbnailUrl} alt={value?.name ?? ''} /> : <Prompt>{prompt}</Prompt>}
+      </Preview>
+      <IconButton onClick={clickOnHiddenInput} aria-label="Change">
+        <UploadIcon icon={faFileUpload} />
+      </IconButton>
+      <IconButton disabled={!value} onClick={() => onChange()} aria-label="Remove">
+        <RemoveIcon icon={faTimes} />
+      </IconButton>
+    </Root>
+  );
+}
+
+ImageUpload.propTypes = ImageUploadPropTypes;
+
+export default ImageUpload;

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -1,6 +1,7 @@
 import { faFileUpload, faTimes } from '@fortawesome/free-solid-svg-icons';
 import PropTypes, { InferProps } from 'prop-types';
 import { ChangeEvent, useRef } from 'react';
+import fileToDataUrl from 'utilities/fileToDataUrl';
 import { IconButton, Label, Preview, Prompt, RemoveIcon, Root, Thumbnail, UploadIcon } from './ImageUpload.styled';
 
 const ImageUploadPropTypes = {
@@ -52,20 +53,9 @@ export function ImageUpload(props: ImageUploadProps) {
     }
   }
 
-  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+  async function handleChange(event: ChangeEvent<HTMLInputElement>) {
     if (event.target.files) {
-      const image = event.target.files[0];
-      const fileReader = new FileReader();
-
-      fileReader.onload = (event) => {
-        if (!event.target) {
-          throw new Error('Creating an image thumbnail failed');
-        }
-
-        onChange(image, event.target.result as string);
-      };
-
-      fileReader.readAsDataURL(image);
+      onChange(event.target.files[0], await fileToDataUrl(event.target.files[0]));
     }
   }
 

--- a/spa/src/components/base/Tabs/TabPanel.test.tsx
+++ b/spa/src/components/base/Tabs/TabPanel.test.tsx
@@ -35,5 +35,10 @@ describe('TabPanel', () => {
     expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', 'test-tab-id');
   });
 
+  it('sets its class attribute based on the prop', () => {
+    tree({ className: 'test-class-name' });
+    expect(screen.getByRole('tabpanel')).toHaveClass('test-class-name');
+  });
+
   // AX test happens with <Tabs>.
 });

--- a/spa/src/components/base/Tabs/TabPanel.tsx
+++ b/spa/src/components/base/Tabs/TabPanel.tsx
@@ -3,6 +3,7 @@ import PropTypes, { InferProps } from 'prop-types';
 const TabPanelPropTypes = {
   active: PropTypes.bool,
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
   dontRenderChildrenWhenInactive: PropTypes.bool,
   'data-testid': PropTypes.string,
   id: PropTypes.string.isRequired,
@@ -15,13 +16,14 @@ export type TabPanelProps = InferProps<typeof TabPanelPropTypes>;
 export function TabPanel({
   active,
   children,
+  className,
   'data-testid': testId,
   id,
   tabId,
   unmountChildrenWhenInactive
 }: TabPanelProps) {
   return (
-    <div aria-labelledby={tabId} data-testid={testId} hidden={!active} id={id} role="tabpanel">
+    <div aria-labelledby={tabId} className={className!} data-testid={testId} hidden={!active} id={id} role="tabpanel">
       {(active || !unmountChildrenWhenInactive) && children}
     </div>
   );

--- a/spa/src/components/donationPage/DonationPageNavbar.js
+++ b/spa/src/components/donationPage/DonationPageNavbar.js
@@ -1,30 +1,54 @@
+import { useEffect, useState } from 'react';
+import fileToDataUrl from 'utilities/fileToDataUrl';
 import * as S from './DonationPageNavbar.styled';
 
 function DonationPageNavbar({ page }) {
-  const getImageUrl = (img) => {
-    if (img instanceof File) {
-      return URL.createObjectURL(img);
-    } else return img;
-  };
+  const [headerLogoSrc, setHeaderLogoSrc] = useState('');
+  const [headerBgSrc, setHeaderBgSrc] = useState('');
+
+  // If the user has set new images on either of these properties in the page,
+  // they will exist there as files, not string URLs.
+
+  useEffect(() => {
+    async function run() {
+      if (page?.header_logo instanceof File) {
+        setHeaderLogoSrc(await fileToDataUrl(page?.header_logo));
+      } else {
+        setHeaderLogoSrc(page?.header_logo);
+      }
+    }
+
+    run();
+  }, [page?.header_logo]);
+
+  useEffect(() => {
+    async function run() {
+      if (page?.header_bg_image instanceof File) {
+        setHeaderBgSrc(await fileToDataUrl(page?.header_bg_image));
+      } else {
+        setHeaderBgSrc(page?.header_bg_image);
+      }
+    }
+
+    run();
+  }, [page?.header_bg_image]);
 
   let headerLogoMarkup = null;
 
-  if (page?.header_logo) {
-    headerLogoMarkup = (
-      <S.DonationPageNavbarLogo src={getImageUrl(page?.header_logo)} data-testid="s-header-bar-logo" />
-    );
+  if (headerLogoSrc) {
+    headerLogoMarkup = <S.DonationPageNavbarLogo src={headerLogoSrc} data-testid="s-header-bar-logo" />;
 
     if (page?.header_link) {
       headerLogoMarkup = (
         <a href={page?.header_link} target="_blank" rel="noreferrer noopener" data-testid="s-header-bar-logo-link">
-          <S.DonationPageNavbarLogo src={getImageUrl(page?.header_logo)} />
+          <S.DonationPageNavbarLogo src={headerLogoSrc} />
         </a>
       );
     }
   }
 
   return (
-    <S.DonationPageNavbar bgImg={getImageUrl(page?.header_bg_image)} data-testid="s-header-bar">
+    <S.DonationPageNavbar bgImg={headerBgSrc} data-testid="s-header-bar">
       {headerLogoMarkup}
     </S.DonationPageNavbar>
   );

--- a/spa/src/components/donationPage/pageContent/SGraphic.js
+++ b/spa/src/components/donationPage/pageContent/SGraphic.js
@@ -1,18 +1,34 @@
 import * as S from './SGraphic.styled';
-
-// Util
-import getSrcForImg from 'utilities/getSrcForImg';
-
-// Context
 import { usePage } from 'components/donationPage/DonationPage';
+import { useEffect, useState } from 'react';
+import fileToDataUrl from 'utilities/fileToDataUrl';
+
 function SGraphic() {
   const { page } = usePage();
+  const [graphicSrc, setGraphicSrc] = useState('');
 
-  if (!page.graphic) return null;
+  // If the user has set a new image on the graphic, it will exist in context as
+  // a file instead of a string URL.
+
+  useEffect(() => {
+    async function run() {
+      if (page?.graphic instanceof File) {
+        setGraphicSrc(await fileToDataUrl(page?.graphic));
+      } else {
+        setGraphicSrc(page?.graphic);
+      }
+    }
+
+    run();
+  }, [page?.graphic]);
+
+  if (!graphicSrc) {
+    return null;
+  }
 
   return (
     <S.SGraphicWrapper data-testid="s-graphic">
-      <S.Graphic src={getSrcForImg(page?.graphic)} />
+      <S.Graphic src={graphicSrc} alt="" />
     </S.SGraphicWrapper>
   );
 }

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -186,7 +186,6 @@ function PageEditor() {
         { method: 'GET', url: LIST_STYLES, params: { revenue_program: rpId } },
         {
           onSuccess: ({ data }) => {
-            console.log(data);
             setAvailableStyles(data);
             setLoading(false);
           },

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -100,6 +100,7 @@ function PageEditor() {
     }
   }, []);
 
+  const [availableStylesRpId, setAvailableStylesRpId] = useState();
   const [availableStyles, setAvailableStyles] = useState([]);
 
   const pageTitle = useMemo(
@@ -174,14 +175,18 @@ function PageEditor() {
   }, [pageId, parameters.revProgramSlug, parameters.pageSlug, handleGetPageFailure]);
 
   useEffect(() => {
-    const rpId = page?.revenue_program?.id;
+    // If the revenue program of the page is either available after loading or
+    // has changed, load styles associated with the RP.
 
-    if (rpId) {
+    const rpId = page?.revenue_program?.id;
+    if (rpId && rpId !== availableStylesRpId) {
       setLoading(true);
+      setAvailableStylesRpId(rpId);
       requestGetPageStyles(
         { method: 'GET', url: LIST_STYLES, params: { revenue_program: rpId } },
         {
           onSuccess: ({ data }) => {
+            console.log(data);
             setAvailableStyles(data);
             setLoading(false);
           },
@@ -192,7 +197,7 @@ function PageEditor() {
       );
     }
     // Don't include requestGetPageStyles for now.
-  }, [page]);
+  }, [availableStylesRpId, page]);
 
   const handlePreview = () => {
     setSelectedButton(PREVIEW);

--- a/spa/src/components/pageEditor/editInterface/EditInterface.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.js
@@ -19,7 +19,6 @@ import { usePageContext } from 'components/dashboard/PageContext';
 
 import * as dynamicPageElements from 'components/donationPage/pageContent/dynamicElements';
 import * as dynamicSidebarElements from 'components/donationPage/pageContent/dynamicSidebarElements';
-import { TabPanel } from 'components/base';
 
 const dynamicElements = { ...dynamicPageElements, ...dynamicSidebarElements };
 
@@ -140,7 +139,7 @@ function EditInterface() {
           ) : (
             <>
               <EditInterfaceTabs tab={tab} onChangeTab={setTab} />
-              <TabPanel
+              <S.TabPanel
                 active={tab === 0}
                 id="edit-layout-tab-panel"
                 tabId="edit-layout-tab"
@@ -154,8 +153,8 @@ function EditInterface() {
                   goToProperties={goToProperties}
                   handleRemoveElement={handleRemoveElement}
                 />
-              </TabPanel>
-              <TabPanel
+              </S.TabPanel>
+              <S.TabPanel
                 active={tab === 1}
                 id="edit-sidebar-tab-panel"
                 tabId="edit-sidebar-tab"
@@ -169,13 +168,13 @@ function EditInterface() {
                     setAddElementModalOpen(true);
                   }}
                 />
-              </TabPanel>
-              <TabPanel active={tab === 2} id="edit-setup-tab-panel" tabId="edit-setup-tab">
+              </S.TabPanel>
+              <S.TabPanel active={tab === 2} id="edit-setup-tab-panel" tabId="edit-setup-tab">
                 <PageSetup backToProperties={() => setTab(0)} />
-              </TabPanel>
-              <TabPanel active={tab === 3} id="edit-styles-tab-panel" tabId="edit-styles-tab">
+              </S.TabPanel>
+              <S.TabPanel active={tab === 3} id="edit-styles-tab-panel" tabId="edit-styles-tab">
                 <PageStyles backToProperties={() => setTab(0)} />
-              </TabPanel>
+              </S.TabPanel>
             </>
           )}
         </S.EditInterface>

--- a/spa/src/components/pageEditor/editInterface/EditInterface.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.js
@@ -170,10 +170,10 @@ function EditInterface() {
                 />
               </TabPanel>
               <TabPanel active={tab === 2} id="edit-setup-tab-panel" tabId="edit-setup-tab">
-                <PageSetup backToProperties={() => setTab(0)} />
+                <PageSetup />
               </TabPanel>
               <TabPanel active={tab === 3} id="edit-styles-tab-panel" tabId="edit-styles-tab">
-                <PageStyles backToProperties={() => setTab(0)} />
+                <PageStyles />
               </TabPanel>
             </>
           )}

--- a/spa/src/components/pageEditor/editInterface/EditInterface.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.js
@@ -1,5 +1,5 @@
 import { useState, useContext, createContext, useEffect, useCallback } from 'react';
-import * as S from './EditInterface.styled';
+import { Root, TabPanel } from './EditInterface.styled';
 
 import { usePageEditorContext } from 'components/pageEditor/PageEditor';
 
@@ -133,13 +133,13 @@ function EditInterface() {
       }}
     >
       <>
-        <S.EditInterface {...editInterfaceAnimation} data-testid="edit-interface">
+        <Root {...editInterfaceAnimation} data-testid="edit-interface">
           {selectedElement ? (
             <ElementProperties selectedElementType={selectedElementType} />
           ) : (
             <>
               <EditInterfaceTabs tab={tab} onChangeTab={setTab} />
-              <S.TabPanel
+              <TabPanel
                 active={tab === 0}
                 id="edit-layout-tab-panel"
                 tabId="edit-layout-tab"
@@ -153,8 +153,8 @@ function EditInterface() {
                   goToProperties={goToProperties}
                   handleRemoveElement={handleRemoveElement}
                 />
-              </S.TabPanel>
-              <S.TabPanel
+              </TabPanel>
+              <TabPanel
                 active={tab === 1}
                 id="edit-sidebar-tab-panel"
                 tabId="edit-sidebar-tab"
@@ -168,16 +168,16 @@ function EditInterface() {
                     setAddElementModalOpen(true);
                   }}
                 />
-              </S.TabPanel>
-              <S.TabPanel active={tab === 2} id="edit-setup-tab-panel" tabId="edit-setup-tab">
+              </TabPanel>
+              <TabPanel active={tab === 2} id="edit-setup-tab-panel" tabId="edit-setup-tab">
                 <PageSetup backToProperties={() => setTab(0)} />
-              </S.TabPanel>
-              <S.TabPanel active={tab === 3} id="edit-styles-tab-panel" tabId="edit-styles-tab">
+              </TabPanel>
+              <TabPanel active={tab === 3} id="edit-styles-tab-panel" tabId="edit-styles-tab">
                 <PageStyles backToProperties={() => setTab(0)} />
-              </S.TabPanel>
+              </TabPanel>
             </>
           )}
-        </S.EditInterface>
+        </Root>
         <AddElementModal
           addElementModalOpen={addElementModalOpen}
           setAddElementModalOpen={setAddElementModalOpen}

--- a/spa/src/components/pageEditor/editInterface/EditInterface.styled.ts
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.styled.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
+import { TabPanel as BaseTabPanel } from 'components/base';
 
 export const EditInterface = styled(motion.aside)`
   position: fixed;
@@ -36,4 +37,8 @@ export const EditInterface = styled(motion.aside)`
     box-sizing: inherit;
     outline-color: ${(props) => props.theme.colors.primary};
   }
+`;
+
+export const TabPanel = styled(BaseTabPanel)`
+  height: 100%;
 `;

--- a/spa/src/components/pageEditor/editInterface/EditInterface.styled.ts
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { motion } from 'framer-motion';
 import { TabPanel as BaseTabPanel } from 'components/base';
 
-export const EditInterface = styled(motion.aside)`
+export const Root = styled(motion.aside)`
   position: fixed;
   right: 0;
   top: 0;

--- a/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.styled.ts
+++ b/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.styled.ts
@@ -5,5 +5,6 @@ export const Tabs = styled(BaseTabs)`
   background-color: ${({ theme }) => theme.colors.white};
   position: sticky;
   top: 0;
+  /* To appear above the tab content, which has the default z-index. */
   z-index: 1;
 `;

--- a/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.styled.ts
+++ b/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.styled.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import { Tabs as BaseTabs } from 'components/base';
+
+export const Tabs = styled(BaseTabs)`
+  background-color: ${({ theme }) => theme.colors.white};
+  position: sticky;
+  top: 0;
+  z-index: 1;
+`;

--- a/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditInterfaceTabs.tsx
@@ -1,5 +1,6 @@
-import { Tab, Tabs } from 'components/base';
 import PropTypes, { InferProps } from 'prop-types';
+import { Tab } from 'components/base';
+import { Tabs } from './EditInterfaceTabs.styled';
 
 export const EDIT_INTERFACE_TAB_NAMES = ['Layout', 'Sidebar', 'Setup', 'Style'];
 

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.stories.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import EditSaveControls from './EditSaveControls';
+
+export default {
+  component: EditSaveControls,
+  title: 'Page Editor/EditSaveControls'
+} as ComponentMeta<typeof EditSaveControls>;
+
+const Template: ComponentStory<typeof EditSaveControls> = (props) => <EditSaveControls {...props} />;
+
+export const Default = Template.bind({});

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.stories.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.stories.tsx
@@ -8,4 +8,10 @@ export default {
 
 const Template: ComponentStory<typeof EditSaveControls> = (props) => <EditSaveControls {...props} />;
 
-export const Default = Template.bind({});
+export const Cancel = Template.bind({});
+
+Cancel.args = { variant: 'cancel' };
+
+export const Undo = Template.bind({});
+
+Undo.args = { variant: 'undo' };

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.styles.ts
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.styles.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { Button as BaseButton } from 'components/base';
+
+export const Root = styled('div')`
+  background: white;
+  border-top: 1px solid #c4c4c4;
+  display: flex;
+  gap: 14px;
+  justify-content: flex-end;
+  left: 0;
+  padding: 28px;
+  position: sticky;
+  right: 0;
+  bottom: 0;
+`;
+
+export const Button = styled(BaseButton)`
+  width: 125px;
+`;

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.styles.ts
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Button as BaseButton } from 'components/base';
 
-export const Root = styled('div')`
+export const Root = styled.div`
   background: white;
   border-top: 1px solid #c4c4c4;
   display: flex;

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.test.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.test.tsx
@@ -4,41 +4,79 @@ import { axe } from 'jest-axe';
 import { EditSaveControls, EditSaveControlsProps } from './EditSaveControls';
 
 function tree(props?: Partial<EditSaveControlsProps>) {
-  return render(<EditSaveControls onUndo={jest.fn()} onUpdate={jest.fn()} {...props} />);
+  return render(<EditSaveControls onCancel={jest.fn()} onUpdate={jest.fn()} variant="cancel" {...props} />);
 }
 
 describe('EditSaveControls', () => {
-  it('shows an Undo button', () => {
-    tree();
-    expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
+  describe('Cancel variant', () => {
+    it('shows a Cancel button', () => {
+      tree({ variant: 'cancel' });
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('shows an Update button', () => {
+      tree({ variant: 'undo' });
+      expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+    });
+
+    it('calls the onCancel prop when the Cancel button is clicked', () => {
+      const onCancel = jest.fn();
+
+      tree({ onCancel, variant: 'cancel' });
+      expect(onCancel).not.toBeCalled();
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onCancel).toBeCalledTimes(1);
+    });
+
+    it('calls the onUpdate prop when the Update button is clicked', () => {
+      const onUpdate = jest.fn();
+
+      tree({ onUpdate, variant: 'cancel' });
+      expect(onUpdate).not.toBeCalled();
+      userEvent.click(screen.getByRole('button', { name: 'Update' }));
+      expect(onUpdate).toBeCalledTimes(1);
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ variant: 'cancel' });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 
-  it('shows an Update button', () => {
-    tree();
-    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
-  });
+  describe('Undo variant', () => {
+    it('shows an Undo button', () => {
+      tree({ variant: 'undo' });
+      expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
+    });
 
-  it('calls the onUndo prop when the Undo button is clicked', () => {
-    const onUndo = jest.fn();
+    it('shows an Update button', () => {
+      tree({ variant: 'undo' });
+      expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+    });
 
-    tree({ onUndo });
-    expect(onUndo).not.toBeCalled();
-    userEvent.click(screen.getByRole('button', { name: 'Undo' }));
-    expect(onUndo).toBeCalledTimes(1);
-  });
+    it('calls the onCancel prop when the Undo button is clicked', () => {
+      const onCancel = jest.fn();
 
-  it('calls the onUpdate prop when the Update button is clicked', () => {
-    const onUpdate = jest.fn();
+      tree({ onCancel, variant: 'undo' });
+      expect(onCancel).not.toBeCalled();
+      userEvent.click(screen.getByRole('button', { name: 'Undo' }));
+      expect(onCancel).toBeCalledTimes(1);
+    });
 
-    tree({ onUpdate });
-    expect(onUpdate).not.toBeCalled();
-    userEvent.click(screen.getByRole('button', { name: 'Update' }));
-    expect(onUpdate).toBeCalledTimes(1);
-  });
+    it('calls the onUpdate prop when the Update button is clicked', () => {
+      const onUpdate = jest.fn();
 
-  it('is accessible', async () => {
-    const { container } = tree();
+      tree({ onUpdate, variant: 'undo' });
+      expect(onUpdate).not.toBeCalled();
+      userEvent.click(screen.getByRole('button', { name: 'Update' }));
+      expect(onUpdate).toBeCalledTimes(1);
+    });
 
-    expect(await axe(container)).toHaveNoViolations();
+    it('is accessible', async () => {
+      const { container } = tree({ variant: 'undo' });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 });

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.test.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { EditSaveControls, EditSaveControlsProps } from './EditSaveControls';
+
+function tree(props?: Partial<EditSaveControlsProps>) {
+  return render(<EditSaveControls onUndo={jest.fn()} onUpdate={jest.fn()} {...props} />);
+}
+
+describe('EditSaveControls', () => {
+  it('shows an Undo button', () => {
+    tree();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
+  });
+
+  it('shows an Update button', () => {
+    tree();
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  it('calls the onUndo prop when the Undo button is clicked', () => {
+    const onUndo = jest.fn();
+
+    tree({ onUndo });
+    expect(onUndo).not.toBeCalled();
+    userEvent.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(onUndo).toBeCalledTimes(1);
+  });
+
+  it('calls the onUpdate prop when the Update button is clicked', () => {
+    const onUpdate = jest.fn();
+
+    tree({ onUpdate });
+    expect(onUpdate).not.toBeCalled();
+    userEvent.click(screen.getByRole('button', { name: 'Update' }));
+    expect(onUpdate).toBeCalledTimes(1);
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.test.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.test.tsx
@@ -15,7 +15,7 @@ describe('EditSaveControls', () => {
     });
 
     it('shows an Update button', () => {
-      tree({ variant: 'undo' });
+      tree({ variant: 'cancel' });
       expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
     });
 

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.tsx
@@ -1,0 +1,28 @@
+import PropTypes, { InferProps } from 'prop-types';
+import { Button, Root } from './EditSaveControls.styles';
+
+const EditSaveControlsPropTypes = {
+  onUndo: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired
+};
+
+export interface EditSaveControlsProps extends InferProps<typeof EditSaveControlsPropTypes> {
+  onUndo: () => void;
+  onUpdate: () => void;
+}
+
+export function EditSaveControls({ onUndo, onUpdate }: EditSaveControlsProps) {
+  return (
+    <Root>
+      <Button color="secondary" onClick={onUndo}>
+        Undo
+      </Button>
+      <Button color="primaryDark" onClick={onUpdate}>
+        Update
+      </Button>
+    </Root>
+  );
+}
+
+EditSaveControls.propTypes = EditSaveControlsPropTypes;
+export default EditSaveControls;

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.tsx
@@ -1,22 +1,33 @@
+import { Undo } from '@material-ui/icons';
 import PropTypes, { InferProps } from 'prop-types';
 import { Button, Root } from './EditSaveControls.styles';
 
 const EditSaveControlsPropTypes = {
-  onUndo: PropTypes.func.isRequired,
-  onUpdate: PropTypes.func.isRequired
+  cancelDisabled: PropTypes.bool,
+  onCancel: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  variant: PropTypes.oneOf(['cancel', 'undo']).isRequired
 };
 
 export interface EditSaveControlsProps extends InferProps<typeof EditSaveControlsPropTypes> {
-  onUndo: () => void;
+  onCancel: () => void;
   onUpdate: () => void;
+  variant: 'cancel' | 'undo';
 }
 
-export function EditSaveControls({ onUndo, onUpdate }: EditSaveControlsProps) {
+export function EditSaveControls({ cancelDisabled, onCancel, onUpdate, variant }: EditSaveControlsProps) {
   return (
     <Root>
-      <Button color="secondary" onClick={onUndo}>
-        Undo
-      </Button>
+      {variant === 'cancel' && (
+        <Button color="secondary" disabled={!!cancelDisabled} onClick={onCancel}>
+          Cancel
+        </Button>
+      )}
+      {variant === 'undo' && (
+        <Button color="text" disabled={!!cancelDisabled} onClick={onCancel} startIcon={<Undo />}>
+          Undo
+        </Button>
+      )}
       <Button color="primaryDark" onClick={onUpdate}>
         Update
       </Button>

--- a/spa/src/components/pageEditor/editInterface/EditSaveControls.tsx
+++ b/spa/src/components/pageEditor/editInterface/EditSaveControls.tsx
@@ -1,5 +1,6 @@
 import { Undo } from '@material-ui/icons';
 import PropTypes, { InferProps } from 'prop-types';
+import { ReactNode } from 'react';
 import { Button, Root } from './EditSaveControls.styles';
 
 const EditSaveControlsPropTypes = {
@@ -16,18 +17,23 @@ export interface EditSaveControlsProps extends InferProps<typeof EditSaveControl
 }
 
 export function EditSaveControls({ cancelDisabled, onCancel, onUpdate, variant }: EditSaveControlsProps) {
+  const commonSecondaryProps = { disabled: !!cancelDisabled, onClick: onCancel };
+  const secondaryButtons: Record<EditSaveControlsProps['variant'], ReactNode> = {
+    cancel: (
+      <Button color="secondary" {...commonSecondaryProps}>
+        Cancel
+      </Button>
+    ),
+    undo: (
+      <Button color="text" startIcon={<Undo />} {...commonSecondaryProps}>
+        Undo
+      </Button>
+    )
+  };
+
   return (
     <Root>
-      {variant === 'cancel' && (
-        <Button color="secondary" disabled={!!cancelDisabled} onClick={onCancel}>
-          Cancel
-        </Button>
-      )}
-      {variant === 'undo' && (
-        <Button color="text" disabled={!!cancelDisabled} onClick={onCancel} startIcon={<Undo />}>
-          Undo
-        </Button>
-      )}
+      {secondaryButtons[variant]}
       <Button color="primaryDark" onClick={onUpdate}>
         Update
       </Button>

--- a/spa/src/components/pageEditor/editInterface/pageElements/ElementProperties.js
+++ b/spa/src/components/pageEditor/editInterface/pageElements/ElementProperties.js
@@ -30,7 +30,6 @@ const dynamicElements = { ...dynamicPageElements, ...dynamicSidebarElements };
  */
 function ElementProperties({ selectedElementType }) {
   const alert = useAlert();
-
   const {
     selectedElement,
     setSelectedElement,
@@ -102,7 +101,7 @@ function ElementProperties({ selectedElementType }) {
         )}
       </S.ElementHeading>
       <S.ElementEditor>{getElementEditor(selectedElement.type)}</S.ElementEditor>
-      <EditSaveControls onUndo={handleDiscardChanges} onUpdate={handleKeepChanges} />
+      <EditSaveControls onCancel={handleDiscardChanges} onUpdate={handleKeepChanges} variant="cancel" />
     </S.ElementProperties>
   );
 }

--- a/spa/src/components/pageEditor/editInterface/pageElements/ElementProperties.js
+++ b/spa/src/components/pageEditor/editInterface/pageElements/ElementProperties.js
@@ -6,17 +6,17 @@ import { useAlert } from 'react-alert';
 import getElementEditor, { getElementValidator } from 'components/pageEditor/elementEditors/getElementEditor';
 
 // Assets
-import { faCheck, faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 // Context
 import { useEditInterfaceContext } from 'components/pageEditor/editInterface/EditInterface';
 
 // Children
-import CircleButton from 'elements/buttons/CircleButton';
 import { NoComponentError } from 'components/donationPage/pageGetters';
 
 import * as dynamicPageElements from 'components/donationPage/pageContent/dynamicElements';
 import * as dynamicSidebarElements from 'components/donationPage/pageContent/dynamicSidebarElements';
+import EditSaveControls from 'components/pageEditor/editInterface/EditSaveControls';
 
 const dynamicElements = { ...dynamicPageElements, ...dynamicSidebarElements };
 
@@ -102,22 +102,7 @@ function ElementProperties({ selectedElementType }) {
         )}
       </S.ElementHeading>
       <S.ElementEditor>{getElementEditor(selectedElement.type)}</S.ElementEditor>
-      <S.ButtonsSection>
-        <S.Buttons>
-          <CircleButton
-            icon={faCheck}
-            buttonType="positive"
-            onClick={handleKeepChanges}
-            data-testid="keep-element-changes-button"
-          />
-          <CircleButton
-            icon={faTimes}
-            buttonType="caution"
-            onClick={handleDiscardChanges}
-            data-testid="discard-element-changes-button"
-          />
-        </S.Buttons>
-      </S.ButtonsSection>
+      <EditSaveControls onUndo={handleDiscardChanges} onUpdate={handleKeepChanges} />
     </S.ElementProperties>
   );
 }

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -18,7 +18,7 @@ import EditTabHeader from '../EditTabHeader';
  *
  * PageSetup is the direct child of EditInterface.
  */
-function PageSetup({ backToProperties }) {
+function PageSetup() {
   const { page, errors } = usePageEditorContext();
   const { setPageContent } = useEditInterfaceContext();
 
@@ -49,7 +49,6 @@ function PageSetup({ backToProperties }) {
       donor_benefits,
       published_date
     });
-    backToProperties();
   };
 
   const handleDiscardChanges = () => {

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -137,7 +137,7 @@ function PageSetup() {
         )}
         <InputWrapper border>
           <Input
-            type="ext"
+            type="text"
             label="Form panel heading"
             value={heading}
             onChange={(e) => setPageHeading(e.target.value)}

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -161,7 +161,7 @@ function PageSetup({ backToProperties }) {
           />
         </S.InputWrapper>
       </S.Controls>
-      <EditSaveControls onUndo={handleDiscardChanges} onUpdate={handleKeepChanges} />
+      <EditSaveControls onCancel={handleDiscardChanges} onUpdate={handleKeepChanges} variant="undo" />
     </S.PageSetup>
   );
 }

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -1,9 +1,6 @@
 import { useState } from 'react';
 import * as S from './PageSetup.styled';
 
-// Assets
-import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
-
 // Context
 import { usePageEditorContext } from 'components/pageEditor/PageEditor';
 import { useEditInterfaceContext } from 'components/pageEditor/editInterface/EditInterface';
@@ -15,7 +12,7 @@ import { isBefore, isAfter } from 'date-fns';
 // Children
 import ImageWithPreview from 'elements/inputs/ImageWithPreview';
 import Input from 'elements/inputs/Input';
-import CircleButton from 'elements/buttons/CircleButton';
+import EditSaveControls from '../EditSaveControls';
 import EditTabHeader from '../EditTabHeader';
 
 /**
@@ -36,8 +33,8 @@ function PageSetup({ backToProperties }) {
   const [header_link, setHeaderLink] = useState(page.header_link);
   const [thank_you_redirect, setThankYouRedirect] = useState(page.thank_you_redirect);
   const [post_thank_you_redirect, setPostThankYouRedirect] = useState(page.post_thank_you_redirect);
-  const [donor_benefits, setDonorBenefits] = useState(page.donor_benefits);
-  const [published_date, setPublishedDate] = useState(page.published_date ? new Date(page.published_date) : undefined);
+  const [donor_benefits] = useState(page.donor_benefits);
+  const [published_date] = useState(page.published_date ? new Date(page.published_date) : undefined);
 
   const handleKeepChanges = () => {
     verifyUnpublish(updatePage);
@@ -164,20 +161,7 @@ function PageSetup({ backToProperties }) {
           />
         </S.InputWrapper>
       </S.Controls>
-      <S.Buttons>
-        <CircleButton
-          icon={faCheck}
-          buttonType="positive"
-          onClick={handleKeepChanges}
-          data-testid="keep-element-changes-button"
-        />
-        <CircleButton
-          icon={faTimes}
-          buttonType="caution"
-          onClick={handleDiscardChanges}
-          data-testid="discard-element-changes-button"
-        />
-      </S.Buttons>
+      <EditSaveControls onUndo={handleDiscardChanges} onUpdate={handleKeepChanges} />
     </S.PageSetup>
   );
 }

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.styled.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const PageSetup = styled.div`
+export const Root = styled.div`
   display: flex;
   flex-direction: column;
 `;
@@ -20,6 +20,12 @@ export const ImageSelectorWrapper = styled.div`
   padding-bottom: 2rem;
 
   border-bottom: 1px solid ${(props) => props.theme.colors.grey[0]};
+`;
+
+export const ImageSelectorHelpText = styled.div`
+  font-style: italic;
+  font-weight: 200;
+  margin-top: 1rem;
 `;
 
 export const InputWrapper = styled.div`

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.styled.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.styled.js
@@ -27,17 +27,3 @@ export const InputWrapper = styled.div`
   border-bottom: ${(props) => (props.border ? '1px solid' : 'none')};
   border-color: ${(props) => props.theme.colors.grey[0]};
 `;
-
-export const Buttons = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding-top: 1rem;
-  margin-bottom: 2rem;
-
-  & button:not(:last-child) {
-    margin-right: 2rem;
-  }
-`;

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
@@ -48,7 +48,7 @@ function PageStyles({ backToProperties }) {
       <Controls>
         <StylesChooser styles={availableStyles} selected={styles} setSelected={setStyles} />
       </Controls>
-      <EditSaveControls onUndo={handleDiscardChanges} onUpdate={handleKeepChanges} />
+      <EditSaveControls onCancel={handleDiscardChanges} onUpdate={handleKeepChanges} variant="undo" />
       <AddStylesModal
         isOpen={addStylesModalOpen}
         closeModal={handleAddStylesModalClose}

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
@@ -1,8 +1,5 @@
 import { useState } from 'react';
-import { Buttons, Controls, Root } from './PageStyles.styled';
-
-// Assets
-import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { Controls, Root } from './PageStyles.styled';
 
 // Context
 import { usePageEditorContext } from 'components/pageEditor/PageEditor';
@@ -10,9 +7,9 @@ import { useEditInterfaceContext } from 'components/pageEditor/editInterface/Edi
 
 // Children
 import useModal from 'hooks/useModal';
-import CircleButton from 'elements/buttons/CircleButton';
 import StylesChooser from 'components/pageEditor/editInterface/pageStyles/StylesChooser';
 import AddStylesModal from 'components/pageEditor/editInterface/pageStyles/AddStylesModal';
+import EditSaveControls from '../EditSaveControls';
 import EditTabHeader from '../EditTabHeader';
 
 function PageStyles({ backToProperties }) {
@@ -51,20 +48,7 @@ function PageStyles({ backToProperties }) {
       <Controls>
         <StylesChooser styles={availableStyles} selected={styles} setSelected={setStyles} />
       </Controls>
-      <Buttons>
-        <CircleButton
-          icon={faCheck}
-          buttonType="positive"
-          onClick={handleKeepChanges}
-          data-testid="keep-element-changes-button"
-        />
-        <CircleButton
-          icon={faTimes}
-          buttonType="caution"
-          onClick={handleDiscardChanges}
-          data-testid="discard-element-changes-button"
-        />
-      </Buttons>
+      <EditSaveControls onUndo={handleDiscardChanges} onUpdate={handleKeepChanges} />
       <AddStylesModal
         isOpen={addStylesModalOpen}
         closeModal={handleAddStylesModalClose}

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
@@ -30,7 +30,8 @@ function PageStyles({ backToProperties }) {
   };
 
   const handleDiscardChanges = () => {
-    backToProperties();
+    console.log('Undoing styles');
+    setStyles(page.styles);
   };
 
   const handleAddNewStyles = (newStyles) => {
@@ -48,7 +49,12 @@ function PageStyles({ backToProperties }) {
       <Controls>
         <StylesChooser styles={availableStyles} selected={styles} setSelected={setStyles} />
       </Controls>
-      <EditSaveControls onCancel={handleDiscardChanges} onUpdate={handleKeepChanges} variant="undo" />
+      <EditSaveControls
+        cancelDisabled={styles === page.styles}
+        onCancel={handleDiscardChanges}
+        onUpdate={handleKeepChanges}
+        variant="undo"
+      />
       <AddStylesModal
         isOpen={addStylesModalOpen}
         closeModal={handleAddStylesModalClose}

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
@@ -12,7 +12,7 @@ import AddStylesModal from 'components/pageEditor/editInterface/pageStyles/AddSt
 import EditSaveControls from '../EditSaveControls';
 import EditTabHeader from '../EditTabHeader';
 
-function PageStyles({ backToProperties }) {
+function PageStyles() {
   const { page, availableStyles, setAvailableStyles } = usePageEditorContext();
   const { setPageContent } = useEditInterfaceContext();
   const {
@@ -26,11 +26,9 @@ function PageStyles({ backToProperties }) {
 
   const handleKeepChanges = () => {
     setPageContent({ styles });
-    backToProperties();
   };
 
   const handleDiscardChanges = () => {
-    console.log('Undoing styles');
     setStyles(page.styles);
   };
 

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.styled.ts
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.styled.ts
@@ -3,23 +3,11 @@ import styled from 'styled-components';
 export const Root = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-export const Buttons = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding-top: 1rem;
-  margin-bottom: 2rem;
-
-  & button:not(:last-child) {
-    margin-right: 2rem;
-  }
+  height: 100%;
 `;
 
 export const Controls = styled.div`
+  flex-grow: 1;
   width: 90%;
   margin: 2rem auto;
 `;

--- a/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
@@ -2,13 +2,13 @@ import * as S from './StylesChooser.styled';
 import Select from 'elements/inputs/Select';
 
 function StylesChooser({ styles = [], selected, setSelected }) {
-  // selectedItem is coerced to an empty string if it's null to prevent React
-  // from treating the select as an uncontrolled component.
   return (
     <S.StylesChooser>
       <Select
         label="Choose from existing styles"
         onSelectedItemChange={({ selectedItem }) => setSelected(selectedItem)}
+        // selectedItem is coerced to an empty string if it's null to prevent React
+        // from treating the select as an uncontrolled component.
         selectedItem={selected === null ? '' : selected}
         items={[{ name: '----none----', id: '' }].concat(styles)}
         itemToString={(i) => i.name}

--- a/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
@@ -2,12 +2,14 @@ import * as S from './StylesChooser.styled';
 import Select from 'elements/inputs/Select';
 
 function StylesChooser({ styles = [], selected, setSelected }) {
+  // selectedItem is coerced to an empty string if it's null to prevent React
+  // from treating the select as an uncontrolled component.
   return (
     <S.StylesChooser>
       <Select
         label="Choose from existing styles"
         onSelectedItemChange={({ selectedItem }) => setSelected(selectedItem)}
-        selectedItem={selected}
+        selectedItem={selected === null ? '' : selected}
         items={[{ name: '----none----', id: '' }].concat(styles)}
         itemToString={(i) => i.name}
         placeholder="Select a style"

--- a/spa/src/components/pageEditor/elementEditors/image/ImageEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/image/ImageEditor.js
@@ -21,6 +21,10 @@ function ImageEditor() {
 ImageEditor.for = 'DImage';
 
 ImageEditor.hasErrors = (file) => {
+  if (!file) {
+    return false;
+  }
+
   // 2.5e6 bytes == 2.5MB
   const fileIsTooBig = file.size >= 2.5e6;
   if (fileIsTooBig) {

--- a/spa/src/utilities/fileToDataUrl.test.ts
+++ b/spa/src/utilities/fileToDataUrl.test.ts
@@ -1,0 +1,38 @@
+import fileToDataUrl from './fileToDataUrl';
+
+describe('fileToDataUrl', () => {
+  const testFile = new File(['abc'], 'test.jpeg');
+
+  it('resolves to a data URI for a file', async () => {
+    expect(await fileToDataUrl(testFile)).toBe(`data:application/octet-stream;base64,${window.btoa('abc')}`);
+  });
+
+  it('rejects if reading the file fails', async () => {
+    const readAsDataUrlSpy = jest.spyOn(FileReader.prototype, 'readAsDataURL');
+
+    // Avoiding an arrow function to keep `this` binding.
+
+    readAsDataUrlSpy.mockImplementation(function () {
+      // TypeScript doesn't like this usage of `this` because it doesn't know
+      // what the function is being attached to.
+      // @ts-expect-error
+      (this as any).onloaderror(new Error());
+    });
+
+    await expect(() => fileToDataUrl(testFile)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('rejects if reading the file succeeds but the resulting event has no target', async () => {
+    const readAsDataUrlSpy = jest.spyOn(FileReader.prototype, 'readAsDataURL');
+
+    // Avoiding an arrow function to keep `this` binding.
+
+    readAsDataUrlSpy.mockImplementation(function () {
+      // See comment above.
+      // @ts-expect-error
+      (this as any).onload({});
+    });
+
+    await expect(() => fileToDataUrl(testFile)).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/spa/src/utilities/fileToDataUrl.ts
+++ b/spa/src/utilities/fileToDataUrl.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns a data URI for an in-browser file.
+ */
+export function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+      if (!event.target) {
+        reject(new Error('FileReader has no target property on load event'));
+      }
+
+      resolve(event.target!.result as string);
+    };
+    reader.onerror = reject;
+
+    reader.readAsDataURL(file);
+  });
+}
+
+export default fileToDataUrl;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Replaces the label-less save/cancel buttons in the page editor with new designs.
- Updates page editor tabs so that they stay on top of a panel when it scrolls. This looks weird locally because the Django code at the top of the page, but should look OK in a review app (and a real one).
- Adds a `className` prop to the base TabPanel component for styling purposes.

#### Why are we doing this? How does it help us?

Better UX.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit a contribution page.
2. Confirm that the Update/Undo buttons on the Setup and Style tabs match the Figma comp.
3. Make a change on the Setup tab and hit Undo. Confirm that it reverts the change.
4. Make a change on the Setup tab and hit Update. Confirm that it updates the page preview.
5. Make a change on the Style tab and hit Undo. Confirm that it reverts the change.
6. Make a change on the Style tab and hit Update. Confirm that it updates the page preview.
7. Go to the Layout tab and scroll the tab content downward. Confirm the tabs at the top stay visible and are in the correct position (as opposed to scrolling with the rest of the tab content).
8. Edit an element on the Layout tab. Confirm the Update/Undo buttons match the Figma comp.
9. Make a change to an element on the Layout tab and hit Undo. Confirm that it reverts the change.
10. Make a change to an element on the Layout tab and hit Update. Confirm that it updates the page preview.
11. Edit an element on the Sidebar tab (you might have to add one). Confirm the Update/Undo buttons match the Figma comp.
12. Make a change to an element on the Sidebar tab and hit Undo. Confirm that it reverts the change.
13. Make a change to an element on the Sidebar tab and hit Update. Confirm that it updates the page preview.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Yes. Screenshots will need to change of the edit interface.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

Updated documentation I think.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

Not that I know of.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2761

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.