### PR TITLE
DEV-2867: Add useEditablePageBatch

### DIFF
--- a/spa/.storybook/preview.js
+++ b/spa/.storybook/preview.js
@@ -1,10 +1,9 @@
 import { withThemes } from '@react-theming/storybook-addon';
 import { ThemeProvider as MuiThemeProvider } from '@material-ui/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ThemeProvider } from 'styled-components';
-import { Provider as AlertProvider } from 'react-alert';
 import { SnackbarProvider } from 'notistack';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Provider as AlertProvider } from 'react-alert';
+import { ThemeProvider } from 'styled-components';
 
 import Alert, { alertOptions } from 'elements/alert/Alert';
 import { revEngineTheme, muiThemeOverrides } from 'styles/themes';

--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -574,7 +574,7 @@ describe('Edit interface: Setup', () => {
     cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: orgAdminWithContentFlag });
     cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_STYLES) }, {});
     cy.intercept(
-      { method: 'GET', pathname: `${getEndpoint(DRAFT_PAGE_DETAIL)}**` },
+      { method: 'GET', pathname: `${getEndpoint(LIST_PAGES)}**` },
       {
         body: {
           ...livePage,
@@ -629,7 +629,7 @@ describe('Edit interface: Setup', () => {
     cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: orgAdminWithContentFlag });
     cy.intercept({ method: 'GET', pathname: getEndpoint(LIST_STYLES) }, {});
     cy.intercept(
-      { method: 'GET', pathname: `${getEndpoint(DRAFT_PAGE_DETAIL)}**` },
+      { method: 'GET', pathname: `${getEndpoint(LIST_PAGES)}**` },
       {
         body: {
           ...livePage,

--- a/spa/src/components/base/ImageUpload/__mocks__/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/__mocks__/ImageUpload.tsx
@@ -1,0 +1,16 @@
+import { ImageUploadProps } from '../ImageUpload';
+
+const mockFile = new File([new Blob(['mock-file'], { type: 'image/png' })], 'mock-file.png');
+
+export const ImageUpload = (props: ImageUploadProps) => (
+  <button
+    data-testid="mock-image-upload"
+    data-thumbnail-url={props.thumbnailUrl}
+    data-value={props.value}
+    onClick={() => props.onChange(mockFile, 'mock-thumbnail-url')}
+  >
+    {props.label}
+  </button>
+);
+
+export default ImageUpload;

--- a/spa/src/components/donationPage/pageContent/DAmount.test.tsx
+++ b/spa/src/components/donationPage/pageContent/DAmount.test.tsx
@@ -16,7 +16,7 @@ const defaultPage = {
   payment_provider: {
     stripe_account_id: 'mock-stripe-account-id'
   }
-};
+} as any;
 
 const defaultOptions = { [CONTRIBUTION_INTERVALS.ONE_TIME]: [1, 2, 3] };
 

--- a/spa/src/components/donationPage/pageContent/DAmount.tsx
+++ b/spa/src/components/donationPage/pageContent/DAmount.tsx
@@ -57,7 +57,17 @@ function DAmount({ element, ...props }: DAmountProps) {
   // Display the fees control here if a DPayment element elsewhere asks for it.
 
   const displayPayFeesControl = useMemo(() => {
-    return (page.elements.find(({ type }) => type === 'DPayment') ?? {})?.content?.offerPayFees;
+    if (!page.elements) {
+      return false;
+    }
+
+    const paymentElement = page.elements.find(({ type }) => type === 'DPayment');
+
+    if (!paymentElement) {
+      return false;
+    }
+
+    return (paymentElement.content as { offerPayFees?: boolean }).offerPayFees;
   }, [page.elements]);
 
   // Find amount options for the page's frequency, and whether any should be

--- a/spa/src/components/pageEditor/PageEditor.js
+++ b/spa/src/components/pageEditor/PageEditor.js
@@ -3,7 +3,6 @@ import { useHistory } from 'react-router-dom';
 import * as S from './PageEditor.styled';
 import { useTheme } from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
-import urlJoin from 'url-join';
 
 // Deps
 import { useAlert } from 'react-alert';
@@ -84,7 +83,7 @@ function PageEditor() {
   const [availableStyles, setAvailableStyles] = useState([]);
   const requestGetPageStyles = useRequest();
   const history = useHistory();
-  useWebFonts(page?.styles?.font);
+  useWebFonts(updatedPagePreview?.styles?.font);
 
   useConfigureAnalytics();
 
@@ -115,16 +114,16 @@ function PageEditor() {
 
   const pageTitle = useMemo(
     () =>
-      `Edit | ${page?.name ? `${page?.name} | ` : ''}${
-        page?.revenue_program?.name ? `${page?.revenue_program?.name}` : ''
+      `Edit | ${updatedPagePreview?.name ? `${updatedPagePreview?.name} | ` : ''}${
+        updatedPagePreview?.revenue_program?.name ? `${updatedPagePreview?.revenue_program?.name}` : ''
       }`,
-    [page?.name, page?.revenue_program?.name]
+    [updatedPagePreview?.name, updatedPagePreview?.revenue_program?.name]
   );
 
   // Load available styles.
 
   useEffect(() => {
-    const rpId = page?.revenue_program?.id;
+    const rpId = updatedPagePreview?.revenue_program?.id;
 
     // If the revenue program of the page is either available after loading or
     // has changed, load styles associated with the RP.
@@ -144,7 +143,7 @@ function PageEditor() {
         }
       );
     }
-  }, [page, requestGetPageStyles]);
+  }, [requestGetPageStyles, updatedPagePreview?.revenue_program?.id]);
 
   // Event handlers.
 
@@ -184,7 +183,7 @@ function PageEditor() {
     async function finishSave() {
       try {
         if (CAPTURE_PAGE_SCREENSHOT) {
-          await savePageChanges({}, page.name, document.getElementById('root'));
+          await savePageChanges({}, updatedPagePreview.name, document.getElementById('root'));
         } else {
           await savePageChanges();
         }
@@ -214,7 +213,7 @@ function PageEditor() {
 
     if (elementErrors?.length > 0) {
       setElementErrors(elementErrors);
-    } else if (pageIsPublished(page)) {
+    } else if (pageIsPublished(updatedPagePreview)) {
       getUserConfirmation("You're making changes to a live contribution page. Continue?", finishSave);
     } else {
       finishSave();
@@ -241,10 +240,10 @@ function PageEditor() {
               <EditInterface />
             </AnimatePresence>
           )}
-          {!isLoading && !stylesLoading && page && (
-            <SegregatedStyles page={page}>
+          {!isLoading && !stylesLoading && updatedPagePreview && (
+            <SegregatedStyles page={updatedPagePreview}>
               {/* set stringified page as key to guarantee that ALL page changes will re-render the page in edit mode */}
-              <DonationPage key={page ? JSON.stringify(page) : ''} live={false} page={updatedPagePreview} />
+              <DonationPage key={JSON.stringify(updatedPagePreview ?? '')} live={false} page={updatedPagePreview} />
             </SegregatedStyles>
           )}
 

--- a/spa/src/components/pageEditor/editInterface/EditInterface.js
+++ b/spa/src/components/pageEditor/editInterface/EditInterface.js
@@ -76,32 +76,33 @@ function EditInterface() {
   }, [errors, setTabFromErrors, setSelectedButton, showEditInterface]);
 
   /**
-   * setPageContent performs updates necessary to affect a change made in
-   * the edit interface.
+   * Sets the elements in the main page content.
    */
-  const setPageContent = (content = {}) => {
-    setPageChanges((existing) => ({ ...existing, ...content }));
-  };
-
   const setElements = (elements) => {
-    setPageContent({ elements });
+    setPageChanges({ elements });
   };
 
+  /**
+   * Sets the elements in the sidebar.
+   */
   const setSidebarElements = (sidebar_elements) => {
-    setPageContent({ sidebar_elements });
+    setPageChanges({ sidebar_elements });
   };
 
+  /**
+   * Removes an element from either the main page content or the sidebar.
+   */
   const handleRemoveElement = (element, elementsType) => {
     if (!dynamicElements[element.type]?.required) {
     }
     if (elementsType === 'layout') {
       const elementsWithout = page?.elements?.filter((el) => el.uuid !== element.uuid);
-      setPageContent({ elements: elementsWithout });
+      setPageChanges({ elements: elementsWithout });
     }
 
     if (elementsType === 'sidebar') {
       const elementsWithout = page?.sidebar_elements?.filter((el) => el.uuid !== element.uuid);
-      setPageContent({ sidebar_elements: elementsWithout });
+      setPageChanges({ sidebar_elements: elementsWithout });
     }
   };
 
@@ -125,7 +126,6 @@ function EditInterface() {
         setElementContent,
         elementRequiredFields,
         setElementRequiredFields,
-        setPageContent,
         handleRemoveElement
       }}
     >

--- a/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.test.js
+++ b/spa/src/components/pageEditor/editInterface/pageSetup/PageSetup.test.js
@@ -1,47 +1,180 @@
-import { render, screen } from 'test-utils';
-import { EditInterfaceContext } from '../EditInterface';
+import { fireEvent, render, screen } from 'test-utils';
 import PageSetup from './PageSetup';
+import { useEditablePageBatch } from 'hooks/useEditablePageBatch';
+import { axe } from 'jest-axe';
 import { PageEditorContext } from 'components/pageEditor/PageEditor';
-import { EditablePageContext } from 'hooks/useEditablePage';
+import userEvent from '@testing-library/user-event';
 
-// This component uses URL.revokeObjectURL() which jsdom doesn't seem to
-// support.
-jest.mock('elements/inputs/ImageWithPreview', () => () => null);
+jest.mock('components/base/ImageUpload/ImageUpload');
+jest.mock('hooks/useEditablePageBatch');
 
-function tree(page) {
+const page = {
+  header_link: 'mock-header-link',
+  header_logo_thumbnail: 'mock-header-logo-thumbnail',
+  heading: 'mock-heading',
+  plan: { custom_thank_you_page_enabled: true, label: 'free' },
+  post_thank_you_redirect: 'mock-post-thank-you-redirect',
+  label: 'Free',
+  thank_you_redirect: 'mock-thank-you-redirect'
+};
+
+function tree() {
   return render(
-    <EditInterfaceContext.Provider value={{ setPageContent: jest.fn() }}>
-      <EditablePageContext.Provider
-        value={{
-          page: {
-            header_link: 'mock-header-link',
-            heading: 'mock-heading',
-            plan: { label: 'free' },
-            post_thank_you_redirect: 'mock-post-thank-you-redirect',
-            label: 'Free',
-            thank_you_redirect: 'mock-thank-you-redirect',
-            ...page
-          }
-        }}
-      >
-        <PageEditorContext.Provider
-          value={{
-            errors: []
-          }}
-        >
-          <PageSetup />
-        </PageEditorContext.Provider>
-      </EditablePageContext.Provider>
-    </EditInterfaceContext.Provider>
+    <PageEditorContext.Provider value={{ errors: {} }}>
+      <PageSetup />
+    </PageEditorContext.Provider>
   );
 }
 
-it('should disable thank you page URL input and have tooltip if not enabled by plan', () => {
-  tree({ plan: { custom_thank_you_page_enabled: false, label: 'free' } });
-  expect(screen.queryByLabelText('Thank You page link')).not.toBeInTheDocument();
-});
+describe('PageSetup', () => {
+  const useEditablePageBatchMock = useEditablePageBatch; // as jest.Mock;
 
-it('should not disable thank you page URL when feature enabled by plan', () => {
-  tree({ plan: { custom_thank_you_page_enabled: true, label: 'free' } });
-  expect(screen.getByLabelText('Thank You page link')).toBeInTheDocument();
+  function mockBatch(props) {
+    useEditablePageBatchMock.mockReturnValue({
+      addBatchChange: jest.fn(),
+      batchHasChanges: true,
+      batchPreview: page,
+      commitBatch: jest.fn(),
+      resetBatch: jest.fn(),
+      ...props
+    });
+  }
+
+  beforeEach(() => mockBatch({}));
+
+  it('displays nothing if the batch preview is undefined', () => {
+    mockBatch({ batchPreview: undefined });
+    tree();
+    expect(document.body.textContent).toBe('');
+  });
+
+  it('displays header text', () => {
+    tree();
+    expect(screen.getByText('Configure page settings here. These settings are page specific.')).toBeVisible();
+  });
+
+  describe.each([
+    ['Main header background', 'header_bg_image'],
+    ['Main header logo', 'header_logo'],
+    ['Graphic', 'graphic']
+  ])('%s', (label, fieldName) => {
+    it('displays the image and thumbnail URL as set in the batch preview', () => {
+      mockBatch({
+        batchPreview: {
+          ...page,
+          [fieldName]: `test-${fieldName}`,
+          [`${fieldName}_thumbnail`]: `test-${fieldName}-image-thumbnail`
+        }
+      });
+      tree();
+
+      const input = screen.getByText(label);
+
+      expect(input).toBeVisible();
+      expect(input.dataset.value).toBe(`test-${fieldName}`);
+      expect(input.dataset.thumbnailUrl).toBe(`test-${fieldName}-image-thumbnail`);
+    });
+
+    it('updates the edit batch when the user makes a change', () => {
+      const addBatchChange = jest.fn();
+
+      mockBatch({ addBatchChange });
+      tree();
+      expect(addBatchChange).not.toBeCalled();
+      userEvent.click(screen.getByText(label));
+      expect(addBatchChange.mock.calls).toEqual([
+        [
+          {
+            [fieldName]: expect.any(File),
+            [`${fieldName}_thumbnail`]: 'mock-thumbnail-url'
+          }
+        ]
+      ]);
+    });
+  });
+
+  describe.each([
+    ['Logo link', 'header_link'],
+    ['Form panel heading', 'heading'],
+    ['Thank You page link', 'thank_you_redirect'],
+    ['Post Thank You redirect', 'post_thank_you_redirect']
+  ])('%s', (label, fieldName) => {
+    it('displays the field value as set in the batch preview', () => {
+      mockBatch({
+        batchPreview: {
+          ...page,
+          [fieldName]: `test-${fieldName}`
+        }
+      });
+      tree();
+
+      const input = screen.getByLabelText(label);
+
+      expect(input).toBeVisible();
+      expect(input).toHaveValue(`test-${fieldName}`);
+    });
+
+    it('updates the edit batch when the user makes a change', () => {
+      const addBatchChange = jest.fn();
+
+      mockBatch({ addBatchChange });
+      tree();
+      expect(addBatchChange).not.toBeCalled();
+
+      // This is a change event, not userEvent.type(), because we aren't using the real
+      // useEditablePageBatch which would cause data to update.
+
+      fireEvent.change(screen.getByLabelText(label), { target: { value: `test-${fieldName}` } });
+      expect(addBatchChange.mock.calls).toEqual([[{ [fieldName]: `test-${fieldName}` }]]);
+    });
+  });
+
+  it('commits the edit batch when the Update button is clicked', () => {
+    const commitBatch = jest.fn();
+
+    mockBatch({ commitBatch });
+    tree();
+    expect(commitBatch).not.toBeCalled();
+    fireEvent.click(screen.getByText('Update'));
+    expect(commitBatch).toBeCalledTimes(1);
+  });
+
+  it('resets the edit batch when the Undo button is clicked', () => {
+    const resetBatch = jest.fn();
+
+    mockBatch({ resetBatch });
+    tree();
+    expect(resetBatch).not.toBeCalled();
+    fireEvent.click(screen.getByText('Undo'));
+    expect(resetBatch).toBeCalledTimes(1);
+  });
+
+  it('enables the Undo button if there are changes to commit', () => {
+    mockBatch({ batchHasChanges: true });
+    tree();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeEnabled();
+  });
+
+  it('disables the Undo button if there are no changes to commit', () => {
+    mockBatch({ batchHasChanges: false });
+    tree();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+  });
+
+  it('hides the thank you page URL field if disabled by plan', () => {
+    mockBatch({ batchPreview: { ...page, plan: { custom_thank_you_page_enabled: false, label: 'free' } } });
+    tree();
+    expect(screen.queryByLabelText('Thank You page link')).not.toBeInTheDocument();
+  });
+
+  it('shows the thank you page URL field if enabled by plan', () => {
+    tree({ batchPreview: { ...page, plan: { custom_thank_you_page_enabled: true, label: 'free' } } });
+    expect(screen.getByLabelText('Thank You page link')).toBeInTheDocument();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
 });

--- a/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.tsx
+++ b/spa/src/components/pageEditor/editInterface/pageStyles/PageStyles.tsx
@@ -1,10 +1,7 @@
-import { useState } from 'react';
 import { Controls, Root } from './PageStyles.styled';
 
 // Context
 import { usePageEditorContext } from 'components/pageEditor/PageEditor';
-import { useEditInterfaceContext } from 'components/pageEditor/editInterface/EditInterface';
-import { useEditablePageContext } from 'hooks/useEditablePage';
 
 // Children
 import useModal from 'hooks/useModal';
@@ -12,32 +9,26 @@ import StylesChooser from 'components/pageEditor/editInterface/pageStyles/Styles
 import AddStylesModal from 'components/pageEditor/editInterface/pageStyles/AddStylesModal';
 import EditSaveControls from '../EditSaveControls';
 import EditTabHeader from '../EditTabHeader';
+import { useEditablePageBatch } from 'hooks/useEditablePageBatch';
+import { Style } from 'hooks/useStyleList';
 
-function PageStyles({ backToProperties }) {
-  const { page } = useEditablePageContext();
+function PageStyles() {
+  const { addBatchChange, batchHasChanges, batchPreview, commitBatch, resetBatch } = useEditablePageBatch();
   const { availableStyles, setAvailableStyles } = usePageEditorContext();
-  const { setPageContent } = useEditInterfaceContext();
   const {
     open: addStylesModalOpen,
     handleClose: handleAddStylesModalClose,
     handleOpen: handleAddStylesModalOpen
   } = useModal(false);
 
-  // Styles state
-  const [styles, setStyles] = useState(page.styles);
-
-  const handleKeepChanges = () => {
-    setPageContent({ styles });
-  };
-
-  const handleDiscardChanges = () => {
-    setStyles(page.styles);
-  };
-
-  const handleAddNewStyles = (newStyles) => {
+  const handleAddNewStyles = (newStyles: Style) => {
     setAvailableStyles([newStyles, ...availableStyles]);
-    setStyles(newStyles);
+    addBatchChange({ styles: newStyles });
   };
+
+  if (!batchPreview) {
+    return null;
+  }
 
   return (
     <Root>
@@ -47,14 +38,13 @@ function PageStyles({ backToProperties }) {
         prompt="Add or create a new style to customize your page."
       />
       <Controls>
-        <StylesChooser styles={availableStyles} selected={styles} setSelected={setStyles} />
+        <StylesChooser
+          styles={availableStyles}
+          selected={batchPreview.styles}
+          setSelected={(styles: Style) => addBatchChange({ styles })}
+        />
       </Controls>
-      <EditSaveControls
-        cancelDisabled={styles === page.styles}
-        onCancel={handleDiscardChanges}
-        onUpdate={handleKeepChanges}
-        variant="undo"
-      />
+      <EditSaveControls cancelDisabled={!batchHasChanges} onCancel={resetBatch} onUpdate={commitBatch} variant="undo" />
       <AddStylesModal
         isOpen={addStylesModalOpen}
         closeModal={handleAddStylesModalClose}

--- a/spa/src/hooks/useContributionPage/pageUpdateToFormData.test.ts
+++ b/spa/src/hooks/useContributionPage/pageUpdateToFormData.test.ts
@@ -111,6 +111,21 @@ describe('pageUpdateToFormData', () => {
     expect(formDataToObject(result)).toEqual(changes);
   });
 
+  it('coerces undefined image field values to empty strings', async () => {
+    const changes = {
+      graphic: undefined,
+      header_bg_image: undefined,
+      header_logo: undefined
+    };
+    const result = await pageUpdateToFormData(changes);
+
+    expect(formDataToObject(result)).toEqual({
+      graphic: '',
+      header_bg_image: '',
+      header_logo: ''
+    });
+  });
+
   it('converts date fields to string timestamps', async () => {
     // This functionality may not be needed--as we adopt TypeScript more, we can
     // force fields to be strings. For now we cast the object as any to reflect

--- a/spa/src/hooks/useContributionPage/pageUpdateToFormData.ts
+++ b/spa/src/hooks/useContributionPage/pageUpdateToFormData.ts
@@ -38,18 +38,23 @@ export async function pageUpdateToFormData(
       return result;
     }
 
-    // Ignore image fields that contain non-empty strings. These must have been
-    // given to us by the API after saving a page, and are URLs to uploaded
-    // files.
-    //
-    // An empty string tells the API to remove the image.
+    if (IMAGE_FIELDS.includes(key)) {
+      // Ignore image fields that contain non-empty strings. These must have been
+      // given to us by the API after saving a page, and are URLs to uploaded
+      // files.
+      //
+      // An empty string tells the API to remove the image.
 
-    if (
-      IMAGE_FIELDS.includes(key) &&
-      typeof pageUpdates[key] === 'string' &&
-      (pageUpdates[key] as string).length !== 0
-    ) {
-      return result;
+      if (typeof pageUpdates[key] === 'string' && (pageUpdates[key] as string).length !== 0) {
+        return result;
+      }
+
+      // An undefined value for an image should also mean "delete this image." We
+      // coerce these to empty strings for the update.
+
+      if (pageUpdates[key] === undefined) {
+        return { ...result, [key]: '' };
+      }
     }
 
     let value = pageUpdates[key];

--- a/spa/src/hooks/useEditablePageBatch.test.tsx
+++ b/spa/src/hooks/useEditablePageBatch.test.tsx
@@ -134,6 +134,7 @@ describe('useEditablePageBatch', () => {
 
       act(() => result.current.addBatchChange({ header_link: 'test' }));
       act(() => result.current.commitBatch());
+      expect(setPageChanges).toBeCalled();
       setPageChanges.mockClear();
       act(() => result.current.commitBatch());
       expect(setPageChanges).not.toBeCalled();

--- a/spa/src/hooks/useEditablePageBatch.test.tsx
+++ b/spa/src/hooks/useEditablePageBatch.test.tsx
@@ -1,0 +1,175 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { ReactNode } from 'react';
+import { EditablePageContext } from './useEditablePage';
+import { useEditablePageBatch } from './useEditablePageBatch';
+
+const setPageChanges = jest.fn();
+let updatedPagePreview: any;
+
+const TestEditablePageContextProvider = ({ children }: { children: ReactNode }) => {
+  return (
+    <EditablePageContext.Provider
+      value={{
+        setPageChanges,
+        deletePage: jest.fn(),
+        isError: false,
+        isLoading: false,
+        pageChanges: {},
+        updatedPagePreview: updatedPagePreview as any
+      }}
+    >
+      {children}
+    </EditablePageContext.Provider>
+  );
+};
+
+describe('useEditablePageBatch', () => {
+  const tree = () => renderHook(() => useEditablePageBatch(), { wrapper: TestEditablePageContextProvider });
+
+  beforeEach(() => {
+    updatedPagePreview = {
+      mockUpdatedPagePreview: true
+    };
+    setPageChanges.mockReset();
+  });
+
+  describe('addBatchChange', () => {
+    it('adds a change to the batch preview', () => {
+      const { result } = tree();
+
+      act(() => result.current.addBatchChange({ header_link: 'test' }));
+      expect(result.current.batchPreview).toEqual({ ...updatedPagePreview, header_link: 'test' });
+    });
+
+    it('overwrites previous changes in the batch preview', () => {
+      const { result } = tree();
+
+      act(() => {
+        result.current.addBatchChange({ header_link: 'test' });
+        result.current.addBatchChange({ header_link: 'test2' });
+      });
+      expect(result.current.batchPreview).toEqual({ ...updatedPagePreview, header_link: 'test2' });
+    });
+  });
+
+  describe('batchHasChanges', () => {
+    it('is false initially', () => {
+      const { result } = tree();
+
+      expect(result.current.batchHasChanges).toBe(false);
+    });
+
+    it('is true when addBatchChange() is called', () => {
+      const { result } = tree();
+
+      act(() => result.current.addBatchChange({ header_link: 'test' }));
+      expect(result.current.batchHasChanges).toBe(true);
+    });
+
+    it('is true when a batch change has an undefined value', () => {
+      const { result } = tree();
+
+      act(() => {
+        result.current.addBatchChange({ header_link: 'test' });
+        result.current.addBatchChange({ header_link: undefined });
+      });
+      expect(result.current.batchHasChanges).toBe(true);
+    });
+  });
+
+  describe('batchPreview', () => {
+    it('is undefined if the editable page preview is undefined', () => {
+      updatedPagePreview = undefined;
+
+      const { result } = tree();
+
+      expect(result.current.batchPreview).toBe(undefined);
+    });
+
+    it('is the editable page preview initially', () => {
+      const { result } = tree();
+
+      expect(result.current.batchPreview).toEqual(updatedPagePreview);
+    });
+  });
+
+  describe('commitBatch', () => {
+    // In the tests below, separate act() calls are needed so that commitBatch
+    // updates.
+
+    it('updates the editable page context', () => {
+      const { result } = tree();
+
+      act(() => result.current.addBatchChange({ header_link: 'test' }));
+      act(() => result.current.commitBatch());
+      expect(setPageChanges).toBeCalledTimes(1);
+
+      // The hook uses the functional setter so we have to call it.
+
+      expect(setPageChanges.mock.calls[0][0]({ existing: true })).toEqual({
+        existing: true,
+        header_link: 'test'
+      });
+    });
+
+    it('resets the batch preview', () => {
+      const { result } = tree();
+
+      act(() => result.current.addBatchChange({ header_link: 'test' }));
+      act(() => result.current.commitBatch());
+      expect(result.current.batchPreview).toEqual(updatedPagePreview);
+    });
+
+    it('causes batchHasChanges to be false', () => {
+      const { result } = tree();
+
+      act(() => result.current.addBatchChange({ header_link: 'test' }));
+      expect(result.current.batchHasChanges).toBe(true);
+      act(() => result.current.commitBatch());
+      expect(result.current.batchHasChanges).toBe(false);
+    });
+
+    it('does nothing if called again without any new changes made', () => {
+      const { result } = tree();
+
+      act(() => result.current.addBatchChange({ header_link: 'test' }));
+      act(() => result.current.commitBatch());
+      setPageChanges.mockClear();
+      act(() => result.current.commitBatch());
+      expect(setPageChanges).not.toBeCalled();
+    });
+  });
+
+  describe('resetBatch', () => {
+    it('resets the batch preview', () => {
+      const { result } = tree();
+
+      act(() => {
+        result.current.addBatchChange({ header_link: 'test' });
+        result.current.resetBatch();
+      });
+      expect(result.current.batchPreview).toEqual(updatedPagePreview);
+    });
+
+    it('causes batchHasChanges to be false', () => {
+      const { result } = tree();
+
+      act(() => {
+        result.current.addBatchChange({ header_link: 'test' });
+        result.current.resetBatch();
+      });
+      expect(result.current.batchHasChanges).toBe(false);
+    });
+
+    it('causes commitBatch to do nothing if called after it', () => {
+      const { result } = tree();
+
+      act(() => {
+        result.current.addBatchChange({ header_link: 'test' });
+        result.current.resetBatch();
+        result.current.commitBatch();
+      });
+      expect(setPageChanges).not.toBeCalled();
+    });
+  });
+});

--- a/spa/src/hooks/useEditablePageBatch.ts
+++ b/spa/src/hooks/useEditablePageBatch.ts
@@ -1,0 +1,72 @@
+import { useCallback, useMemo, useState } from 'react';
+import { ContributionPage } from './useContributionPage/useContributionPage.types';
+import { useEditablePageContext } from './useEditablePage';
+
+export interface UseEditablePageBatchResult {
+  /**
+   * Adds a change to the batch. This overrides previous values set in the
+   * batch. i.e. addBatchChange({ name: 'foo' }), then addBatchChange({ name:
+   * 'bar' }), will result ultimately in changing name to 'bar'.
+   */
+  addBatchChange: (changes: Partial<ContributionPage>) => void;
+  /**
+   * Are there actually changes in the batch?
+   */
+  batchHasChanges: boolean;
+  /**
+   * A preview of the page object if commit() was called. This is undefined if
+   * `updatedPagePreview` in the editable page context is undefined, e.g. while
+   * the underlying page is being loaded from the API.
+   */
+  batchPreview?: ContributionPage;
+  /**
+   * Commits changes to the editable page context and resets changes in the
+   * batch. This updates `pageChanges` only. It doesn not save changes to the
+   * API.
+   */
+  commitBatch: () => void;
+  /**
+   * Removes all changes in this batch.
+   */
+  resetBatch: () => void;
+}
+
+/**
+ * This hook allows storing a set of pending changes to a contribution page
+ * which can either be committed or discarded. Each invocation of this hook owns
+ * a separate set of changes.
+ */
+export function useEditablePageBatch(): UseEditablePageBatchResult {
+  const { setPageChanges, updatedPagePreview } = useEditablePageContext();
+  const [batchChanges, setBatchChanges] = useState<Partial<ContributionPage>>({});
+  const addBatchChange = useCallback(
+    (value: Partial<ContributionPage>) => setBatchChanges((existing) => ({ ...existing, ...value })),
+    []
+  );
+  const batchPreview = useMemo(() => {
+    if (!updatedPagePreview) {
+      return undefined;
+    }
+
+    return { ...updatedPagePreview, ...batchChanges };
+  }, [batchChanges, updatedPagePreview]);
+  const commitBatch = useCallback(() => {
+    // Don't do anything if there's nothing to commit.
+
+    if (Object.keys(batchChanges).length === 0) {
+      return;
+    }
+
+    setPageChanges((value) => ({ ...value, ...batchChanges }));
+    setBatchChanges({});
+  }, [batchChanges, setPageChanges]);
+  const resetBatch = useCallback(() => setBatchChanges({}), []);
+
+  return {
+    addBatchChange,
+    batchHasChanges: !!updatedPagePreview && Object.keys(batchChanges).length > 0,
+    batchPreview,
+    commitBatch,
+    resetBatch
+  };
+}


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

1. https://github.com/newsrevenuehub/rev-engine/pull/843
2. https://github.com/newsrevenuehub/rev-engine/pull/882 
3. https://github.com/newsrevenuehub/rev-engine/pull/938
4. https://github.com/newsrevenuehub/rev-engine/pull/955 (this PR)
5. 🏁 

#### What's this PR do?

- Adds a new hook, useEditablePageBatch. The idea of the hook is that it manages a local set of page changes that can either be committed (set in the shared context) or reset (discarded).
- Refactored the Setup and Style tabs in the page editor to use this hook. The Layout and Sidebar tabs don't have changes because they don't have the same Undo/Update buttons.
- Adds comprehensive Jest coverage of the Setup tab. I didn't do this for Style because we're going to get rid of the tab in the near future.
 
#### Why are we doing this? How does it help us?

Improves testability, moves data logic out of components into a hook where it can be tested easier.

#### How should this be manually tested? Please include detailed step-by-step instructions.

We'll do QA on the feature branch as with other stacked PRs.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

See note about why there aren't tests for the Style tab.

I didn't migrate PageSetup to TypeScript (yet) because it is using some JS components still.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2867

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.