### PR TITLE
Dev 2962 improve undo in editor

### DIFF
--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -550,6 +550,25 @@ describe('Edit interface: Styles', () => {
     cy.getByTestId('edit-style-tab').click({ force: true });
   });
 
+  it("disables the Undo button if the user hasn't made a change", () => {
+    cy.findByRole('button', { name: 'Undo' }).should('be.disabled');
+  });
+
+  it('enables the Undo button when the user makes a change', () => {
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).click();
+    cy.findByText('----none----').click();
+    cy.findByRole('button', { name: 'Undo' }).should('not.be.disabled');
+  });
+
+  it('resets changes when the Undo button is clicked', () => {
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).should('have.value', 'mock-style');
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).click();
+    cy.findByText('----none----').click();
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).should('have.value', '----none----');
+    cy.findByRole('button', { name: 'Undo' }).click();
+    cy.findByLabelText('Choose from existing styles', { selector: 'input' }).should('have.value', 'mock-style');
+  });
+
   describe('When creating a new style', () => {
     beforeEach(() => {
       cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_FONTS) }, { body: [] });

--- a/spa/cypress/fixtures/pages/live-page-1.json
+++ b/spa/cypress/fixtures/pages/live-page-1.json
@@ -138,6 +138,7 @@
       "inputBackground": "#fff",
       "inputBorder": "#c3c3c3"
     },
+    "name": "mock-style",
     "ruleStyle": "dotted"
   },
   "revenue_program": {

--- a/spa/cypress/fixtures/pages/live-page-1.json
+++ b/spa/cypress/fixtures/pages/live-page-1.json
@@ -2,6 +2,7 @@
   "id": 99,
   "name": "Test Page 1",
   "heading": "Test Heading 1",
+  "post_thank_you_redirect": "https://fundjournalism.org",
   "published_date": "2020-09-17T00:00:00",
   "revenue_program_is_nonprofit": true,
   "plan": {

--- a/spa/src/components/base/ImageUpload/ImageUpload.stories.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import ImageUpload from './ImageUpload';
+
+export default {
+  component: ImageUpload,
+  title: 'Base/ImageUpload'
+} as ComponentMeta<typeof ImageUpload>;
+
+const sampleImageSrc = `
+  <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <defs>
+      <radialGradient id="a"><stop offset="0%" stop-color="green"/><stop offset="200%" stop-color="#00f"/>
+      </radialGradient>
+    </defs>
+    <path fill="url(#a)" d="M0 0h100v100H0z"/>
+  </svg>`;
+
+const sampleImageUri = `data:image/svg+xml;base64,${window.btoa(sampleImageSrc)}`;
+const sampleImageBlob = new Blob([sampleImageSrc], { type: 'image/svg+xml' });
+const sampleImage = new File([sampleImageBlob], 'uploaded-file.svg', { type: 'image/svg+xml' });
+
+const Template: ComponentStory<typeof ImageUpload> = (props) => <ImageUpload {...props} />;
+
+export const Empty = Template.bind({});
+Empty.args = { label: 'Input label', prompt: 'Choose an image' };
+
+export const WithThumbnailOnly = Template.bind({});
+WithThumbnailOnly.args = {
+  label: 'Input label',
+  thumbnailUrl: sampleImageUri
+};
+
+export const WithImage = Template.bind({});
+WithImage.args = {
+  label: 'Input label',
+  thumbnailUrl: sampleImageUri,
+  value: sampleImage
+};

--- a/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
+++ b/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
@@ -1,0 +1,70 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconButton as MuiIconButton } from '@material-ui/core';
+import styled from 'styled-components';
+
+export const IconButton = styled(MuiIconButton)`
+  && {
+    height: 50px;
+    max-height: 50px;
+    max-width: 50px;
+    width: 50px;
+
+    svg {
+      height: auto;
+      width: 12px;
+    }
+
+    &.Mui-disabled {
+      opacity: 0.5;
+    }
+  }
+`;
+
+export const Label = styled.label`
+  font-size: 16px;
+  font-weight: 500;
+  padding-bottom: 0.5rem;
+  grid-area: label;
+`;
+
+export const Preview = styled.div`
+  cursor: pointer;
+  grid-area: preview;
+  height: 100%;
+  position: relative;
+`;
+
+export const Prompt = styled.div`
+  align-items: center;
+  border: 1px solid ${({ theme }) => theme.colors.grey[0]};
+  display: flex;
+  font-size: ${({ theme }) => theme.fontSizesUpdated.sm};
+  height: 100%;
+  justify-content: center;
+`;
+
+export const RemoveIcon = styled(FontAwesomeIcon)`
+  color: ${(props) => props.theme.colors.caution};
+`;
+
+export const Root = styled.div`
+  display: grid;
+  grid-template-areas:
+    'label label'
+    'preview upload'
+    'preview remove';
+  grid-template-columns: 1fr 50px;
+  max-height: 125px;
+`;
+
+export const Thumbnail = styled.img`
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`;
+
+export const UploadIcon = styled(FontAwesomeIcon)`
+  color: ${(props) => props.theme.colors.primary};
+`;

--- a/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
+++ b/spa/src/components/base/ImageUpload/ImageUpload.styled.ts
@@ -21,7 +21,7 @@ export const IconButton = styled(MuiIconButton)`
 `;
 
 export const Label = styled.label`
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
   font-weight: 500;
   padding-bottom: 0.5rem;
   grid-area: label;

--- a/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
@@ -1,0 +1,125 @@
+import { axe } from 'jest-axe';
+import { fireEvent, render, screen, waitFor } from 'test-utils';
+import ImageUpload, { ImageUploadProps } from './ImageUpload';
+
+const mockFile = new File([], 'test.jpeg');
+
+function tree(props?: Partial<ImageUploadProps>) {
+  return render(<ImageUpload id="mock-id" label="mock-label" onChange={jest.fn()} prompt="mock-prompt" {...props} />);
+}
+
+describe('ImageUpload', () => {
+  function changeFile() {
+    // Need to fire the event directly on the input.
+
+    fireEvent.change(document.querySelector('input[type="file"]')!, { target: { files: [mockFile] } });
+  }
+
+  describe('When no image or thumbnail is set', () => {
+    it('displays the prompt prop', () => {
+      tree({ prompt: 'test-prompt' });
+      expect(screen.getByText('test-prompt')).toBeVisible();
+    });
+
+    it('sets the accept property of the file input based on the accept prop', () => {
+      tree({ accept: 'test-accept' });
+      expect(document.querySelector('input[type="file"]')).toHaveAttribute('accept', 'test-accept');
+    });
+
+    it('only accepts a single file', () => {
+      tree();
+      expect(document.querySelector('input[type="file"]')).not.toHaveAttribute('multiple');
+    });
+
+    it('calls the onChange prop with the file and a generated thumbnail when the file input is changed', async () => {
+      const onChange = jest.fn();
+
+      tree({ onChange });
+      expect(onChange).not.toBeCalled();
+      changeFile();
+      await waitFor(() => expect(onChange).toBeCalled());
+      expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
+    });
+
+    it('disables the remove button', () => {
+      tree({});
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree();
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('When only a thumbnail is set', () => {
+    it("doesn't show a prompt", () => {
+      tree({ prompt: 'test-prompt', thumbnailUrl: 'mock-thumbnail' });
+      expect(screen.queryByText('test-prompt')).not.toBeInTheDocument();
+    });
+
+    it('displays an image with the thumbnail', () => {
+      tree({ prompt: 'test-prompt', thumbnailUrl: 'mock-thumbnail' });
+      expect(screen.getByRole('img')).toHaveAttribute('src', 'mock-thumbnail');
+    });
+
+    it('calls the onChange prop with the file and a generated thumbnail when the file input is changed', async () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail' });
+      expect(onChange).not.toBeCalled();
+      changeFile();
+      await waitFor(() => expect(onChange).toBeCalled());
+      expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
+    });
+
+    it('disables the remove button', () => {
+      tree({ thumbnailUrl: 'mock-thumbnail' });
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ thumbnailUrl: 'mock-thumbnail' });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('When both a thumbnail and value is set', () => {
+    it("doesn't show a prompt", () => {
+      tree({ prompt: 'test-prompt', thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(screen.queryByText('test-prompt')).not.toBeInTheDocument();
+    });
+
+    it('calls the onChange prop with the file and a generated thumbnail when the file input is changed', async () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(onChange).not.toBeCalled();
+      changeFile();
+      await waitFor(() => expect(onChange).toBeCalled());
+      expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
+    });
+
+    it('enables the remove button', () => {
+      tree({ thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeEnabled();
+    });
+
+    it('calls the onChange prop with no arguments when the remove button is clicked', () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail', value: mockFile });
+      expect(onChange).not.toBeCalled();
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(onChange.mock.calls).toEqual([[]]);
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ thumbnailUrl: 'mock-thumbnail', value: mockFile });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.test.tsx
@@ -74,9 +74,18 @@ describe('ImageUpload', () => {
       expect(onChange.mock.calls).toEqual([[mockFile, expect.any(String)]]);
     });
 
-    it('disables the remove button', () => {
+    it('enables the remove button', () => {
       tree({ thumbnailUrl: 'mock-thumbnail' });
-      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Remove' })).not.toBeDisabled();
+    });
+
+    it('calls the onChange prop with no arguments when the remove button is clicked', () => {
+      const onChange = jest.fn();
+
+      tree({ onChange, thumbnailUrl: 'mock-thumbnail' });
+      expect(onChange).not.toBeCalled();
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(onChange.mock.calls).toEqual([[]]);
     });
 
     it('is accessible', async () => {

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -22,6 +22,17 @@ export interface ImageUploadProps extends InferProps<typeof ImageUploadPropTypes
   onChange: (value?: File, thumbnailUrl?: string) => void;
 }
 
+/**
+ * A form control allowing the user to choose an image. The value that the user
+ * sees is fully controlled, but there is a DOM input used to manage changes
+ * whose state may not reflect the value. (This can cause confusion when writing
+ * E2E tests.)
+ *
+ * In most cases, `value` and `thumbnailUrl` should either both be provided or
+ * neither. However, you can specify just a `thumbnailUrl` if you want the
+ * preview of the input to match a state previously saved to the back end. The
+ * remove button will be enabled in this case.
+ */
 export function ImageUpload(props: ImageUploadProps) {
   const {
     accept = 'image/gif,image/jpeg,image/png,image/svg+xml,image/webp',
@@ -71,7 +82,7 @@ export function ImageUpload(props: ImageUploadProps) {
       <IconButton onClick={clickOnHiddenInput} aria-label="Change">
         <UploadIcon icon={faFileUpload} />
       </IconButton>
-      <IconButton disabled={!value} onClick={() => onChange()} aria-label="Remove">
+      <IconButton disabled={!thumbnailUrl && !value} onClick={() => onChange()} aria-label="Remove">
         <RemoveIcon icon={faTimes} />
       </IconButton>
     </Root>

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -66,9 +66,6 @@ export function ImageUpload(props: ImageUploadProps) {
       };
 
       fileReader.readAsDataURL(image);
-    } else {
-      // User didn't select a file, perhaps?
-      onChange();
     }
   }
 

--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -1,0 +1,83 @@
+import { faFileUpload, faTimes } from '@fortawesome/free-solid-svg-icons';
+import PropTypes, { InferProps } from 'prop-types';
+import { ChangeEvent, useRef } from 'react';
+import { IconButton, Label, Preview, Prompt, RemoveIcon, Root, Thumbnail, UploadIcon } from './ImageUpload.styled';
+
+const ImageUploadPropTypes = {
+  accept: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  prompt: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  thumbnailUrl: PropTypes.string,
+  value: PropTypes.instanceOf(File)
+};
+
+export interface ImageUploadProps extends InferProps<typeof ImageUploadPropTypes> {
+  /**
+   * Called when the user changes the image. If both arguments are undefined,
+   * the user removed the image.
+   */
+  onChange: (value?: File, thumbnailUrl?: string) => void;
+}
+
+export function ImageUpload(props: ImageUploadProps) {
+  const {
+    accept = 'image/gif,image/jpeg,image/png,image/svg+xml,image/webp',
+    className,
+    id,
+    label,
+    onChange,
+    prompt,
+    thumbnailUrl,
+    value
+  } = props;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function clickOnHiddenInput() {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  }
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    if (event.target.files) {
+      const image = event.target.files[0];
+      const fileReader = new FileReader();
+
+      fileReader.onload = (event) => {
+        if (!event.target) {
+          throw new Error('Creating an image thumbnail failed');
+        }
+
+        onChange(image, event.target.result as string);
+      };
+
+      fileReader.readAsDataURL(image);
+    } else {
+      // User didn't select a file, perhaps?
+      onChange();
+    }
+  }
+
+  return (
+    <Root className={className!}>
+      <Label htmlFor={id}>{label}</Label>
+      <Preview>
+        <input accept={accept!} hidden id={id} onChange={handleChange} ref={inputRef} type="file" />
+        {thumbnailUrl ? <Thumbnail src={thumbnailUrl} alt={value?.name ?? ''} /> : <Prompt>{prompt}</Prompt>}
+      </Preview>
+      <IconButton onClick={clickOnHiddenInput} aria-label="Change">
+        <UploadIcon icon={faFileUpload} />
+      </IconButton>
+      <IconButton disabled={!value} onClick={() => onChange()} aria-label="Remove">
+        <RemoveIcon icon={faTimes} />
+      </IconButton>
+    </Root>
+  );
+}
+
+ImageUpload.propTypes = ImageUploadPropTypes;
+
+export default ImageUpload;

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -186,7 +186,6 @@ function PageEditor() {
         { method: 'GET', url: LIST_STYLES, params: { revenue_program: rpId } },
         {
           onSuccess: ({ data }) => {
-            console.log(data);
             setAvailableStyles(data);
             setLoading(false);
           },

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -100,6 +100,7 @@ function PageEditor() {
     }
   }, []);
 
+  const [availableStylesRpId, setAvailableStylesRpId] = useState();
   const [availableStyles, setAvailableStyles] = useState([]);
 
   const pageTitle = useMemo(
@@ -174,14 +175,18 @@ function PageEditor() {
   }, [pageId, parameters.revProgramSlug, parameters.pageSlug, handleGetPageFailure]);
 
   useEffect(() => {
-    const rpId = page?.revenue_program?.id;
+    // If the revenue program of the page is either available after loading or
+    // has changed, load styles associated with the RP.
 
-    if (rpId) {
+    const rpId = page?.revenue_program?.id;
+    if (rpId && rpId !== availableStylesRpId) {
       setLoading(true);
+      setAvailableStylesRpId(rpId);
       requestGetPageStyles(
         { method: 'GET', url: LIST_STYLES, params: { revenue_program: rpId } },
         {
           onSuccess: ({ data }) => {
+            console.log(data);
             setAvailableStyles(data);
             setLoading(false);
           },
@@ -192,7 +197,7 @@ function PageEditor() {
       );
     }
     // Don't include requestGetPageStyles for now.
-  }, [page]);
+  }, [availableStylesRpId, page]);
 
   const handlePreview = () => {
     setSelectedButton(PREVIEW);

--- a/spa/src/components/pageEditor/editInterface/EditInterface.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.js
@@ -170,10 +170,10 @@ function EditInterface() {
                 />
               </TabPanel>
               <TabPanel active={tab === 2} id="edit-setup-tab-panel" tabId="edit-setup-tab">
-                <PageSetup backToProperties={() => setTab(0)} />
+                <PageSetup />
               </TabPanel>
               <TabPanel active={tab === 3} id="edit-styles-tab-panel" tabId="edit-styles-tab">
-                <PageStyles backToProperties={() => setTab(0)} />
+                <PageStyles />
               </TabPanel>
             </>
           )}

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -18,7 +18,7 @@ import EditTabHeader from '../EditTabHeader';
  *
  * PageSetup is the direct child of EditInterface.
  */
-function PageSetup({ backToProperties }) {
+function PageSetup() {
   const { page, errors } = usePageEditorContext();
   const { setPageContent } = useEditInterfaceContext();
 
@@ -49,7 +49,6 @@ function PageSetup({ backToProperties }) {
       donor_benefits,
       published_date
     });
-    backToProperties();
   };
 
   const handleDiscardChanges = () => {

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -137,7 +137,7 @@ function PageSetup() {
         )}
         <InputWrapper border>
           <Input
-            type="ext"
+            type="text"
             label="Form panel heading"
             value={heading}
             onChange={(e) => setPageHeading(e.target.value)}

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.styled.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const PageSetup = styled.div`
+export const Root = styled.div`
   display: flex;
   flex-direction: column;
 `;
@@ -20,6 +20,12 @@ export const ImageSelectorWrapper = styled.div`
   padding-bottom: 2rem;
 
   border-bottom: 1px solid ${(props) => props.theme.colors.grey[0]};
+`;
+
+export const ImageSelectorHelpText = styled.div`
+  font-style: italic;
+  font-weight: 200;
+  margin-top: 1rem;
 `;
 
 export const InputWrapper = styled.div`

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
@@ -30,7 +30,8 @@ function PageStyles({ backToProperties }) {
   };
 
   const handleDiscardChanges = () => {
-    backToProperties();
+    console.log('Undoing styles');
+    setStyles(page.styles);
   };
 
   const handleAddNewStyles = (newStyles) => {
@@ -48,7 +49,12 @@ function PageStyles({ backToProperties }) {
       <Controls>
         <StylesChooser styles={availableStyles} selected={styles} setSelected={setStyles} />
       </Controls>
-      <EditSaveControls onCancel={handleDiscardChanges} onUpdate={handleKeepChanges} variant="undo" />
+      <EditSaveControls
+        cancelDisabled={styles === page.styles}
+        onCancel={handleDiscardChanges}
+        onUpdate={handleKeepChanges}
+        variant="undo"
+      />
       <AddStylesModal
         isOpen={addStylesModalOpen}
         closeModal={handleAddStylesModalClose}

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.js
@@ -12,7 +12,7 @@ import AddStylesModal from 'components/pageEditor/editInterface/pageStyles/AddSt
 import EditSaveControls from '../EditSaveControls';
 import EditTabHeader from '../EditTabHeader';
 
-function PageStyles({ backToProperties }) {
+function PageStyles() {
   const { page, availableStyles, setAvailableStyles } = usePageEditorContext();
   const { setPageContent } = useEditInterfaceContext();
   const {
@@ -26,11 +26,9 @@ function PageStyles({ backToProperties }) {
 
   const handleKeepChanges = () => {
     setPageContent({ styles });
-    backToProperties();
   };
 
   const handleDiscardChanges = () => {
-    console.log('Undoing styles');
     setStyles(page.styles);
   };
 

--- a/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
@@ -2,13 +2,13 @@ import * as S from './StylesChooser.styled';
 import Select from 'elements/inputs/Select';
 
 function StylesChooser({ styles = [], selected, setSelected }) {
-  // selectedItem is coerced to an empty string if it's null to prevent React
-  // from treating the select as an uncontrolled component.
   return (
     <S.StylesChooser>
       <Select
         label="Choose from existing styles"
         onSelectedItemChange={({ selectedItem }) => setSelected(selectedItem)}
+        // selectedItem is coerced to an empty string if it's null to prevent React
+        // from treating the select as an uncontrolled component.
         selectedItem={selected === null ? '' : selected}
         items={[{ name: '----none----', id: '' }].concat(styles)}
         itemToString={(i) => i.name}

--- a/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/StylesChooser.js
@@ -2,12 +2,14 @@ import * as S from './StylesChooser.styled';
 import Select from 'elements/inputs/Select';
 
 function StylesChooser({ styles = [], selected, setSelected }) {
+  // selectedItem is coerced to an empty string if it's null to prevent React
+  // from treating the select as an uncontrolled component.
   return (
     <S.StylesChooser>
       <Select
         label="Choose from existing styles"
         onSelectedItemChange={({ selectedItem }) => setSelected(selectedItem)}
-        selectedItem={selected}
+        selectedItem={selected === null ? '' : selected}
         items={[{ name: '----none----', id: '' }].concat(styles)}
         itemToString={(i) => i.name}
         placeholder="Select a style"


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Improves the Undo functionality on the Setup and Style tabs so that it resets the fields on the respective tabs to match the original data, and no longer changes tab.
- Adds an ImageUpload base component. We have an existing one, ImageWithPreview, but it's not a controlled component so it's not possible to reset the field value. I created ImageUpload to handle this. We need to keep ImageWithPreview around for a little longer as it is also used by the Image block, and I wanted to limit PR scope.

#### Why are we doing this? How does it help us?

Better UX in the page editor, better functionality in our component library.

#### How should this be manually tested? Please include detailed step-by-step instructions.

Testing disabled state of Undo button:
1. Edit a page.
2. Confirm the Undo button is disabled in both Setup and Styles tab.

Testing Setup tab:
1. Edit a page and choose the Setup tab.
2. Change all of the fields in this tab.
3. Click the Undo button in the tab.
4. Confirm that all changes you made have been reversed to the original state of the page in the tab fields as well as the page preview.
5. Make an unrelated edit to the page and save it. Confirm that none of the changes you made in step 2 were saved.

Testing Styles tab:
1. Edit a page and choose the Style tab. 
2. Choose a different page style.
3. Click the Undo button in the tab.
4. Confirm that the style change you made has been reversed to the original state in the dropdown menu and on the page preview.
6. Make an unrelated edit to the page and save it. Confirm that the page style was not changed when you saved.
 
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Yes, the Undo button is now disabled when the user hasn't made any relevant changes.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

See documentation answer above.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

- https://news-revenue-hub.atlassian.net/browse/DEV-2761 (parent)
- https://news-revenue-hub.atlassian.net/browse/DEV-2962

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.