### PR TITLE
DEV-2897: Limit Chromatic runs based on branch name and code changed

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,11 +13,31 @@ on:
       - staging
       - test
 
-# Copied from https://www.chromatic.com/docs/github-actions
-
 # List of jobs
 jobs:
+  # Only run if SPA code has changed
+  check-changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      spa: ${{ steps.filter.outputs.spa }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            spa:
+              - 'spa/**'
+  # Copied from https://www.chromatic.com/docs/github-actions
   chromatic-deployment:
+    needs: check-changes
+    if: ${{ needs.changes.outputs.spa == 'true' }}
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,14 @@
 name: "Chromatic"
 
 # Event for the workflow
-on: push
+on:
+  push:
+    branches-ignore:
+      - demo
+      - "dependabot/**"
+      - develop
+      - staging
+      - test
 
 # Copied from https://www.chromatic.com/docs/github-actions
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Blocks Chromatic CI from running on the branches listed in the YAML below. I kept `main` in for now with the idea that it is a baseline for comparison. We can revisit that later if we find ourselves bumping against the snapshot limit.

- Doesn't run Chromatic in CI for PRs that don't modify code in `spa/`.

#### Why are we doing this? How does it help us?

Faster CI, prevents useless snapshots.

#### How should this be manually tested? Please include detailed step-by-step instructions.

n/a I think since it only runs in CI. You can see Chromatic not running in this PR, but we need to check once merged that Chromatic does run on SPA commits. Alternatively, we could do a test commit on this PR that changes SPA code to show it does the right thing.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No, CI only.

#### How should this change be communicated to end users?

Not needed.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2897

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.