### PR TITLE
DEV-2641: Update new page name to contain revenue program

### DIFF
--- a/spa/cypress/e2e/03-donationPageList.cy.js
+++ b/spa/cypress/e2e/03-donationPageList.cy.js
@@ -114,9 +114,9 @@ describe('Add Page modal', () => {
       cy.getByTestId('new-page-button').click();
       cy.wait('@createNewPage').then(({ request }) => {
         expect(request.body).to.eql({
-          name: 'Page 1',
+          name: 'Some Rev Program Page 1',
           revenue_program: 1,
-          slug: 'page-1'
+          slug: 'some-rev-program-page-1'
         });
       });
     });
@@ -132,9 +132,9 @@ describe('Add Page modal', () => {
       cy.getByTestId('new-page-button').click();
       cy.wait('@createNewPage').then(({ request }) => {
         expect(request.body).to.eql({
-          name: 'Page 2',
+          name: 'Some Rev Program Page 2',
           revenue_program: 1,
-          slug: 'page-2'
+          slug: 'some-rev-program-page-2'
         });
       });
     });

--- a/spa/src/components/content/pages/AddPage.tsx
+++ b/spa/src/components/content/pages/AddPage.tsx
@@ -25,19 +25,22 @@ function AddPage({ pagesByRevenueProgram, disabled }: AddPageType) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
 
-  const getTemporaryPageName = useCallback((pages: typeof pagesByRevenueProgram[number]['pages']) => {
-    const pagesSize = (pages?.length ?? 0) + 1;
-    const slugs = pages ? pages.map(({ slug }) => slug) : [];
-    let number = pagesSize;
-    let tempName = `Page ${number}`;
-    let tempSlug = slugify(tempName);
-    while (slugs.includes(tempSlug)) {
-      number += 1;
-      tempName = `Page ${number}`;
-      tempSlug = slugify(tempName);
-    }
-    return { tempName, tempSlug };
-  }, []);
+  const getTemporaryPageName = useCallback(
+    (pages: typeof pagesByRevenueProgram[number]['pages'], revenueProgramName: string) => {
+      const pagesSize = (pages?.length ?? 0) + 1;
+      const slugs = pages ? pages.map(({ slug }) => slug) : [];
+      let number = pagesSize;
+      let tempName = `${revenueProgramName} Page ${number}`;
+      let tempSlug = slugify(tempName);
+      while (slugs.includes(tempSlug)) {
+        number += 1;
+        tempName = `${revenueProgramName} Page ${number}`;
+        tempSlug = slugify(tempName);
+      }
+      return { tempName, tempSlug };
+    },
+    []
+  );
 
   const handleSaveFailure = useCallback(
     (e) => {
@@ -56,10 +59,14 @@ function AddPage({ pagesByRevenueProgram, disabled }: AddPageType) {
   );
 
   const handleSave = useCallback(
-    (pagesBySelectedRp: typeof pagesByRevenueProgram[number]['pages'], revenueProgramId: string) => {
+    (
+      pagesBySelectedRp: typeof pagesByRevenueProgram[number]['pages'],
+      revenueProgramId: string,
+      revenueProgramName: string
+    ) => {
       setLoading(true);
 
-      const { tempName, tempSlug } = getTemporaryPageName(pagesBySelectedRp);
+      const { tempName, tempSlug } = getTemporaryPageName(pagesBySelectedRp, revenueProgramName);
       const formData = {
         name: tempName,
         slug: tempSlug,
@@ -89,7 +96,7 @@ function AddPage({ pagesByRevenueProgram, disabled }: AddPageType) {
 
   const checkCreatePage = useCallback(() => {
     if (user?.revenue_programs?.length === 1) {
-      handleSave(pagesByRevenueProgram[0]?.pages, user!.revenue_programs[0].id);
+      handleSave(pagesByRevenueProgram[0]?.pages, user!.revenue_programs[0].id, user!.revenue_programs[0].name);
     } else {
       handleOpen();
     }
@@ -99,7 +106,7 @@ function AddPage({ pagesByRevenueProgram, disabled }: AddPageType) {
     (revenueProgramId: string) => {
       const rp = user?.revenue_programs.find((rp) => Number(rp.id) === Number(revenueProgramId));
       const pages = pagesByRevenueProgram?.find(({ name }) => name === rp?.name)?.pages ?? [];
-      handleSave(pages, revenueProgramId);
+      handleSave(pages, revenueProgramId, rp?.name!);
     },
     [handleSave, pagesByRevenueProgram, user?.revenue_programs]
   );


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a

#### What's this PR do?
Updates the page creation defaul name, instead of being only "Page [number]", it now is "[Revenue Program name] Page [number]"

#### Why are we doing this? How does it help us?
Makes it clearer for the user which RP the page is without having to enter the page details.

#### How should this be manually tested? Please include detailed step-by-step instructions.
1) User with multiple RP
- Login with user
- Create a new page with any available RP
- Page name should be "RP Page number"

2) User with 1 RP
- Create new account
- Create new page
- Page name should be "RP Page 1"

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
yes

#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-2641

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no