### PR TITLE
DEV-3166: Fix select amount when options are strings

### DIFF
--- a/spa/src/components/donationPage/DonationPage.d.ts
+++ b/spa/src/components/donationPage/DonationPage.d.ts
@@ -24,9 +24,7 @@ export interface DonationPage {
     type: string;
     content?: {
       offerPayFees?: boolean;
-      options?: {
-        [x: string]: string[] | number[];
-      };
+      options?: Record<string, string[] | number[]>;
       [x: string]: any;
     };
   }[];

--- a/spa/src/components/donationPage/DonationPage.d.ts
+++ b/spa/src/components/donationPage/DonationPage.d.ts
@@ -24,6 +24,9 @@ export interface DonationPage {
     type: string;
     content?: {
       offerPayFees?: boolean;
+      options?: {
+        [x: string]: string[] | number[];
+      };
       [x: string]: any;
     };
   }[];

--- a/spa/src/components/donationPage/pageContent/DAmount.test.tsx
+++ b/spa/src/components/donationPage/pageContent/DAmount.test.tsx
@@ -180,6 +180,41 @@ describe('DAmount', () => {
     expect(setAmount.mock.calls).toEqual([[3]]);
   });
 
+  describe('When options contains an array of strings', () => {
+    it('selects correct amount', () => {
+      tree(
+        {
+          element: {
+            ...element,
+            content: { options: { ...defaultOptions, [CONTRIBUTION_INTERVALS.MONTHLY]: ['11', '22', '33'] } }
+          }
+        },
+        { amount: 22, frequency: CONTRIBUTION_INTERVALS.MONTHLY }
+      );
+
+      expect(screen.getByTestId('amount-22-selected')).toBeInTheDocument();
+    });
+
+    it('sets the amount when a payment option div is clicked', () => {
+      const setAmount = jest.fn();
+      tree(
+        {
+          element: {
+            ...element,
+            content: { options: { ...defaultOptions, [CONTRIBUTION_INTERVALS.MONTHLY]: ['11', '22', '33'] } }
+          }
+        },
+        { setAmount, amount: 22, frequency: CONTRIBUTION_INTERVALS.MONTHLY }
+      );
+      expect(setAmount).not.toBeCalled();
+      userEvent.click(screen.getByText('mock-currency-symbol11'));
+      expect(setAmount.mock.calls).toEqual([[11]]);
+      setAmount.mockClear();
+      userEvent.click(screen.getByText('mock-currency-symbol33'));
+      expect(setAmount.mock.calls).toEqual([[33]]);
+    });
+  });
+
   it('does not show a field where the user can enter an amount', () => {
     tree();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();

--- a/spa/src/components/donationPage/pageContent/DAmount.tsx
+++ b/spa/src/components/donationPage/pageContent/DAmount.tsx
@@ -73,7 +73,7 @@ function DAmount({ element, ...props }: DAmountProps) {
       return -1;
     }
 
-    return amountOptions.findIndex((option) => option === amount);
+    return amountOptions.findIndex((option) => parseFloat(`${option}`) === amount);
   }, [amountOptions, otherValue, amount]);
 
   // Called when the user chooses a preselected option.
@@ -123,7 +123,7 @@ function DAmount({ element, ...props }: DAmountProps) {
             <li key={`${index}-${amountOption}`}>
               <SelectableButton
                 selected={selected}
-                onClick={() => handleSelectAmountOption(amountOption!)}
+                onClick={() => handleSelectAmountOption(parseFloat(`${amountOption}`))}
                 data-testid={`amount-${amountOption}${selected ? '-selected' : ''}`}
               >
                 {`${currencySymbol}${amountOption}`}{' '}
@@ -172,7 +172,9 @@ function DAmount({ element, ...props }: DAmountProps) {
 
 const paymentPropTypes = {
   allowOther: PropTypes.bool,
-  options: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.number)),
+  options: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired).isRequired
+  ),
   defaults: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))
 };
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a

#### What's this PR do?
Fixes the issue with selecting amounts on donation pages if the frequency options list came in as an array of "strings" instead of the expected array of numbers.

#### Why are we doing this? How does it help us?
Because we have an issue that if the donation page had the array of strings options the user was unable to select any of the pre-existing amount options.

#### How should this be manually tested? Please include detailed step-by-step instructions.
- Log into the admin dashboard
- Go to `Pages > Donation Pages`
- Select a page
- Go to Elements field
- Find `type: DAmount` and go to the next `options` that you find
- Check the fields `year, month, one_time`
- Make sure at least one option has only numbers: ex `year: [200, 500, 1000]`
- Make sure at least one option has only strings (number wrapped by `"`): ex: `month: ["100", "200", "500"]`
- Save changes
![image](https://user-images.githubusercontent.com/9381325/214582904-3c96edac-a427-4643-a825-3118a21f13a8.png)
- Access that page donation url
- Make sure all frequencies work as expected (the continue button shows "Continue" instead of "Enter a valid amount" and the fees are updated with every change):
   - Default value is pre-selected when changing frequencies
   -  Selection of other pre-existing amounts works
   - "Other" field still works

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no

#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
n/a

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-3166

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no