### PR TITLE
DEV-2974: Export button does not display when contributions table empty

### DIFF
--- a/spa/src/components/common/Hero/Hero.stories.tsx
+++ b/spa/src/components/common/Hero/Hero.stories.tsx
@@ -29,6 +29,16 @@ ShowExport.args = {
   }
 };
 
+export const ShowExportWithZeroTransactions: ComponentStory<typeof Hero> = Hero.bind({});
+
+ShowExportWithZeroTransactions.args = {
+  ...args,
+  exportData: {
+    transactions: 0,
+    email: 'mock-email@mock.com'
+  }
+};
+
 export const NoSearch: ComponentStory<typeof Hero> = Hero.bind({});
 
 NoSearch.args = {

--- a/spa/src/components/common/Hero/Hero.test.tsx
+++ b/spa/src/components/common/Hero/Hero.test.tsx
@@ -41,6 +41,12 @@ describe('Hero', () => {
     expect(screen.getByRole('button', { name: 'mock-export-button' })).toBeInTheDocument();
   });
 
+  it("shouldn't render export if exportData is not defined", () => {
+    tree({ exportData: undefined });
+
+    expect(screen.queryByRole('button', { name: 'mock-export-button' })).not.toBeInTheDocument();
+  });
+
   it('should be accessible with export button', async () => {
     const { container } = tree({ exportData: { email: 'mock-email', transactions: 0 } });
     expect(await axe(container)).toHaveNoViolations();

--- a/spa/src/components/common/Hero/Hero.test.tsx
+++ b/spa/src/components/common/Hero/Hero.test.tsx
@@ -2,6 +2,10 @@ import { axe } from 'jest-axe';
 import { render, screen } from 'test-utils';
 import Hero, { HeroProps } from './Hero';
 
+jest.mock('components/common/Button/ExportButton', () => () => {
+  return <button>mock-export-button</button>;
+});
+
 const heroTitle = 'Page title';
 const heroSubtitle = 'This is the page subtitle';
 const heroPlaceholder = 'placeholder value';
@@ -29,12 +33,12 @@ describe('Hero', () => {
 
   it('should render export if exportData is received', () => {
     tree({ exportData: { email: 'mock-email', transactions: 1234 } });
-    expect(screen.getByRole('button', { name: /Export/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'mock-export-button' })).toBeInTheDocument();
   });
 
   it('should render export even if exportData.transactions is 0', () => {
     tree({ exportData: { email: 'mock-email', transactions: 0 } });
-    expect(screen.getByRole('button', { name: /Export/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'mock-export-button' })).toBeInTheDocument();
   });
 
   it('should be accessible', async () => {

--- a/spa/src/components/common/Hero/Hero.test.tsx
+++ b/spa/src/components/common/Hero/Hero.test.tsx
@@ -1,6 +1,6 @@
 import { axe } from 'jest-axe';
 import { render, screen } from 'test-utils';
-import Hero from './Hero';
+import Hero, { HeroProps } from './Hero';
 
 const heroTitle = 'Page title';
 const heroSubtitle = 'This is the page subtitle';
@@ -8,8 +8,14 @@ const heroPlaceholder = 'placeholder value';
 const onChange = jest.fn();
 
 describe('Hero', () => {
+  function tree(props?: Partial<HeroProps>) {
+    return render(
+      <Hero title={heroTitle} subtitle={heroSubtitle} placeholder={heroPlaceholder} onChange={onChange} {...props} />
+    );
+  }
+
   it('should render title, subtitle and searchbar', () => {
-    render(<Hero title={heroTitle} subtitle={heroSubtitle} placeholder={heroPlaceholder} onChange={onChange} />);
+    tree();
 
     const title = screen.getByText(heroTitle);
     expect(title).toBeInTheDocument();
@@ -19,6 +25,16 @@ describe('Hero', () => {
 
     const searchText = screen.getByRole('textbox', { name: `Search for ${heroPlaceholder}` });
     expect(searchText).toBeInTheDocument();
+  });
+
+  it('should render export if exportData is received', () => {
+    tree({ exportData: { email: 'mock-email', transactions: 1234 } });
+    expect(screen.getByRole('button', { name: /Export/i })).toBeInTheDocument();
+  });
+
+  it('should render export even if exportData.transactions is 0', () => {
+    tree({ exportData: { email: 'mock-email', transactions: 0 } });
+    expect(screen.getByRole('button', { name: /Export/i })).toBeInTheDocument();
   });
 
   it('should be accessible', async () => {

--- a/spa/src/components/common/Hero/Hero.test.tsx
+++ b/spa/src/components/common/Hero/Hero.test.tsx
@@ -41,10 +41,13 @@ describe('Hero', () => {
     expect(screen.getByRole('button', { name: 'mock-export-button' })).toBeInTheDocument();
   });
 
-  it('should be accessible', async () => {
-    const { container } = render(
-      <Hero title={heroTitle} subtitle={heroSubtitle} placeholder={heroPlaceholder} onChange={onChange} />
-    );
+  it('should be accessible with export button', async () => {
+    const { container } = tree({ exportData: { email: 'mock-email', transactions: 0 } });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('should be accessible without export button', async () => {
+    const { container } = tree();
     expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/spa/src/components/common/Hero/Hero.tsx
+++ b/spa/src/components/common/Hero/Hero.tsx
@@ -10,7 +10,7 @@ export type HeroProps = InferProps<typeof HeroPropTypes>;
 
 const Hero = ({ title, subtitle, onChange, placeholder, className, exportData }: HeroProps) => {
   const classes = useStyles();
-  const showExport = !!exportData?.transactions && !!exportData.email;
+  const showExport = !!exportData?.email;
 
   return (
     <Flex className={className!}>
@@ -31,7 +31,7 @@ const HeroPropTypes = {
   className: PropTypes.string,
   exportData: PropTypes.shape({
     transactions: PropTypes.number,
-    email: PropTypes.string
+    email: PropTypes.string.isRequired
   })
 };
 

--- a/spa/src/components/common/Hero/Hero.tsx
+++ b/spa/src/components/common/Hero/Hero.tsx
@@ -4,7 +4,7 @@ import HeaderSection from 'components/common/HeaderSection';
 import Searchbar from 'components/common/TextField/Searchbar';
 
 import useStyles, { Flex, RightAction } from './Hero.styled';
-import ExportButton from '../Button/ExportButton';
+import ExportButton from 'components/common/Button/ExportButton';
 
 export type HeroProps = InferProps<typeof HeroPropTypes>;
 


### PR DESCRIPTION
#### Plan? (if this draft/incomplete indicate what you intend to do and how)
This is the **second** of **2** stacked PRs to deliver the ticket [DEV-2783](https://news-revenue-hub.atlassian.net/browse/DEV-2783)

- (https://github.com/newsrevenuehub/rev-engine/pull/879) (corresponding to [DEV-2836](https://news-revenue-hub.atlassian.net/browse/DEV-2836) Enhancement: Export contributions system notification  - **THE CURRENT PR**
- (https://github.com/newsrevenuehub/rev-engine/pull/901) (corresponding to [DEV-2231](https://news-revenue-hub.atlassian.net/browse/DEV-2974) Export button does not display when contributions table empty - **THE CURRENT PR**

#### What's this PR do?
Shows Export button in Contributions dashboard even if there aren't any transactions yet

#### Why are we doing this? How does it help us?
Consistently show the user the Export Button so that they are aware of the functionality

#### How should this be manually tested? Please include detailed step-by-step instructions.
Login with a user with 0 contributions (if you don't have any accounts, you can create a new one)

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
No, just leaves it on screen in a scenario.

#### Have automated unit tests been added? If not, why?
Yes

#### How should this change be communicated to end users?
N/A

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-2974

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no