### PR TITLE
DEV-2214: Replace react-color with native input

### DIFF
--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -44,7 +44,6 @@
         "query-string": "^7.0.1",
         "react": "^17.0.2",
         "react-alert": "^7.0.3",
-        "react-color": "^2.19.3",
         "react-cookie": "^4.1.1",
         "react-datepicker": "^4.1.1",
         "react-dom": "^17.0.2",
@@ -3362,6 +3361,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "dev": true,
       "peerDependencies": {
         "react": "*"
       }
@@ -26487,7 +26487,8 @@
     "node_modules/material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+      "dev": true
     },
     "node_modules/md5": {
       "version": "2.3.0",
@@ -30193,6 +30194,7 @@
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
       "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+      "dev": true,
       "dependencies": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.15",
@@ -31070,6 +31072,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.0.1"
       }
@@ -38748,6 +38751,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "dev": true,
       "requires": {}
     },
     "@istanbuljs/load-nyc-config": {
@@ -56614,7 +56618,8 @@
     "material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+      "dev": true
     },
     "md5": {
       "version": "2.3.0",
@@ -59282,6 +59287,7 @@
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
       "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+      "dev": true,
       "requires": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.15",
@@ -59948,6 +59954,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "dev": true,
       "requires": {
         "lodash": "^4.0.1"
       }

--- a/spa/package.json
+++ b/spa/package.json
@@ -40,7 +40,6 @@
     "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-alert": "^7.0.3",
-    "react-color": "^2.19.3",
     "react-cookie": "^4.1.1",
     "react-datepicker": "^4.1.1",
     "react-dom": "^17.0.2",

--- a/spa/src/components/base/ColorPicker/ColorPicker.stories.tsx
+++ b/spa/src/components/base/ColorPicker/ColorPicker.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { FormControlLabel } from '../FormControlLabel';
+import ColorPicker from './ColorPicker';
+
+export default {
+  component: ColorPicker,
+  title: 'Base/ColorPicker'
+} as ComponentMeta<typeof ColorPicker>;
+
+const Template: ComponentStory<typeof ColorPicker> = (props) => <ColorPicker {...props} />;
+
+export const Unlabeled = Template.bind({});
+Unlabeled.args = {
+  value: '#0000ff'
+};
+
+const LabeledTemplate: ComponentStory<typeof ColorPicker> = (props) => (
+  <FormControlLabel control={<ColorPicker {...props} />} label="Label" labelPlacement="top" />
+);
+
+export const Labeled = LabeledTemplate.bind({});
+Labeled.args = {
+  value: '#123456'
+};

--- a/spa/src/components/base/ColorPicker/ColorPicker.test.tsx
+++ b/spa/src/components/base/ColorPicker/ColorPicker.test.tsx
@@ -1,0 +1,54 @@
+import { axe } from 'jest-axe';
+import { fireEvent, render, screen } from 'test-utils';
+import ColorPicker, { ColorPickerProps } from './ColorPicker';
+
+describe('ColorPicker', () => {
+  function tree(props?: Partial<ColorPickerProps>) {
+    return render(
+      <>
+        <label htmlFor="test-picker">mock label</label>
+        <ColorPicker id="test-picker" onChange={jest.fn()} value="#ff0000" {...props} />
+      </>
+    );
+  }
+
+  function getColorInput() {
+    return document.querySelector('input[type="color"]');
+  }
+
+  it('displays a color input', () => {
+    tree();
+    expect(getColorInput()).toBeInTheDocument();
+    expect(screen.getByLabelText('mock label')).toBeVisible();
+  });
+
+  it('sets the ID on the input with the id prop', () => {
+    tree({ id: 'test-id' });
+    expect(document.getElementById('test-id')).toBeVisible();
+  });
+
+  it("sets the input's value to the value prop", () => {
+    tree({ value: '#00ff00' });
+    expect(getColorInput()).toHaveValue('#00ff00');
+  });
+
+  it('displays the value prop', () => {
+    tree({ value: '#00ff00' });
+    expect(screen.getByText('#00ff00')).toBeVisible();
+  });
+
+  it('calls onChange when the value of the input is changed', () => {
+    const onChange = jest.fn();
+
+    tree({ onChange });
+    expect(onChange).not.toBeCalled();
+    fireEvent.change(getColorInput()!, { target: { value: '#0000ff' } });
+    expect(onChange).toBeCalledTimes(1);
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/ColorPicker/ColorPicker.tsx
+++ b/spa/src/components/base/ColorPicker/ColorPicker.tsx
@@ -61,7 +61,7 @@ const Swatch = styled.div`
 const ValueLabel = styled.div`
   align-items: center;
   display: grid;
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
   font-weight: 200;
   justify-content: center;
   pointer-events: none;

--- a/spa/src/components/base/ColorPicker/ColorPicker.tsx
+++ b/spa/src/components/base/ColorPicker/ColorPicker.tsx
@@ -1,0 +1,87 @@
+import { ChangeEvent } from 'react';
+import PropTypes, { InferProps } from 'prop-types';
+import styled from 'styled-components';
+
+const ColorPickerPropTypes = {
+  id: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+export interface ColorPickerProps extends InferProps<typeof ColorPickerPropTypes> {
+  onChange: (event: ChangeEvent) => void;
+}
+
+// The general approach on styling is to turn the native input into an empty
+// container (hiding the swatch it would normally render), then render the
+// swatch and label on top of that. Trying to style the native swatch
+// consistently is difficult because each browser takes a different approach.
+
+const Root = styled.div`
+  height: 45px;
+  position: relative;
+  width: 200px;
+`;
+
+const ColorInput = styled.input`
+  appearance: none;
+  background: none;
+  border: 1px solid ${({ theme }) => theme.colors.inputBorder};
+  cursor: pointer;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+
+  &:focus {
+    border: 1px solid ${({ theme }) => theme.colors.primary};
+    outline: none;
+  }
+
+  &::-moz-color-swatch {
+    display: none;
+  }
+
+  &::-webkit-color-swatch {
+    display: none;
+  }
+`;
+
+const Swatch = styled.div`
+  pointer-events: none;
+  position: absolute;
+  /* Leaving room for the border of the enclosing input. */
+  top: 1px;
+  left: 1px;
+  width: 30px;
+  bottom: 1px;
+`;
+
+const ValueLabel = styled.div`
+  align-items: center;
+  display: grid;
+  font-size: 16px;
+  font-weight: 200;
+  justify-content: center;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 30px;
+  right: 0;
+  bottom: 0;
+`;
+
+export function ColorPicker({ id, onChange, value }: ColorPickerProps) {
+  return (
+    <Root>
+      <ColorInput id={id!} type="color" onChange={onChange} value={value} />
+      <Swatch style={{ backgroundColor: value }} />
+      {/* Hidden because screen readers will announce the value, so this would be redundant. */}
+      <ValueLabel aria-hidden>{value}</ValueLabel>
+    </Root>
+  );
+}
+
+ColorPicker.propTypes = ColorPickerPropTypes;
+export default ColorPicker;

--- a/spa/src/components/base/index.ts
+++ b/spa/src/components/base/index.ts
@@ -1,5 +1,6 @@
 export * from './Button/Button';
 export * from './Checkbox/Checkbox';
+export * from './ColorPicker/ColorPicker';
 export * from './FormControlLabel/FormControlLabel';
 export * from './Modal';
 export * from './OffscreenText/OffscreenText';

--- a/spa/src/components/stylesEditor/LabeledColorPicker.styles.ts
+++ b/spa/src/components/stylesEditor/LabeledColorPicker.styles.ts
@@ -1,0 +1,11 @@
+import { FormControlLabel as BaseFormControlLabel } from 'components/base';
+import styled from 'styled-components';
+
+export const FormControlLabel = styled(BaseFormControlLabel)`
+  && {
+    .NreFormControlLabelLabel {
+      font-weight: 500;
+      margin-bottom: 0.5rem;
+    }
+  }
+`;

--- a/spa/src/components/stylesEditor/LabeledColorPicker.test.tsx
+++ b/spa/src/components/stylesEditor/LabeledColorPicker.test.tsx
@@ -1,0 +1,37 @@
+import { axe } from 'jest-axe';
+import { fireEvent, render, screen } from 'test-utils';
+import LabeledColorPicker, { LabeledColorPickerProps } from './LabeledColorPicker';
+
+describe('LabeledColorPicker', () => {
+  function tree(props?: Partial<LabeledColorPickerProps>) {
+    return render(<LabeledColorPicker onChange={jest.fn()} label="mock-label" value="#ff0000" {...props} />);
+  }
+
+  it('displays a color input set to the value prop', () => {
+    tree({ value: '#00ff00' });
+    expect(document.querySelector('input[type="color"]')).toHaveValue('#00ff00');
+  });
+
+  it('displays the label prop', () => {
+    tree({ label: 'test-label' });
+
+    // Unclear why testing-library doesn't see this as a label per se.
+    // screen.debug() shows what looks like correct HTML structure.
+
+    expect(screen.getByText('test-label')).toBeInTheDocument();
+  });
+
+  it('calls onChange when the input is changed', () => {
+    const onChange = jest.fn();
+
+    tree({ onChange });
+    fireEvent.change(document.querySelector('input[type="color"]')!, { target: { value: '#00ff00' } });
+    expect(onChange).toBeCalledTimes(1);
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/stylesEditor/LabeledColorPicker.tsx
+++ b/spa/src/components/stylesEditor/LabeledColorPicker.tsx
@@ -1,0 +1,20 @@
+import { ColorPicker } from 'components/base';
+import PropTypes, { InferProps } from 'prop-types';
+import { FormControlLabel } from './LabeledColorPicker.styles';
+
+const LabeledColorPickerPropTypes = {
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+export type LabeledColorPickerProps = InferProps<typeof LabeledColorPickerPropTypes>;
+
+export function LabeledColorPicker({ label, onChange, value }: LabeledColorPickerProps) {
+  return (
+    <FormControlLabel control={<ColorPicker onChange={onChange} value={value} />} label={label} labelPlacement="top" />
+  );
+}
+
+LabeledColorPicker.propTypes = LabeledColorPickerPropTypes;
+export default LabeledColorPicker;

--- a/spa/src/components/stylesEditor/StylesEditor.js
+++ b/spa/src/components/stylesEditor/StylesEditor.js
@@ -12,7 +12,6 @@ import { faSave, faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
 // Deps
 import { GENERIC_ERROR } from 'constants/textConstants';
 import { useAlert } from 'react-alert';
-import { ChromePicker } from 'react-color';
 
 // Hooks
 import useWebFonts from 'hooks/useWebFonts';
@@ -23,6 +22,7 @@ import { useConfirmationModalContext } from 'elements/modal/GlobalConfirmationMo
 
 // Children
 import CircleButton from 'elements/buttons/CircleButton';
+import LabeledColorPicker from './LabeledColorPicker';
 import Select from 'elements/inputs/Select';
 
 const UNIQUE_NAME_ERROR = 'The fields name, organization must make a unique set.';
@@ -52,8 +52,8 @@ function StylesEditor({ styles, setStyles, handleKeepChanges, handleDiscardChang
     setStyles({ ...styles, name });
   };
 
-  const setColor = (colorName, color) => {
-    setStyles({ ...styles, colors: { ...styles.colors, [colorName]: color.hex } });
+  const setColor = (colorName, value) => {
+    setStyles({ ...styles, colors: { ...styles.colors, [colorName]: value } });
   };
 
   const setRadii = (_e, radiiBase) => {
@@ -205,46 +205,46 @@ function StylesEditor({ styles, setStyles, handleKeepChanges, handleDiscardChang
         )}
         <StylesFieldset label="Colors">
           <S.FieldRow>
-            <ColorPicker
+            <LabeledColorPicker
               label="Main header"
-              value={styles?.colors?.cstm_mainHeader || ''}
-              onChange={(color) => setColor('cstm_mainHeader', color)}
+              onChange={(event) => setColor('cstm_mainHeader', event.target.value)}
+              value={styles?.colors?.cstm_mainHeader ?? ''}
             />
           </S.FieldRow>
           <S.FieldRow>
-            <ColorPicker
+            <LabeledColorPicker
               label="Main background"
-              value={styles?.colors?.cstm_mainBackground || ''}
-              onChange={(color) => setColor('cstm_mainBackground', color)}
+              onChange={(event) => setColor('cstm_mainBackground', event.target.value)}
+              value={styles?.colors?.cstm_mainBackground ?? ''}
             />
-            <ColorPicker
+            <LabeledColorPicker
               label="Form panel background"
-              value={styles?.colors?.cstm_formPanelBackground || ''}
-              onChange={(color) => setColor('cstm_formPanelBackground', color)}
+              onChange={(event) => setColor('cstm_formPanelBackground', event.target.value)}
+              value={styles?.colors?.cstm_formPanelBackground ?? ''}
             />
           </S.FieldRow>
           <S.FieldRow>
-            <ColorPicker
+            <LabeledColorPicker
               label="CTAs"
-              value={styles?.colors?.cstm_CTAs || ''}
-              onChange={(color) => setColor('cstm_CTAs', color)}
+              onChange={(event) => setColor('cstm_CTAs', event.target.value)}
+              value={styles?.colors?.cstm_CTAs ?? ''}
             />
-            <ColorPicker
+            <LabeledColorPicker
               label="Ornaments"
-              value={styles?.colors?.cstm_ornaments || ''}
-              onChange={(color) => setColor('cstm_ornaments', color)}
+              onChange={(event) => setColor('cstm_ornaments', event.target.value)}
+              value={styles?.colors?.cstm_ornaments ?? ''}
             />
           </S.FieldRow>
           <S.FieldRow>
-            <ColorPicker
+            <LabeledColorPicker
               label="Input background"
-              value={styles?.colors?.cstm_inputBackground || ''}
-              onChange={(color) => setColor('cstm_inputBackground', color)}
+              onChange={(event) => setColor('cstm_inputBackground', event.target.value)}
+              value={styles?.colors?.cstm_inputBackground ?? ''}
             />
-            <ColorPicker
+            <LabeledColorPicker
               label="Input border"
-              value={styles?.colors?.cstm_inputBorder || ''}
-              onChange={(color) => setColor('cstm_inputBorder', color)}
+              onChange={(event) => setColor('cstm_inputBorder', event.target.value)}
+              value={styles?.colors?.cstm_inputBorder ?? ''}
             />
           </S.FieldRow>
         </StylesFieldset>
@@ -324,39 +324,6 @@ function StylesFieldset({ label, description, children, ...props }) {
       {description && <S.FieldsetDescription>{description}</S.FieldsetDescription>}
       {children}
     </S.StylesFieldset>
-  );
-}
-
-function ColorPicker({ label, helpText, value, onChange }) {
-  const [colorPickerOpen, setColorPickerOpen] = useState(false);
-  const [internalValue, setIntervalValue] = useState({ hex: value });
-
-  const closePicker = () => {
-    onChange(internalValue);
-    setColorPickerOpen(false);
-  };
-
-  return (
-    <>
-      <S.ColorPickerWrapper>
-        {label && <Label>{label}</Label>}
-        <S.ColorButtonWrapper>
-          <S.ColorButton onClick={() => setColorPickerOpen(true)}>
-            <S.ColorButtonSwatch color={internalValue.hex || '#fff'} />
-            <S.ColorButtonHex color={internalValue.hex || '#fff'}>
-              {internalValue.hex || <S.NoColor>Select a color...</S.NoColor>}
-            </S.ColorButtonHex>
-          </S.ColorButton>
-        </S.ColorButtonWrapper>
-        {helpText && <HelpText>{helpText}</HelpText>}
-        {colorPickerOpen && (
-          <S.PickerWrapper>
-            <ChromePicker color={internalValue} onChange={setIntervalValue} disableAlpha />
-          </S.PickerWrapper>
-        )}
-      </S.ColorPickerWrapper>
-      {colorPickerOpen && <S.PickerOverlay onClick={closePicker} />}
-    </>
   );
 }
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Replaces react-color with a native color input.

#### Why are we doing this? How does it help us?

- react-color injects inline styles that cause CSP errors because they don't have a nonce attribute on them. I couldn't find a way to do this in [their documentation](https://casesandberg.github.io/react-color/).
- Speeds up load time by [reducing our bundle size](https://bundlephobia.com/package/react-color@2.19.3).
- Gives us mobile-friendly color pickers for free, and hopefully accessible ones (though there are [some issues with the native inputs](https://a11ysupport.io/tech/html/input(type-color)_element)).

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit a page style.
2. Confirm that color fields look like they do on deployment of the main branch, like dev.
3. Change all of the color fields. Confirm that the fields behave as they did before (show hex code that updates as you choose a different color).
4. Save changes to the page style and confirm that color changes were saved.

These steps should be repeated on all browsers we support (including mobile ones). The color picker will look different once you click on it in each browser, but the field on the page should look identical.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

With unit tests, I had to work with the underlying input directly instead of using AX-oriented calls. Those didn't work but Axe didn't flag any issues, and the rendered HTML structure looks right to me... but there could be something I'm missing.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2214

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.