### PR TITLE
DEV-3114: Review changes to webhook tests

### DIFF
--- a/apps/contributions/tests/fixtures/customer-subscription-deleted-webhook.json
+++ b/apps/contributions/tests/fixtures/customer-subscription-deleted-webhook.json
@@ -1,0 +1,168 @@
+{
+    "id": "evt_fakefakefake",
+    "object": "event",
+    "account": "acct_fakefakefake",
+    "api_version": "2020-08-27",
+    "created": 1673018247,
+    "data": {
+      "object": {
+        "id": "sub_fakefakefake",
+        "object": "subscription",
+        "application": "ca_fakefakefakefake",
+        "application_fee_percent": null,
+        "automatic_tax": {
+          "enabled": false
+        },
+        "billing_cycle_anchor": 1663773174,
+        "billing_thresholds": null,
+        "cancel_at": null,
+        "cancel_at_period_end": false,
+        "canceled_at": 1673018247,
+        "collection_method": "charge_automatically",
+        "created": 1663773174,
+        "currency": "usd",
+        "current_period_end": 1674313974,
+        "current_period_start": 1671635574,
+        "customer": "cus_MTRUJ5nMGZ5ldM",
+        "days_until_due": null,
+        "default_payment_method": "pm_fakefakefake",
+        "default_source": null,
+        "default_tax_rates": [
+        ],
+        "description": null,
+        "discount": null,
+        "ended_at": 1673018247,
+        "items": {
+          "object": "list",
+          "data": [
+            {
+              "id": "si_fakefakefake",
+              "object": "subscription_item",
+              "billing_thresholds": null,
+              "created": 1663773174,
+              "metadata": {
+              },
+              "plan": {
+                "id": "price_fakefakefake",
+                "object": "plan",
+                "active": false,
+                "aggregate_usage": null,
+                "amount": 23957,
+                "amount_decimal": "23957",
+                "billing_scheme": "per_unit",
+                "created": 1663773174,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {
+                },
+                "nickname": null,
+                "product": "prod_fakefakefake",
+                "tiers_mode": null,
+                "transform_usage": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "price": {
+                "id": "price_fakefakefake",
+                "object": "price",
+                "active": false,
+                "billing_scheme": "per_unit",
+                "created": 1663773174,
+                "currency": "usd",
+                "custom_unit_amount": null,
+                "livemode": false,
+                "lookup_key": null,
+                "metadata": {
+                },
+                "nickname": null,
+                "product": "prod_fakefakefake",
+                "recurring": {
+                  "aggregate_usage": null,
+                  "interval": "month",
+                  "interval_count": 1,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "tax_behavior": "unspecified",
+                "tiers_mode": null,
+                "transform_quantity": null,
+                "type": "recurring",
+                "unit_amount": 23957,
+                "unit_amount_decimal": "23957"
+              },
+              "quantity": 1,
+              "subscription": "sub_fakefakefake",
+              "tax_rates": [
+              ]
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscription_items?subscription=sub_fakefakefake"
+        },
+        "latest_invoice": "in_fakefakefake",
+        "livemode": false,
+        "metadata": {
+          "agreed_to_pay_fees": "False",
+          "referer": "https://foo.org/donate",
+          "source": "rev-engine",
+          "revenue_program_id": "22",
+          "donor_selected_amount": "23957",
+          "swag_opt_out": "False",
+          "contributor_id": "425",
+          "revenue_program_slug": "foo",
+          "schema_version": "1.1"
+        },
+        "next_pending_invoice_item_invoice": null,
+        "on_behalf_of": null,
+        "pause_collection": null,
+        "payment_settings": {
+          "payment_method_options": null,
+          "payment_method_types": null,
+          "save_default_payment_method": "on_subscription"
+        },
+        "pending_invoice_item_interval": null,
+        "pending_setup_intent": null,
+        "pending_update": null,
+        "plan": {
+          "id": "price_fakefakefake",
+          "object": "plan",
+          "active": false,
+          "aggregate_usage": null,
+          "amount": 23957,
+          "amount_decimal": "23957",
+          "billing_scheme": "per_unit",
+          "created": 1663773174,
+          "currency": "usd",
+          "interval": "month",
+          "interval_count": 1,
+          "livemode": false,
+          "metadata": {
+          },
+          "nickname": null,
+          "product": "prod_fakefakefake",
+          "tiers_mode": null,
+          "transform_usage": null,
+          "trial_period_days": null,
+          "usage_type": "licensed"
+        },
+        "quantity": 1,
+        "schedule": null,
+        "start_date": 1663773174,
+        "status": "canceled",
+        "test_clock": null,
+        "transfer_data": null,
+        "trial_end": null,
+        "trial_start": null
+      }
+    },
+    "livemode": false,
+    "pending_webhooks": 15,
+    "request": {
+      "id": "req_fakefakefake",
+      "idempotency_key": null
+    },
+    "type": "customer.subscription.deleted"
+  }

--- a/apps/contributions/tests/fixtures/customer-subscription-updated-webhook.json
+++ b/apps/contributions/tests/fixtures/customer-subscription-updated-webhook.json
@@ -1,0 +1,173 @@
+{
+    "id": "evt_fakefakefake",
+    "object": "event",
+    "account": "acct_fakefakefake",
+    "api_version": "2020-08-27",
+    "created": 1672964931,
+    "data": {
+      "object": {
+        "id": "sub_fakefakefake",
+        "object": "subscription",
+        "application": "ca_fakefakefake",
+        "application_fee_percent": null,
+        "automatic_tax": {
+          "enabled": false
+        },
+        "billing_cycle_anchor": 1672964927,
+        "billing_thresholds": null,
+        "cancel_at": null,
+        "cancel_at_period_end": false,
+        "canceled_at": 1672964931,
+        "collection_method": "charge_automatically",
+        "created": 1672964927,
+        "currency": "usd",
+        "current_period_end": 1675643327,
+        "current_period_start": 1672964927,
+        "customer": "cus_fakefakefake",
+        "days_until_due": null,
+        "default_payment_method": null,
+        "default_source": null,
+        "default_tax_rates": [
+        ],
+        "description": null,
+        "discount": null,
+        "ended_at": 1672964931,
+        "items": {
+          "object": "list",
+          "data": [
+            {
+              "id": "si_fakefakefake",
+              "object": "subscription_item",
+              "billing_thresholds": null,
+              "created": 1672964927,
+              "metadata": {
+              },
+              "plan": {
+                "id": "price_fakefakefake",
+                "object": "plan",
+                "active": false,
+                "aggregate_usage": null,
+                "amount": 37352,
+                "amount_decimal": "37352",
+                "billing_scheme": "per_unit",
+                "created": 1672964927,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {
+                },
+                "nickname": null,
+                "product": "prod_fakefakefake",
+                "tiers_mode": null,
+                "transform_usage": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "price": {
+                "id": "price_fakefakefake",
+                "object": "price",
+                "active": false,
+                "billing_scheme": "per_unit",
+                "created": 1672964927,
+                "currency": "usd",
+                "custom_unit_amount": null,
+                "livemode": false,
+                "lookup_key": null,
+                "metadata": {
+                },
+                "nickname": null,
+                "product": "prod_fakefakefake",
+                "recurring": {
+                  "aggregate_usage": null,
+                  "interval": "month",
+                  "interval_count": 1,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "tax_behavior": "unspecified",
+                "tiers_mode": null,
+                "transform_quantity": null,
+                "type": "recurring",
+                "unit_amount": 37352,
+                "unit_amount_decimal": "37352"
+              },
+              "quantity": 1,
+              "subscription": "sub_fakefakefake",
+              "tax_rates": [
+              ]
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscription_items?subscription=sub_fakefakefake"
+        },
+        "latest_invoice": "in_1MN3nfPbhdfvD1kVyiI1mKlR",
+        "livemode": false,
+        "metadata": {
+          "referer": "https://foo.revengine-staging.org/",
+          "donor_selected_amount": "365.0",
+          "revenue_program_id": "3",
+          "source": "rev-engine",
+          "swag_opt_out": "False",
+          "contributor_id": "132",
+          "agreed_to_pay_fees": "True",
+          "revenue_program_slug": "foo",
+          "schema_version": "1.1"
+        },
+        "next_pending_invoice_item_invoice": null,
+        "on_behalf_of": null,
+        "pause_collection": null,
+        "payment_settings": {
+          "payment_method_options": null,
+          "payment_method_types": null,
+          "save_default_payment_method": "on_subscription"
+        },
+        "pending_invoice_item_interval": null,
+        "pending_setup_intent": null,
+        "pending_update": null,
+        "plan": {
+          "id": "price_fakefakefake",
+          "object": "plan",
+          "active": false,
+          "aggregate_usage": null,
+          "amount": 37352,
+          "amount_decimal": "37352",
+          "billing_scheme": "per_unit",
+          "created": 1672964927,
+          "currency": "usd",
+          "interval": "month",
+          "interval_count": 1,
+          "livemode": false,
+          "metadata": {
+          },
+          "nickname": null,
+          "product": "prod_fakefakefake",
+          "tiers_mode": null,
+          "transform_usage": null,
+          "trial_period_days": null,
+          "usage_type": "licensed"
+        },
+        "quantity": 1,
+        "schedule": null,
+        "start_date": 1672964927,
+        "status": "incomplete_expired",
+        "test_clock": null,
+        "transfer_data": null,
+        "trial_end": null,
+        "trial_start": null
+      },
+      "previous_attributes": {
+        "canceled_at": null,
+        "ended_at": null,
+        "status": "incomplete"
+      }
+    },
+    "livemode": false,
+    "pending_webhooks": 14,
+    "request": {
+      "id": "req_fakefakefake",
+      "idempotency_key": null
+    },
+    "type": "customer.subscription.updated"
+  }

--- a/apps/contributions/tests/fixtures/payment-intent-canceled-webhook.json
+++ b/apps/contributions/tests/fixtures/payment-intent-canceled-webhook.json
@@ -1,0 +1,77 @@
+{
+    "id": "evt_fakefakefake",
+    "object": "event",
+    "account": "acct_fakefakefake",
+    "api_version": "2020-08-27",
+    "created": 1672964931,
+    "data": {
+      "object": {
+        "id": "pi_fakefakefake",
+        "object": "payment_intent",
+        "amount": 37352,
+        "amount_capturable": 0,
+        "amount_details": {
+          "tip": {
+          }
+        },
+        "amount_received": 0,
+        "application": "ca_fakefakefake",
+        "application_fee_amount": null,
+        "automatic_payment_methods": null,
+        "canceled_at": 1672964931,
+        "cancellation_reason": "void_invoice",
+        "capture_method": "automatic",
+        "charges": {
+          "object": "list",
+          "data": [
+          ],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/charges?payment_intent=pi_fakefakefake"
+        },
+        "client_secret": "pi_fakefakefake_secret_fakefakefake",
+        "confirmation_method": "automatic",
+        "created": 1672964927,
+        "currency": "usd",
+        "customer": "cus_fakefakefake",
+        "description": "Subscription creation",
+        "invoice": "in_fakefakefake",
+        "last_payment_error": null,
+        "livemode": false,
+        "metadata": {
+        },
+        "next_action": null,
+        "on_behalf_of": null,
+        "payment_method": null,
+        "payment_method_options": {
+          "card": {
+            "installments": null,
+            "mandate_options": null,
+            "network": null,
+            "request_three_d_secure": "automatic"
+          }
+        },
+        "payment_method_types": [
+          "card"
+        ],
+        "processing": null,
+        "receipt_email": null,
+        "review": null,
+        "setup_future_usage": "off_session",
+        "shipping": null,
+        "source": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "canceled",
+        "transfer_data": null,
+        "transfer_group": null
+      }
+    },
+    "livemode": false,
+    "pending_webhooks": 14,
+    "request": {
+      "id": "req_fakefakefake",
+      "idempotency_key": null
+    },
+    "type": "payment_intent.canceled"
+  }

--- a/apps/contributions/tests/fixtures/payment-intent-payment-failed-webhook.json
+++ b/apps/contributions/tests/fixtures/payment-intent-payment-failed-webhook.json
@@ -1,0 +1,230 @@
+{
+    "id": "evt_fakefakefake",
+    "object": "event",
+    "account": "acct_fakefakefakefake",
+    "api_version": "2020-08-27",
+    "created": 1673034346,
+    "data": {
+      "object": {
+        "id": "pi_fakefakefakfake123",
+        "object": "payment_intent",
+        "amount": 36500,
+        "amount_capturable": 0,
+        "amount_details": {
+          "tip": {
+          }
+        },
+        "amount_received": 0,
+        "application": "ca_fakefakefakefakeabc",
+        "application_fee_amount": null,
+        "automatic_payment_methods": null,
+        "canceled_at": null,
+        "cancellation_reason": null,
+        "capture_method": "automatic",
+        "charges": {
+          "object": "list",
+          "data": [
+            {
+              "id": "ch_fakefakefakefakexyz",
+              "object": "charge",
+              "amount": 36500,
+              "amount_captured": 0,
+              "amount_refunded": 0,
+              "application": "ca_fakefakefakefakeabc",
+              "application_fee": null,
+              "application_fee_amount": null,
+              "balance_transaction": null,
+              "billing_details": {
+                "address": {
+                  "city": "Eau Claire",
+                  "country": "AR",
+                  "line1": "234",
+                  "line2": "",
+                  "postal_code": "54701",
+                  "state": "WI"
+                },
+                "email": "foo@fundjournalism.org",
+                "name": "foo",
+                "phone": "234"
+              },
+              "calculated_statement_descriptor": "WWW.FOO.ORG",
+              "captured": false,
+              "created": 1673034346,
+              "currency": "usd",
+              "customer": "cus_fakefakefakeABC",
+              "description": "Subscription creation",
+              "destination": null,
+              "dispute": null,
+              "disputed": false,
+              "failure_balance_transaction": null,
+              "failure_code": "card_declined",
+              "failure_message": "Your card was declined.",
+              "fraud_details": {
+              },
+              "invoice": "in_fakefakefakefake678",
+              "livemode": false,
+              "metadata": {
+              },
+              "on_behalf_of": null,
+              "order": null,
+              "outcome": {
+                "network_status": "declined_by_network",
+                "reason": "generic_decline",
+                "risk_level": "normal",
+                "risk_score": 44,
+                "seller_message": "The bank did not return any further details with this decline.",
+                "type": "issuer_declined"
+              },
+              "paid": false,
+              "payment_intent": "pi_fakefakefakfake123",
+              "payment_method": "pm_fakefakefake234555",
+              "payment_method_details": {
+                "card": {
+                  "brand": "visa",
+                  "checks": {
+                    "address_line1_check": "pass",
+                    "address_postal_code_check": "pass",
+                    "cvc_check": "pass"
+                  },
+                  "country": "US",
+                  "exp_month": 12,
+                  "exp_year": 2023,
+                  "fingerprint": "jiWTkvoYfuvFMg51",
+                  "funding": "credit",
+                  "installments": null,
+                  "last4": "0002",
+                  "mandate": null,
+                  "network": "visa",
+                  "three_d_secure": null,
+                  "wallet": null
+                },
+                "type": "card"
+              },
+              "receipt_email": null,
+              "receipt_number": null,
+              "receipt_url": null,
+              "refunded": false,
+              "refunds": {
+                "object": "list",
+                "data": [
+                ],
+                "has_more": false,
+                "total_count": 0,
+                "url": "/v1/charges/ch_fakefakefakefakexyz/refunds"
+              },
+              "review": null,
+              "shipping": null,
+              "source": null,
+              "source_transfer": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "failed",
+              "transfer_data": null,
+              "transfer_group": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/charges?payment_intent=pi_fakefakefakfake123"
+        },
+        "client_secret": "pi_fakefakefakfake123_secret_39s",
+        "confirmation_method": "automatic",
+        "created": 1673034338,
+        "currency": "usd",
+        "customer": "cus_fakefakefakeABC",
+        "description": "Subscription creation",
+        "invoice": "in_fakefakefakefake678",
+        "last_payment_error": {
+          "charge": "ch_fakefakefakefakexyz",
+          "code": "card_declined",
+          "decline_code": "generic_decline",
+          "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+          "message": "Your card was declined.",
+          "payment_method": {
+            "id": "pm_fakefakefake234555",
+            "object": "payment_method",
+            "billing_details": {
+              "address": {
+                "city": "Eau Claire",
+                "country": "AR",
+                "line1": "234",
+                "line2": "",
+                "postal_code": "54701",
+                "state": "WI"
+              },
+              "email": "foo@fundjournalism.org",
+              "name": "Foo",
+              "phone": "234"
+            },
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": "pass",
+                "address_postal_code_check": "pass",
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 12,
+              "exp_year": 2023,
+              "fingerprint": "jiWTkvoYfuvFMg51",
+              "funding": "credit",
+              "generated_from": null,
+              "last4": "0002",
+              "networks": {
+                "available": [
+                  "visa"
+                ],
+                "preferred": null
+              },
+              "three_d_secure_usage": {
+                "supported": true
+              },
+              "wallet": null
+            },
+            "created": 1673034346,
+            "customer": null,
+            "livemode": false,
+            "metadata": {
+            },
+            "type": "card"
+          },
+          "type": "card_error"
+        },
+        "livemode": false,
+        "metadata": {
+        },
+        "next_action": null,
+        "on_behalf_of": null,
+        "payment_method": null,
+        "payment_method_options": {
+          "card": {
+            "installments": null,
+            "mandate_options": null,
+            "network": null,
+            "request_three_d_secure": "automatic"
+          }
+        },
+        "payment_method_types": [
+          "card"
+        ],
+        "processing": null,
+        "receipt_email": null,
+        "review": null,
+        "setup_future_usage": "off_session",
+        "shipping": null,
+        "source": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "requires_payment_method",
+        "transfer_data": null,
+        "transfer_group": null
+      }
+    },
+    "livemode": false,
+    "pending_webhooks": 15,
+    "request": {
+      "id": "req_fakefakefake",
+      "idempotency_key": "9cf72c9e-998b-40fa-8ef4-5c4af6623cc2"
+    },
+    "type": "payment_intent.payment_failed"
+  }

--- a/apps/contributions/tests/fixtures/payment-intent-succeeded-webhook.json
+++ b/apps/contributions/tests/fixtures/payment-intent-succeeded-webhook.json
@@ -1,0 +1,175 @@
+{
+    "id": "evt_fakefakefake",
+    "object": "event",
+    "account": "acct_fakefakefake",
+    "api_version": "2020-08-27",
+    "created": 1673016228,
+    "data": {
+      "object": {
+        "id": "pi_fakefakefake",
+        "object": "payment_intent",
+        "amount": 1564,
+        "amount_capturable": 0,
+        "amount_details": {
+          "tip": {
+          }
+        },
+        "amount_received": 1564,
+        "application": "ca_fakefakefake",
+        "application_fee_amount": null,
+        "automatic_payment_methods": null,
+        "canceled_at": null,
+        "cancellation_reason": null,
+        "capture_method": "automatic",
+        "charges": {
+          "object": "list",
+          "data": [
+            {
+              "id": "ch_fakefakefakefake",
+              "object": "charge",
+              "amount": 1564,
+              "amount_captured": 1564,
+              "amount_refunded": 0,
+              "application": "ca_fakefakefake",
+              "application_fee": null,
+              "application_fee_amount": null,
+              "balance_transaction": "txn_fakefakefake",
+              "billing_details": {
+                "address": {
+                  "city": "Philadelphia",
+                  "country": "US",
+                  "line1": "2546 South Broad Street",
+                  "line2": "",
+                  "postal_code": "19145",
+                  "state": "Pennsylvania"
+                },
+                "email": "foo@fundjournalism.org",
+                "name": "Foo Bar",
+                "phone": "1234567890"
+              },
+              "calculated_statement_descriptor": "ORG.ORG",
+              "captured": true,
+              "created": 1673016227,
+              "currency": "usd",
+              "customer": "cus_fakefakefake",
+              "description": "Subscription update",
+              "destination": null,
+              "dispute": null,
+              "disputed": false,
+              "failure_balance_transaction": null,
+              "failure_code": null,
+              "failure_message": null,
+              "fraud_details": {
+              },
+              "invoice": "in_1fakefakefake",
+              "livemode": false,
+              "metadata": {
+              },
+              "on_behalf_of": null,
+              "order": null,
+              "outcome": {
+                "network_status": "approved_by_network",
+                "reason": null,
+                "risk_level": "normal",
+                "risk_score": 41,
+                "seller_message": "Payment complete.",
+                "type": "authorized"
+              },
+              "paid": true,
+              "payment_intent": "pi_fakefakefake",
+              "payment_method": "pm_fakefakefake",
+              "payment_method_details": {
+                "card": {
+                  "brand": "visa",
+                  "checks": {
+                    "address_line1_check": "pass",
+                    "address_postal_code_check": "pass",
+                    "cvc_check": null
+                  },
+                  "country": "US",
+                  "exp_month": 4,
+                  "exp_year": 2024,
+                  "fingerprint": "fakefakefake",
+                  "funding": "credit",
+                  "installments": null,
+                  "last4": "4242",
+                  "mandate": null,
+                  "network": "visa",
+                  "three_d_secure": null,
+                  "wallet": null
+                },
+                "type": "card"
+              },
+              "receipt_email": null,
+              "receipt_number": null,
+              "receipt_url": "https://pay.stripe.com/receipts/invoices/fakefakefake?s=ap",
+              "refunded": false,
+              "refunds": {
+                "object": "list",
+                "data": [
+                ],
+                "has_more": false,
+                "total_count": 0,
+                "url": "/v1/charges/ch_fakefakefakefake/refunds"
+              },
+              "review": null,
+              "shipping": null,
+              "source": null,
+              "source_transfer": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "succeeded",
+              "transfer_data": null,
+              "transfer_group": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/charges?payment_intent=pi_fakefakefake"
+        },
+        "client_secret": "pi_fakefakefake_secret_fakefakefake",
+        "confirmation_method": "automatic",
+        "created": 1673016227,
+        "currency": "usd",
+        "customer": "cus_fakefakefake",
+        "description": "Subscription update",
+        "invoice": "in_1fakefakefake",
+        "last_payment_error": null,
+        "livemode": false,
+        "metadata": {
+        },
+        "next_action": null,
+        "on_behalf_of": null,
+        "payment_method": "pm_fakefakefake",
+        "payment_method_options": {
+          "card": {
+            "installments": null,
+            "mandate_options": null,
+            "network": null,
+            "request_three_d_secure": "automatic"
+          }
+        },
+        "payment_method_types": [
+          "card"
+        ],
+        "processing": null,
+        "receipt_email": null,
+        "review": null,
+        "setup_future_usage": null,
+        "shipping": null,
+        "source": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": null
+      }
+    },
+    "livemode": false,
+    "pending_webhooks": 15,
+    "request": {
+      "id": null,
+      "idempotency_key": "in_1fakefakefake-initial_attempt-6bfb1a9bbbb5714ce"
+    },
+    "type": "payment_intent.succeeded"
+  }

--- a/apps/contributions/tests/test_webhooks.py
+++ b/apps/contributions/tests/test_webhooks.py
@@ -2,306 +2,278 @@ import json
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-from django.conf import settings
-from django.test import override_settings
 from django.urls import reverse
 from django.utils.timezone import make_aware
 
 import pytest
 from rest_framework import status
-from rest_framework.test import APIRequestFactory, APITestCase
-from stripe.error import SignatureVerificationError
-from stripe.stripe_object import StripeObject
 from stripe.webhook import WebhookSignature
 
 from apps.contributions.models import Contribution, ContributionInterval, ContributionStatus
 from apps.contributions.tests.factories import ContributionFactory
-from apps.contributions.views import process_stripe_webhook_view
-from apps.contributions.webhooks import StripeWebhookProcessor
-from apps.organizations.tests.factories import (
-    OrganizationFactory,
-    PaymentProviderFactory,
-    RevenueProgramFactory,
-)
-from apps.pages.tests.factories import DonationPageFactory
 
 
-valid_secret = "myvalidstripesecret"
-invalid_secret = "notavalidsecret"
+@pytest.fixture
+def payment_intent_canceled():
+    with open("apps/contributions/tests/fixtures/payment-intent-canceled-webhook.json") as fl:
+        return json.load(fl)
 
 
-class MockPaymentIntentEvent(StripeObject):
-    id = 1
-    # Something, somewhere down the line, needs this to be set just so...
-    _transient_values = []
-
-    def __init__(
-        self,
-        event_type=None,
-        intent_id=None,
-        object_type="payment_intent",
-        cancellation_reason=None,
-        customer=None,
-        livemode=False,
-    ):
-        self.type = event_type
-        self.data = {
-            "object": {
-                "id": intent_id,
-                "object": object_type,
-                "cancellation_reason": cancellation_reason,
-                "customer": customer,
-                "created": datetime.now().timestamp(),
-                "metadata": {"schema_version": settings.METADATA_SCHEMA_VERSION},
-            }
-        }
-        self.livemode = livemode
-        self.account = "acct_test_1234"
+@pytest.fixture
+def payment_intent_succeeded():
+    with open("apps/contributions/tests/fixtures/payment-intent-succeeded-webhook.json") as fl:
+        return json.load(fl)
 
 
-class MockSubscriptionEvent(StripeObject):
-    id = 1
-    # Something, somewhere down the line, needs this to be set just so...
-    _transient_values = []
-
-    def __init__(
-        self,
-        event_type=None,
-        subscription_id=None,
-        new_payment_method="",
-        previous_attributes={},
-        object_type="subscription",
-        cancellation_reason=None,
-        customer=None,
-        livemode=False,
-        metadata_schema_version=settings.METADATA_SCHEMA_VERSION,
-    ):
-        self.type = event_type
-        self.data = {
-            "object": {
-                "id": subscription_id,
-                "object": object_type,
-                "cancellation_reason": cancellation_reason,
-                "customer": customer,
-                "created": datetime.now().timestamp(),
-                "default_payment_method": new_payment_method,
-                "metadata": {"schema_version": metadata_schema_version},
-            },
-            "previous_attributes": previous_attributes,
-        }
-        self.livemode = livemode
-        self.account = "acct_1234"
+@pytest.fixture
+def payment_intent_payment_failed():
+    with open("apps/contributions/tests/fixtures/payment-intent-payment-failed-webhook.json") as fl:
+        return json.load(fl)
 
 
-def mock_valid_signature_verification_with_payment_intent(*args, **kwargs):
-    return MockPaymentIntentEvent(event_type="payment_intent.canceled")
+@pytest.fixture
+def payment_method_attached():
+    with open("apps/contributions/tests/fixtures/payment-method-attached-webhook.json") as fl:
+        return json.load(fl)
 
 
-def mock_valid_signature_verification(*args, **kwargs):
-    return MockPaymentIntentEvent(event_type="test")
+@pytest.fixture
+def customer_subscription_updated():
+    with open("apps/contributions/tests/fixtures/customer-subscription-updated-webhook.json") as fl:
+        return json.load(fl)
 
 
-def mock_invalid_signature_verification(*args, **kwargs):
-    raise SignatureVerificationError("message", "sig_header")
+@pytest.fixture
+def customer_subscription_deleted():
+    with open("apps/contributions/tests/fixtures/customer-subscription-deleted-webhook.json") as fl:
+        return json.load(fl)
 
 
-def mock_valid_signature_bad_payload_verification(*args, **kwargs):
-    raise ValueError()
+@pytest.fixture
+def invoice_upcoming():
+    with open("apps/contributions/tests/fixtures/stripe-invoice-upcoming.json") as fl:
+        return json.load(fl)
 
 
-@override_settings(STRIPE_WEBHOOK_SECRET=valid_secret)
-class PaymentIntentWebhooksTest(APITestCase):
-    def _create_contribution(self, payment_intent_id=None):
-        return Contribution.objects.create(
-            provider_payment_id=payment_intent_id, amount=1000, status=ContributionStatus.PROCESSING
+@pytest.mark.django_db
+class TestPaymentIntentSucceeded:
+    def test_when_contribution_found(self, payment_intent_succeeded, monkeypatch, client):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
+            contribution = ContributionFactory(
+                one_time=True,
+                status=ContributionStatus.PROCESSING,
+                last_payment_date=None,
+                payment_provider_data=None,
+                provider_payment_id=payment_intent_succeeded["data"]["object"]["id"],
+            )
+            response = client.post(reverse("stripe-webhooks"), data=payment_intent_succeeded, **header)
+        assert response.status_code == status.HTTP_200_OK
+        contribution.refresh_from_db()
+        assert contribution.payment_provider_data == payment_intent_succeeded
+        assert contribution.provider_payment_id == payment_intent_succeeded["data"]["object"]["id"]
+        assert contribution.last_payment_date is not None
+        assert contribution.status == ContributionStatus.PAID
+
+    def test_when_contribution_not_found(self, payment_intent_succeeded, monkeypatch, client):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        mock_log_exception = Mock()
+        monkeypatch.setattr("apps.contributions.views.logger.exception", mock_log_exception)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        assert not Contribution.objects.filter(
+            provider_payment_id=payment_intent_succeeded["data"]["object"]["id"]
+        ).exists()
+        response = client.post(reverse("stripe-webhooks"), data=payment_intent_succeeded, **header)
+        assert response.status_code == status.HTTP_200_OK
+        mock_log_exception.assert_called_once_with("Could not find contribution matching provider_payment_id")
+
+
+@pytest.mark.django_db
+class TestPaymentIntentCanceled:
+    @pytest.mark.parametrize("cancellation_reason", (None, "", "random-thing", "fraudulent"))
+    def test_when_contribution_found(self, cancellation_reason, monkeypatch, client, payment_intent_canceled):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
+            contribution = ContributionFactory(
+                one_time=True,
+                status=ContributionStatus.PROCESSING,
+                provider_payment_id=payment_intent_canceled["data"]["object"]["id"],
+            )
+            payment_intent_canceled["data"]["object"]["cancellation_reason"] = cancellation_reason
+            response = client.post(reverse("stripe-webhooks"), data=payment_intent_canceled, **header)
+        assert response.status_code == status.HTTP_200_OK
+        contribution.refresh_from_db()
+        assert contribution.payment_provider_data == payment_intent_canceled
+        assert (
+            contribution.status == ContributionStatus.REJECTED
+            if cancellation_reason == "fraudulent"
+            else ContributionStatus.CANCELED
         )
 
-    def _run_webhook_view_with_request(self):
-        request = APIRequestFactory().post(reverse("stripe-webhooks"))
-        request.META["HTTP_STRIPE_SIGNATURE"] = "testing"
-        return process_stripe_webhook_view(request)
+    def test_when_contribution_not_found(self, monkeypatch, client, payment_intent_canceled):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        mock_log_exception = Mock()
+        monkeypatch.setattr("apps.contributions.views.logger.exception", mock_log_exception)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        assert not Contribution.objects.filter(
+            provider_payment_id=payment_intent_canceled["data"]["object"]["id"]
+        ).exists()
+        response = client.post(reverse("stripe-webhooks"), data=payment_intent_canceled, **header)
+        assert response.status_code == status.HTTP_200_OK
+        mock_log_exception.assert_called_once_with("Could not find contribution matching provider_payment_id")
 
-    @patch("stripe.Webhook.construct_event", side_effect=mock_valid_signature_verification)
-    def test_valid_webhook_signature_proceeds(self, *args):
-        response = self._run_webhook_view_with_request()
-        self.assertEqual(response.status_code, 200)
 
-    @patch("stripe.Webhook.construct_event", side_effect=mock_invalid_signature_verification)
-    def test_invalid_webhook_signature_response(self, *args):
-        response = self._run_webhook_view_with_request()
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data["error"], "Invalid signature")
+@pytest.mark.django_db
+class TestPaymentIntentPaymentFailed:
+    def test_when_contribution_found(self, monkeypatch, client, payment_intent_payment_failed):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
+            contribution = ContributionFactory(
+                one_time=True,
+                status=ContributionStatus.PROCESSING,
+                provider_payment_id=payment_intent_payment_failed["data"]["object"]["id"],
+            )
+            response = client.post(reverse("stripe-webhooks"), data=payment_intent_payment_failed, **header)
+        assert response.status_code == status.HTTP_200_OK
+        contribution.refresh_from_db()
+        assert contribution.payment_provider_data == payment_intent_payment_failed
+        assert contribution.status == ContributionStatus.FAILED
 
-    @patch("stripe.Webhook.construct_event", side_effect=mock_valid_signature_bad_payload_verification)
-    def test_malformed_webhook_body_response(self, *args):
-        response = self._run_webhook_view_with_request()
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data["error"], "Invalid payload")
+    def test_when_contribution_not_found(self, monkeypatch, client, payment_intent_payment_failed):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        mock_log_exception = Mock()
+        monkeypatch.setattr("apps.contributions.views.logger.exception", mock_log_exception)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        assert not Contribution.objects.filter(
+            provider_payment_id=payment_intent_payment_failed["data"]["object"]["id"]
+        ).exists()
+        response = client.post(reverse("stripe-webhooks"), data=payment_intent_payment_failed, **header)
+        assert response.status_code == status.HTTP_200_OK
+        mock_log_exception.assert_called_once_with("Could not find contribution matching provider_payment_id")
 
-    @patch(
-        "stripe.Webhook.construct_event",
-        side_effect=mock_valid_signature_verification_with_payment_intent,
+
+@pytest.mark.django_db
+class TestCustomerSubscriptionUpdated:
+    @pytest.mark.parametrize("payment_method_has_changed", (True, False))
+    def test_when_contribution_found(
+        self, monkeypatch, client, customer_subscription_updated, payment_method_has_changed
+    ):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
+            contribution = ContributionFactory(
+                annual_subscription=True,
+                provider_subscription_id=customer_subscription_updated["data"]["object"]["id"],
+            )
+            if payment_method_has_changed:
+                customer_subscription_updated["data"]["previous_attributes"] = {"default_payment_method": "something"}
+            response = client.post(reverse("stripe-webhooks"), data=customer_subscription_updated, **header)
+        assert response.status_code == status.HTTP_200_OK
+        contribution.refresh_from_db()
+        assert contribution.payment_provider_data == customer_subscription_updated
+        assert contribution.provider_subscription_id == customer_subscription_updated["data"]["object"]["id"]
+        if payment_method_has_changed:
+            assert (
+                contribution.provider_payment_method_id
+                == customer_subscription_updated["data"]["object"]["default_payment_method"]
+            )
+
+    def test_when_contribution_not_found(self, monkeypatch, client, customer_subscription_updated):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        mock_log_exception = Mock()
+        monkeypatch.setattr("apps.contributions.views.logger.exception", mock_log_exception)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        assert not Contribution.objects.filter(
+            provider_subscription_id=customer_subscription_updated["data"]["object"]["id"]
+        ).exists()
+        response = client.post(reverse("stripe-webhooks"), data=customer_subscription_updated, **header)
+        assert response.status_code == status.HTTP_200_OK
+        mock_log_exception.assert_called_once_with("Could not find contribution matching provider_payment_id")
+
+
+@pytest.mark.django_db
+class TestCustomerSubscriptionDeleted:
+    @pytest.mark.parametrize("payment_method_has_changed", (True, False))
+    def test_when_contribution_found(
+        self, monkeypatch, client, customer_subscription_updated, payment_method_has_changed
+    ):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
+            contribution = ContributionFactory(
+                annual_subscription=True,
+                provider_subscription_id=customer_subscription_updated["data"]["object"]["id"],
+            )
+            if payment_method_has_changed:
+                customer_subscription_updated["data"]["previous_attributes"] = {"default_payment_method": "something"}
+            response = client.post(reverse("stripe-webhooks"), data=customer_subscription_updated, **header)
+        assert response.status_code == status.HTTP_200_OK
+        contribution.refresh_from_db()
+        assert contribution.payment_provider_data == customer_subscription_updated
+        assert contribution.provider_subscription_id == customer_subscription_updated["data"]["object"]["id"]
+        if payment_method_has_changed:
+            assert (
+                contribution.provider_payment_method_id
+                == customer_subscription_updated["data"]["object"]["default_payment_method"]
+            )
+
+    def test_when_contribution_not_found(self, monkeypatch, client, customer_subscription_updated):
+        monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+        mock_log_exception = Mock()
+        monkeypatch.setattr("apps.contributions.views.logger.exception", mock_log_exception)
+        header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+        assert not Contribution.objects.filter(
+            provider_subscription_id=customer_subscription_updated["data"]["object"]["id"]
+        ).exists()
+        response = client.post(reverse("stripe-webhooks"), data=customer_subscription_updated, **header)
+        assert response.status_code == status.HTTP_200_OK
+        mock_log_exception.assert_called_once_with("Could not find contribution matching provider_payment_id")
+
+
+@pytest.mark.django_db
+def test_customer_subscription_untracked_event(client, customer_subscription_updated, monkeypatch):
+    mock_log_warning = Mock()
+    monkeypatch.setattr("apps.contributions.webhooks.logger.warning", mock_log_warning)
+    monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+    header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+    with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
+        ContributionFactory(
+            annual_subscription=True,
+            provider_subscription_id=customer_subscription_updated["data"]["object"]["id"],
+        )
+        customer_subscription_updated["type"] = "untracked-event"
+        response = client.post(reverse("stripe-webhooks"), data=customer_subscription_updated, **header)
+    assert response.status_code == status.HTTP_200_OK
+    mock_log_warning.assert_called_once_with(
+        "`StripeWebhookProcessor.process_subscription` called with unexpected event type: %s",
+        customer_subscription_updated["type"],
     )
-    @patch("apps.contributions.views.logger")
-    def test_webhook_view_invalid_contribution(self, mock_logger, *args):
-        self._create_contribution(payment_intent_id="abcd")
-        self._run_webhook_view_with_request()
-        self.assertEqual(
-            "Could not find contribution matching provider_payment_id", mock_logger.exception.call_args[0][0]
+
+
+@pytest.mark.django_db
+def test_payment_method_attached(client, monkeypatch, payment_method_attached):
+    monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
+    header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+    with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
+        contribution = ContributionFactory(
+            one_time=True,
+            provider_customer_id=payment_method_attached["data"]["object"]["customer"],
         )
-
-    def test_payment_intent_canceled_webhook(self):
-        payment_intent_id = "1234"
-        contribution = self._create_contribution(payment_intent_id=payment_intent_id)
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(event_type="payment_intent.canceled", intent_id=payment_intent_id)
-        )
-        processor.process()
-        contribution.refresh_from_db()
-        self.assertEqual(contribution.status, ContributionStatus.CANCELED)
-
-    def test_payment_intent_fraudulent(self):
-        payment_intent_id = "1234"
-        contribution = self._create_contribution(payment_intent_id=payment_intent_id)
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(
-                event_type="payment_intent.canceled", intent_id=payment_intent_id, cancellation_reason="fraudulent"
-            )
-        )
-        processor.process()
-        contribution.refresh_from_db()
-        self.assertEqual(contribution.status, ContributionStatus.REJECTED)
-
-    def test_payment_intent_payment_failed_webhook(self):
-        payment_intent_id = "1234"
-        contribution = self._create_contribution(payment_intent_id=payment_intent_id)
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(event_type="payment_intent.payment_failed", intent_id=payment_intent_id)
-        )
-        processor.process()
-        contribution.refresh_from_db()
-        self.assertEqual(contribution.status, ContributionStatus.FAILED)
-
-    @patch("apps.slack.slack_manager.SlackManager.publish_contribution")
-    def test_payment_intent_succeeded_webhook(self, mock_publish_contribution):
-        payment_intent_id = "1234"
-        contribution = self._create_contribution(payment_intent_id=payment_intent_id)
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(event_type="payment_intent.succeeded", intent_id=payment_intent_id)
-        )
-        processor.process()
-        contribution.refresh_from_db()
-        self.assertEqual(contribution.status, ContributionStatus.PAID)
-        mock_publish_contribution.assert_called_once()
-
-    def test_webhook_with_invalid_contribution_payment_intent_id(self):
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(event_type="payment_intent.succeeded", intent_id="no-id-like-this-exists")
-        )
-        self.assertRaises(Contribution.DoesNotExist, processor.process)
-
-    @patch("apps.contributions.webhooks.logger")
-    def test_unknown_event_logs_helpful_message(self, mock_logger):
-        payment_intent_id = "abcd"
-        self._create_contribution(payment_intent_id=payment_intent_id)
-        fake_event_object = "criminal_activiy"
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(object_type=fake_event_object, intent_id=payment_intent_id)
-        )
-        processor.process()
-        self.assertIn("Received un-handled Stripe object of type", mock_logger.warning.call_args[0][0])
-        self.assertEqual(mock_logger.warning.call_args[0][1], fake_event_object)
-
-    @patch("apps.contributions.webhooks.settings.STRIPE_LIVE_MODE", True)
-    @patch("apps.contributions.webhooks.logger")
-    @patch("apps.contributions.webhooks.StripeWebhookProcessor.process_payment_intent")
-    @patch("apps.contributions.webhooks.StripeWebhookProcessor.process_subscription")
-    def test_will_not_process_test_event_in_live_mode(self, mock_process_pi, mock_process_sub, mock_logger):
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(object_type="unimportant", intent_id="ignore", livemode=False)
-        )
-        processor.process()
-        assert "ignoring" in mock_logger.info.call_args[0][0]
-        assert not mock_process_pi.called
-        assert not mock_process_sub.called
-
-    @patch("apps.contributions.webhooks.logger")
-    @patch("apps.contributions.webhooks.StripeWebhookProcessor.process_payment_intent")
-    @patch("apps.contributions.webhooks.StripeWebhookProcessor.process_subscription")
-    def test_will_not_process_live_event_in_test_mode(self, mock_process_pi, mock_process_sub, mock_logger):
-        processor = StripeWebhookProcessor(
-            MockPaymentIntentEvent(object_type="payment_intent.succeeded", intent_id="ignore", livemode=True)
-        )
-        processor.process()
-        assert "ignoring" in mock_logger.info.call_args[0][0]
-        assert not mock_process_pi.called
-        assert not mock_process_sub.called
+        response = client.post(reverse("stripe-webhooks"), data=payment_method_attached, **header)
+    assert response.status_code == status.HTTP_200_OK
+    contribution.refresh_from_db()
+    assert contribution.provider_payment_method_id == payment_method_attached["data"]["object"]["id"]
 
 
-class CustomerSubscriptionWebhooksTest(APITestCase):
-    def _create_contribution(self, provider_subscription_id=None, **kwargs):
-        org = OrganizationFactory()
-        payment_provider = PaymentProviderFactory(stripe_account_id="test")
-        revenue_program = RevenueProgramFactory(payment_provider=payment_provider, organization=org)
-        return Contribution.objects.create(
-            provider_subscription_id=provider_subscription_id,
-            amount=1000,
-            status=ContributionStatus.PROCESSING,
-            donation_page=DonationPageFactory(revenue_program=revenue_program),
-            **kwargs,
-        )
-
-    @patch("apps.contributions.webhooks.StripeWebhookProcessor.process_subscription")
-    def test_process_subscription_handles_event(self, mock_process_subscription):
-        processor = StripeWebhookProcessor(MockSubscriptionEvent(event_type="customer.subscription.updated"))
-        processor.process()
-        mock_process_subscription.assert_called_once()
-
-    @patch("apps.contributions.webhooks.StripeWebhookProcessor.handle_subscription_updated")
-    def test_handle_subscription_updated_handles_event(self, mock_handle_subscription_updated):
-        processor = StripeWebhookProcessor(MockSubscriptionEvent(event_type="customer.subscription.updated"))
-        processor.process()
-        mock_handle_subscription_updated.assert_called_once()
-
-    @patch("apps.contributions.webhooks.StripeWebhookProcessor.handle_subscription_canceled")
-    def test_handle_subscription_canceled_handles_event(self, mock_handle_subscription_canceled):
-        processor = StripeWebhookProcessor(MockSubscriptionEvent(event_type="customer.subscription.deleted"))
-        processor.process()
-        mock_handle_subscription_canceled.assert_called_once()
-
-    @patch("stripe.PaymentMethod.retrieve", side_effect="{}")
-    def test_updated_subscription_gets_updated(self, mock_fetch_pm):
-        provider_subscription_id = "1234"
-        previous_payment_method_id = "testing-previous-pm-id"
-        new_payment_method = "testing-new-pm-id"
-        contribution = self._create_contribution(
-            provider_subscription_id=provider_subscription_id, provider_payment_method_id=previous_payment_method_id
-        )
-        processor = StripeWebhookProcessor(
-            MockSubscriptionEvent(
-                event_type="customer.subscription.updated",
-                subscription_id=provider_subscription_id,
-                new_payment_method=new_payment_method,
-                previous_attributes={"default_payment_method": previous_payment_method_id},
-            )
-        )
-        processor.process()
-        mock_fetch_pm.assert_called()
-        contribution.refresh_from_db()
-        self.assertEqual(contribution.provider_payment_method_id, new_payment_method)
-
-    @patch("stripe.PaymentMethod.retrieve", side_effect="{}")
-    def test_canceled_subscription_gets_updated(self, mock_fetch_pm):
-        subscription_id = "1234"
-        contribution = self._create_contribution(provider_subscription_id=subscription_id)
-        self.assertNotEqual(contribution.status, ContributionStatus.CANCELED)
-        processor = StripeWebhookProcessor(
-            MockSubscriptionEvent(event_type="customer.subscription.deleted", subscription_id=subscription_id)
-        )
-        processor.process()
-        mock_fetch_pm.assert_not_called()
-        contribution.refresh_from_db()
-        self.assertEqual(contribution.status, ContributionStatus.CANCELED)
+@pytest.mark.django_db
+def test_stripe_webhooks_endpoint_when_invalid_signature(client):
+    header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
+    response = client.post(reverse("stripe-webhooks"), data={}, **header)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["error"] == "Invalid signature"
 
 
 @pytest.mark.django_db()
@@ -312,26 +284,21 @@ class CustomerSubscriptionWebhooksTest(APITestCase):
         (ContributionInterval.YEARLY, True),
     ),
 )
-def test_invoice_updated_webhook(
-    interval,
-    expect_reminder_email,
-    client,
-    monkeypatch,
-):
+def test_invoice_updated_webhook(interval, expect_reminder_email, client, monkeypatch, invoice_upcoming):
     mock_send_reminder = Mock()
     monkeypatch.setattr(Contribution, "send_recurring_contribution_email_reminder", mock_send_reminder)
     monkeypatch.setattr(WebhookSignature, "verify_header", lambda *args, **kwargs: True)
-    with open("apps/contributions/tests/fixtures/stripe-invoice-upcoming.json") as fl:
-        data = json.load(fl)
     # TODO: DEV-3026
     with patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None):
-        ContributionFactory(interval=interval, provider_subscription_id=data["data"]["object"]["subscription"])
+        ContributionFactory(
+            interval=interval, provider_subscription_id=invoice_upcoming["data"]["object"]["subscription"]
+        )
     header = {"HTTP_STRIPE_SIGNATURE": "testing", "content_type": "application/json"}
-    response = client.post(reverse("stripe-webhooks"), data=data, **header)
+    response = client.post(reverse("stripe-webhooks"), data=invoice_upcoming, **header)
     assert response.status_code == status.HTTP_200_OK
     if expect_reminder_email:
         mock_send_reminder.assert_called_once_with(
-            make_aware(datetime.fromtimestamp(data["data"]["object"]["next_payment_attempt"])).date()
+            make_aware(datetime.fromtimestamp(invoice_upcoming["data"]["object"]["next_payment_attempt"])).date()
         )
     else:
         mock_send_reminder.assert_not_called()

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -97,17 +97,12 @@ class StripeWebhookProcessor:
     def handle_payment_intent_succeeded(self):
         contribution = self.get_contribution_from_event()
         contribution.payment_provider_data = self.event
-        contribution.provider_payment_id = self.event.charges[0].payment_method
+        contribution.provider_payment_id = self.obj_data["id"]
+        contribution.provider_payment_method_id = self.obj_data.get("payment_method")
         contribution.last_payment_date = datetime.datetime.fromtimestamp(
             self.obj_data["created"], tz=datetime.timezone.utc
         )
         contribution.status = ContributionStatus.PAID
-
-        # Grab the payment_intent id from the event and store it as provider_payment_id
-        contribution.provider_payment_id = self.obj_data["id"]
-        # Grab payment_method_id
-        contribution.provider_payment_method_id = self.obj_data.get("payment_method")
-
         contribution.save()
         logger.info("Contribution %s succeeded.", contribution)
 
@@ -130,9 +125,8 @@ class StripeWebhookProcessor:
         It looks like Stripe gives us event.data.previous_attributes, which is a dict of updated attributes previous values.
         """
         contribution = self.get_contribution_from_event()
-        contribution.payment_provider_data = self.obj_data
+        contribution.payment_provider_data = self.event
         contribution.provider_subscription_id = self.obj_data["id"]
-        contribution.provider_payment_method_id = self.obj_data[""]
 
         if "default_payment_method" in self.event.data["previous_attributes"]:
             # If stripe reports 'default_payment_method' as a previous attribute, then we've updated 'default_payment_method'
@@ -147,12 +141,11 @@ class StripeWebhookProcessor:
         """
         logger.info("Contribution canceled event")
         contribution = self.get_contribution_from_event()
-        contribution.payment_provider_data = self.obj_data
+        contribution.payment_provider_data = self.event
         contribution.status = ContributionStatus.CANCELED
         contribution.save()
 
     def process_payment_method(self):
-        """ """
         logger.info("`process_payment_method` called")
         if self.event.type == "payment_method.attached":
             contribution = Contribution.objects.get(provider_customer_id=self.obj_data["customer"])


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)


The two branches for this PR were created after already having made commits within the parent branch DEV-2342.  In merging upstream changes from main, there were merge conflicts and then broken tests that required touching otherwise untouched webhook tests.  The pre-existing webhook tests did not use fixtures from Stripe and they were (to my mind) hard to reason about. 

With that in mind, I solved for the broken tests by pivoting to using fixtures and relying on Pytest over unittest.

After committing these changes, I had the late realization that these were substantive enough to warrant review, hence this PR.

If changes are not required for this PR, then there is no further action item. If changes are required, I'll make them in the incoming branch for this PR, and then once conversations have settled, I can port those changes to DEV-2342 

#### What's this PR do?

See important context above and JIRA ticket. 

- Start using fixtures for Stripe webhook receiver tests
- Start using pytest instead of unittest.testcase


#### Why are we doing this? How does it help us?

It's part of shipping DEV-2342.

#### How should this be manually tested? Please include detailed step-by-step instructions.


Python tests pass in CI.


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?


N/A


#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-3114](https://news-revenue-hub.atlassian.net/browse/DEV-3114)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

Described at top of PR description.

[DEV-3114]: https://news-revenue-hub.atlassian.net/browse/DEV-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ