### PR TITLE
DEV-3094: Fix image removal in contribution page

### DIFF
--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -577,6 +577,61 @@ describe('Edit interface: Setup', () => {
       cy.findByAltText(`image-${label}.jpeg`).should('not.exist');
     }
   });
+
+  it('sends blank strings for the appropriate fields when images are removed', () => {
+    // Have to re-run the entire before() process, but with different API
+    // data.
+
+    cy.forceLogin(orgAdminUser);
+    cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: orgAdminWithContentFlag });
+    cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_STYLES) }, {});
+    cy.intercept(
+      { method: 'GET', pathname: `${getEndpoint(DRAFT_PAGE_DETAIL)}**` },
+      {
+        body: {
+          ...livePage,
+          graphic: 'mock-image-url.jpeg',
+          graphic_thumbnail: 'mock-image-url.jpeg',
+          header_bg_image: 'mock-image-url.jpeg',
+          header_bg_image_thumbnail: 'mock-image-url.jpeg',
+          header_logo: 'mock-image-url.jpeg',
+          header_logo_thumbnail: 'mock-image-url.jpeg'
+        },
+        statusCode: 200
+      }
+    ).as('getPage');
+    cy.intercept(
+      { method: 'PATCH', pathname: `${getEndpoint(PATCH_PAGE)}${livePage.id}/` },
+      { body: livePage, statusCode: 200 }
+    ).as('patchPage');
+
+    const route = testEditPageUrl;
+
+    cy.visit(route);
+    cy.url().should('include', route);
+    cy.wait('@getPage');
+    cy.getByTestId('edit-page-button').click();
+    cy.getByTestId('edit-setup-tab').click({ force: true });
+    cy.findAllByLabelText('Remove').filter(':enabled').click({ multiple: true });
+    // Accept changes
+    cy.findByRole('button', { name: 'Update' }).click({ force: true });
+
+    // Save changes
+    cy.getByTestId('save-page-button').click();
+    cy.findByText('Continue').click();
+    cy.wait('@patchPage').then(({ request }) => {
+      // This request is sent as multipart form data, so we assert on its
+      // contents. If we end up doing this a lot, it might be worth it to bring
+      // in a module to parse the response.
+      //
+      // The intent here is to test we are sending an empty value, not the
+      // string 'undefined' or something else.
+
+      for (const field of ['graphic', 'header_bg_image', 'header_logo']) {
+        expect(request.body).to.include(`Content-Disposition: form-data; name="${field}"\r\n\r\n\r\n------`);
+      }
+    });
+  });
 });
 
 describe('Edit interface: Styles', () => {

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -250,11 +250,9 @@ function PageEditor() {
   const cleanImageKeys = (patchedPage) => {
     // Can't send back existing values for images, as they come in as slugs.
     // The API expects an image. So if typeof page.[image] is a string, delete the key.
+    // An empty string here means "remove this image".
     for (const image of IMAGE_KEYS) {
-      // If it's undefined, we're removing an image. Coerce it to an empty string.
-      if (typeof patchedPage[image] === 'undefined') {
-        patchedPage[image] = '';
-      } else if (patchedPage[image] !== '' && typeof patchedPage[image] === 'string') {
+      if (patchedPage[image] !== '' && typeof patchedPage[image] === 'string') {
         delete patchedPage[image];
       }
     }

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -251,8 +251,10 @@ function PageEditor() {
     // Can't send back existing values for images, as they come in as slugs.
     // The API expects an image. So if typeof page.[image] is a string, delete the key.
     for (const image of IMAGE_KEYS) {
-      // If it's undefined, we're removing an image. Keep that value.
-      if (patchedPage[image] !== '' && typeof patchedPage[image] === 'string') {
+      // If it's undefined, we're removing an image. Coerce it to an empty string.
+      if (typeof patchedPage[image] === 'undefined') {
+        patchedPage[image] = '';
+      } else if (patchedPage[image] !== '' && typeof patchedPage[image] === 'string') {
         delete patchedPage[image];
       }
     }

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.js
@@ -40,9 +40,20 @@ function PageSetup() {
   const [published_date] = useState(page.published_date ? new Date(page.published_date) : undefined);
 
   const handleKeepChanges = () => {
+    // Coerce undefined values in `images` to empty strings, as this is what the
+    // API request is looking for.
+
+    const parsedImages = Object.keys(images).reduce((result, key) => {
+      if (images[key] === undefined) {
+        return { ...result, [key]: '' };
+      }
+
+      return { ...result, [key]: images[key] };
+    }, {});
+
     setPageContent({
       heading,
-      ...images,
+      ...parsedImages,
       header_link,
       thank_you_redirect,
       post_thank_you_redirect,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Fixes a bug where removing an image from the Setup tab of a contribution page doesn't save properly.
- Resolves problems with Cypress tests that don't seem related to the PR.

#### Why are we doing this? How does it help us?

Fixes a bug and improves CI.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit a contribution page.
2. Add images to all possible fields on the Setup tab.
3. Save changes to the page.
4. Confirm the images show on the live page.
5. Edit the page again.
6. Remove all images you added in step 2 and make a text change to another field, like Form Panel Heading.
7. Save changes to the page.
8. Confirm that the page now shows no images and the text change you made shows correctly.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

In the Cypress tests:

- I did a basic text compare to assert that the data being submitted to the API is correct. It felt overkill to bring in a module to parse the request properly for a single test, but it probably would make sense if we end up adding multiple tests to do this.
- I hardcoded the table length of contributions after switching pages. I don't understand why, but trying to assert on the length of a second intercept seems to be inconsistent. Sometimes it asserts on the second interception's response, sometimes on the first.
  
#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3094

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.