### PR TITLE
DEV-1758: Include timezone in receipt emails

### DIFF
--- a/apps/emails/helpers.py
+++ b/apps/emails/helpers.py
@@ -2,15 +2,11 @@ import zoneinfo
 
 from django.utils import timezone
 
-import pytz
 
-
-def convert_to_timezone(utctime, selected_timezone=None):
-    fmt = "%m-%d-%y %H:%M %Z"
-    utc = utctime.replace(tzinfo=pytz.UTC)
+def convert_to_timezone_formatted(utc, selected_timezone=None, date_format="%m-%d-%y %H:%M %Z"):
     if selected_timezone:
         localtz = utc.astimezone(zoneinfo.ZoneInfo(selected_timezone))
     else:
-        # TODO: update function to get client's timezone
+        # TODO: DEV-2904 show correct time/date/zone in transactional emails -> update function to get client's timezone
         localtz = utc.astimezone(timezone.get_current_timezone())
-    return localtz.strftime(fmt)
+    return localtz.strftime(date_format)

--- a/apps/emails/helpers.py
+++ b/apps/emails/helpers.py
@@ -1,0 +1,16 @@
+import zoneinfo
+
+from django.utils import timezone
+
+import pytz
+
+
+def convert_to_timezone(utctime, selected_timezone=None):
+    fmt = "%m-%d-%y %H:%M %Z"
+    utc = utctime.replace(tzinfo=pytz.UTC)
+    if selected_timezone:
+        localtz = utc.astimezone(zoneinfo.ZoneInfo(selected_timezone))
+    else:
+        # TODO: update function to get client's timezone
+        localtz = utc.astimezone(timezone.get_current_timezone())
+    return localtz.strftime(fmt)

--- a/apps/emails/tasks.py
+++ b/apps/emails/tasks.py
@@ -11,6 +11,7 @@ from celery.utils.log import get_task_logger
 from stripe.error import StripeError
 
 from apps.contributions.models import Contribution, Contributor
+from apps.emails.helpers import convert_to_timezone
 
 
 logger = get_task_logger(f"{settings.DEFAULT_LOGGER}.{__name__}")
@@ -76,7 +77,7 @@ def send_thank_you_email(contribution_id: int, contribution_date: datetime, copy
         "nrh-default-contribution-confirmation-email.txt",
         "nrh-default-contribution-confirmation-email.html",
         {
-            "contribution_date": contribution_date.strftime("%m-%d-%y"),
+            "contribution_date": convert_to_timezone(contribution_date, "America/New_York"),
             "contributor_email": contribution.contributor.email,
             "contribution_amount": contribution.formatted_amount,
             "contribution_interval": contribution.interval,

--- a/apps/emails/tasks.py
+++ b/apps/emails/tasks.py
@@ -9,7 +9,7 @@ from celery.utils.log import get_task_logger
 from stripe.error import StripeError
 
 from apps.contributions.models import Contribution, Contributor
-from apps.emails.helpers import convert_to_timezone
+from apps.emails.helpers import convert_to_timezone_formatted
 
 
 logger = get_task_logger(f"{settings.DEFAULT_LOGGER}.{__name__}")
@@ -75,7 +75,7 @@ def send_thank_you_email(contribution_id: int):
         "nrh-default-contribution-confirmation-email.txt",
         "nrh-default-contribution-confirmation-email.html",
         {
-            "contribution_date": convert_to_timezone(contribution.created, "America/New_York"),
+            "contribution_date": convert_to_timezone_formatted(contribution.created, "America/New_York"),
             "contributor_email": contribution.contributor.email,
             "contribution_amount": contribution.formatted_amount,
             "contribution_interval": contribution.interval,

--- a/apps/emails/templates/nrh-default-contribution-base-template.html
+++ b/apps/emails/templates/nrh-default-contribution-base-template.html
@@ -131,7 +131,7 @@
                       <div class="contribution-container">
                         <p class="contribution-header">Contribution Details</p>
                         <p class="contribution-details">
-                          <span class="contribution-details-strong">Date&nbsp;
+                          <span class="contribution-details-strong">
                             {% block contribution_date_label %}
                             {% endblock contribution_date_label %}
                           </span>

--- a/apps/emails/tests/test_helpers.py
+++ b/apps/emails/tests/test_helpers.py
@@ -1,0 +1,28 @@
+import datetime
+
+from django.test import SimpleTestCase
+
+import pytz
+
+from apps.emails.helpers import convert_to_timezone
+
+
+class HelperTests(SimpleTestCase):
+    def test_convert_to_timezone_with_selected_timezone(self):
+        test_date = datetime.datetime(2022, 12, 6)
+
+        utc = test_date.replace(tzinfo=pytz.UTC)
+        self.assertEqual(utc.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 UTC")
+
+        tz_date = convert_to_timezone(test_date, "America/New_York")
+        self.assertEqual(tz_date, "12-05-22 19:00 EST")
+
+    def test_convert_to_timezone_without_selected_timezone(self):
+        test_date = datetime.datetime(2022, 12, 6)
+
+        utc = test_date.replace(tzinfo=pytz.UTC)
+        self.assertEqual(utc.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 UTC")
+
+        tz_date = convert_to_timezone(test_date)
+        # Should be the same as the "timezone.get_current_timezone()" is UTC
+        self.assertEqual(tz_date, "12-06-22 00:00 UTC")

--- a/apps/emails/tests/test_helpers.py
+++ b/apps/emails/tests/test_helpers.py
@@ -1,40 +1,26 @@
 import datetime
 
-from django.test import SimpleTestCase
-
+import pytest
 import pytz
 
 from apps.emails.helpers import convert_to_timezone_formatted
 
 
-class HelperTests(SimpleTestCase):
-    def test_convert_to_timezone_formatted_with_custom_format_string(self):
-        test_date = datetime.datetime(2022, 12, 6)
-        self.assertEqual(test_date.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 ")
+@pytest.mark.parametrize(
+    "timezone, fmt, isUTC, expect",
+    [
+        ("America/New_York", "%d/%m/%Y %H:%M %Z", False, "05/12/2022 19:00 EST"),
+        ("America/New_York", None, False, "12-05-22 19:00 EST"),
+        ("America/New_York", None, True, "12-05-22 19:00 EST"),
+        (None, None, False, "12-06-22 00:00 UTC"),
+    ],
+)
+def test__convert_to_timezone_formatted(timezone, fmt, isUTC, expect):
+    test_date = datetime.datetime(2022, 12, 6)
 
-        tz_date = convert_to_timezone_formatted(test_date, "America/New_York", "%d/%m/%Y %H:%M %Z")
-        self.assertEqual(tz_date, "05/12/2022 19:00 EST")
+    if isUTC:
+        test_date = test_date.replace(tzinfo=pytz.UTC)
+    assert test_date.strftime("%m-%d-%y %H:%M %Z") == "12-06-22 00:00" + " UTC" if isUTC else " "
 
-    def test_convert_to_timezone_formatted_with_selected_timezone_and_date_without_timezone_info(self):
-        test_date = datetime.datetime(2022, 12, 6)
-        self.assertEqual(test_date.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 ")
-
-        # Even with test_date not having timezone information, `convert_to_timezone_formatted` assumes it's UTC
-        tz_date = convert_to_timezone_formatted(test_date, "America/New_York")
-        self.assertEqual(tz_date, "12-05-22 19:00 EST")
-
-    def test_convert_to_timezone_formatted_with_selected_timezone_and_date_with_UTC_timezone(self):
-        test_date = datetime.datetime(2022, 12, 6)
-        utc = test_date.replace(tzinfo=pytz.UTC)
-        self.assertEqual(utc.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 UTC")
-
-        tz_date = convert_to_timezone_formatted(utc, "America/New_York")
-        self.assertEqual(tz_date, "12-05-22 19:00 EST")
-
-    def test_convert_to_timezone_formatted_without_selected_timezone(self):
-        test_date = datetime.datetime(2022, 12, 6)
-        self.assertEqual(test_date.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 ")
-
-        tz_date = convert_to_timezone_formatted(test_date)
-        # Should be the same as the "timezone.get_current_timezone()" is UTC
-        self.assertEqual(tz_date, "12-06-22 00:00 UTC")
+    tz_date = convert_to_timezone_formatted(test_date, timezone, fmt)
+    assert tz_date == expect

--- a/apps/emails/tests/test_helpers.py
+++ b/apps/emails/tests/test_helpers.py
@@ -4,25 +4,37 @@ from django.test import SimpleTestCase
 
 import pytz
 
-from apps.emails.helpers import convert_to_timezone
+from apps.emails.helpers import convert_to_timezone_formatted
 
 
 class HelperTests(SimpleTestCase):
-    def test_convert_to_timezone_with_selected_timezone(self):
+    def test_convert_to_timezone_formatted_with_custom_format_string(self):
         test_date = datetime.datetime(2022, 12, 6)
+        self.assertEqual(test_date.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 ")
 
-        utc = test_date.replace(tzinfo=pytz.UTC)
-        self.assertEqual(utc.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 UTC")
+        tz_date = convert_to_timezone_formatted(test_date, "America/New_York", "%d/%m/%Y %H:%M %Z")
+        self.assertEqual(tz_date, "05/12/2022 19:00 EST")
 
-        tz_date = convert_to_timezone(test_date, "America/New_York")
+    def test_convert_to_timezone_formatted_with_selected_timezone_and_date_without_timezone_info(self):
+        test_date = datetime.datetime(2022, 12, 6)
+        self.assertEqual(test_date.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 ")
+
+        # Even with test_date not having timezone information, `convert_to_timezone_formatted` assumes it's UTC
+        tz_date = convert_to_timezone_formatted(test_date, "America/New_York")
         self.assertEqual(tz_date, "12-05-22 19:00 EST")
 
-    def test_convert_to_timezone_without_selected_timezone(self):
+    def test_convert_to_timezone_formatted_with_selected_timezone_and_date_with_UTC_timezone(self):
         test_date = datetime.datetime(2022, 12, 6)
-
         utc = test_date.replace(tzinfo=pytz.UTC)
         self.assertEqual(utc.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 UTC")
 
-        tz_date = convert_to_timezone(test_date)
+        tz_date = convert_to_timezone_formatted(utc, "America/New_York")
+        self.assertEqual(tz_date, "12-05-22 19:00 EST")
+
+    def test_convert_to_timezone_formatted_without_selected_timezone(self):
+        test_date = datetime.datetime(2022, 12, 6)
+        self.assertEqual(test_date.strftime("%m-%d-%y %H:%M %Z"), "12-06-22 00:00 ")
+
+        tz_date = convert_to_timezone_formatted(test_date)
         # Should be the same as the "timezone.get_current_timezone()" is UTC
         self.assertEqual(tz_date, "12-06-22 00:00 UTC")

--- a/apps/emails/tests/test_helpers.py
+++ b/apps/emails/tests/test_helpers.py
@@ -7,7 +7,7 @@ from apps.emails.helpers import convert_to_timezone_formatted
 
 
 @pytest.mark.parametrize(
-    "timezone, fmt, isUTC, expect",
+    "timezone, fmt, is_UTC, expect",
     [
         ("America/New_York", "%d/%m/%Y %H:%M %Z", False, "05/12/2022 19:00 EST"),
         ("America/New_York", None, False, "12-05-22 19:00 EST"),
@@ -15,12 +15,16 @@ from apps.emails.helpers import convert_to_timezone_formatted
         (None, None, False, "12-06-22 00:00 UTC"),
     ],
 )
-def test__convert_to_timezone_formatted(timezone, fmt, isUTC, expect):
+def test_convert_to_timezone_formatted(timezone, fmt, is_UTC, expect):
     test_date = datetime.datetime(2022, 12, 6)
 
-    if isUTC:
+    if is_UTC:
         test_date = test_date.replace(tzinfo=pytz.UTC)
-    assert test_date.strftime("%m-%d-%y %H:%M %Z") == "12-06-22 00:00" + " UTC" if isUTC else " "
+    assert test_date.strftime("%m-%d-%y %H:%M %Z") == "12-06-22 00:00" + " UTC" if is_UTC else " "
 
-    tz_date = convert_to_timezone_formatted(test_date, timezone, fmt)
+    tz_date = (
+        convert_to_timezone_formatted(test_date, timezone, fmt)
+        if fmt
+        else convert_to_timezone_formatted(test_date, timezone)
+    )
     assert tz_date == expect

--- a/apps/emails/tests/test_tasks.py
+++ b/apps/emails/tests/test_tasks.py
@@ -35,7 +35,7 @@ class TestSendThankYouEmail:
         assert mock_send_email.call_args[0][2] == "nrh-default-contribution-confirmation-email.txt"
         assert mock_send_email.call_args[0][3] == "nrh-default-contribution-confirmation-email.html"
         assert mock_send_email.call_args[0][4] == {
-            "contribution_date": contribution.created.strftime("%m-%d-%y"),
+            "contribution_date": convert_to_timezone_formatted(contribution.created, "America/New_York"),
             "contributor_email": contribution.contributor.email,
             "contribution_amount": contribution.formatted_amount,
             "contribution_interval": contribution.interval,

--- a/apps/emails/tests/test_tasks.py
+++ b/apps/emails/tests/test_tasks.py
@@ -8,6 +8,7 @@ from stripe.error import StripeError
 
 from apps.contributions.models import Contribution, ContributionInterval
 from apps.contributions.tests.factories import ContributionFactory
+from apps.emails.helpers import convert_to_timezone
 from apps.emails.tasks import send_thank_you_email
 from apps.organizations.models import PaymentProvider
 from apps.organizations.tests.factories import RevenueProgramFactory
@@ -37,7 +38,7 @@ class TestSendThankYouEmail:
             "nrh-default-contribution-confirmation-email.txt",
             "nrh-default-contribution-confirmation-email.html",
             {
-                "contribution_date": now.date().strftime("%m-%d-%y"),
+                "contribution_date": convert_to_timezone(now, "America/New_York"),
                 "contributor_email": contribution.contributor.email,
                 "contribution_amount": contribution.formatted_amount,
                 "contribution_interval": contribution.interval,

--- a/apps/emails/tests/test_tasks.py
+++ b/apps/emails/tests/test_tasks.py
@@ -6,7 +6,7 @@ from stripe.error import StripeError
 
 from apps.contributions.models import Contribution, ContributionInterval
 from apps.contributions.tests.factories import ContributionFactory
-from apps.emails.helpers import convert_to_timezone
+from apps.emails.helpers import convert_to_timezone_formatted
 from apps.emails.tasks import send_thank_you_email
 from apps.organizations.models import PaymentProvider
 from apps.organizations.tests.factories import RevenueProgramFactory
@@ -35,7 +35,7 @@ class TestSendThankYouEmail:
             "nrh-default-contribution-confirmation-email.txt",
             "nrh-default-contribution-confirmation-email.html",
             {
-                "contribution_date": convert_to_timezone(contribution.created, "America/New_York"),
+                "contribution_date": convert_to_timezone_formatted(contribution.created, "America/New_York"),
                 "contributor_email": contribution.contributor.email,
                 "contribution_amount": contribution.formatted_amount,
                 "contribution_interval": contribution.interval,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
This is the **third** of **3** planned stacked PRs to deliver the ticket [DEV-2783](https://news-revenue-hub.atlassian.net/browse/DEV-2783)

1. (https://github.com/newsrevenuehub/rev-engine/pull/851) (corresponding to [DEV-2783 | Update layout in receipt emails (add required tax information, contributor portal link, and refer to RP in copyright)](https://news-revenue-hub.atlassian.net/browse/DEV-2783) 
2. (https://github.com/newsrevenuehub/rev-engine/pull/868) (corresponding to [DEV-2892 | provide requested data for receipt emails](https://news-revenue-hub.atlassian.net/browse/DEV-2892))  
3. (https://github.com/newsrevenuehub/rev-engine/pull/884) (corresponding to [DEV-1758](https://news-revenue-hub.atlassian.net/browse/DEV-1758) Improvement: Include time zone in receipt emails - **THE CURRENT PR**

#### What's this PR do?
Adds a helper function to convert datetimes without timezone or UTC timezones into a specific timezone. Our usecase in this PR is to convert UTC to EST to show in the contribution receipt email.

#### Why are we doing this? How does it help us?
The timestamp with timezone is important in the receipt email because clients can use that receipt for tax purposes. The exact time of the receipt needs to be returned to the user.

#### How should this be manually tested? Please include detailed step-by-step instructions.
- Create a contribution and make sure the receipt received contains the date + time + timezone information and that it is the correct values.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
Date + time + timezone instead of only date in receipt email

#### Have automated unit tests been added? If not, why?
Yes

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
This PR corresponds to this ticket: https://news-revenue-hub.atlassian.net/browse/DEV-1758

But it is built upon:
https://news-revenue-hub.atlassian.net/browse/DEV-2783
https://news-revenue-hub.atlassian.net/browse/DEV-2892

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no