### PR TITLE
DEV-3110: enhancement warn when user changes tax status in org settings

### DIFF
--- a/spa/src/components/settings/Organization/Organization.styled.ts
+++ b/spa/src/components/settings/Organization/Organization.styled.ts
@@ -1,5 +1,5 @@
-import { TextField } from 'components/base';
 import InfoTooltip from 'components/account/Profile/InfoTooltip';
+import { TextField } from 'components/base';
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`
@@ -44,4 +44,22 @@ export const InputWrapper = styled.div`
   display: grid;
   gap: 17px;
   grid-template-columns: 1fr 1fr;
+`;
+
+export const WarningMessage = styled.div`
+  display: grid;
+  grid-template-columns: 15px 1fr;
+  padding: 9px;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background-color: ${(props) => `${props.theme.colors.error.primary}1A`};
+  border-radius: ${(props) => props.theme.muiBorderRadius.lg};
+  max-width: 700px;
+
+  svg {
+    width: 15px;
+    height: 15px;
+    fill: ${(props) => props.theme.colors.error.primary};
+  }
 `;

--- a/spa/src/components/settings/Organization/Organization.test.tsx
+++ b/spa/src/components/settings/Organization/Organization.test.tsx
@@ -1,4 +1,5 @@
 import { axe } from 'jest-axe';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from 'test-utils';
 
 import useUser from 'hooks/useUser';
@@ -56,9 +57,31 @@ describe('Settings Organization Page', () => {
       )
     ).toBeInTheDocument();
     expect(screen.getByText('Tax Status')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Tax Status Non-profit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tax Status Nonprofit' })).toBeInTheDocument();
     expect(screen.getByText('EIN')).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'EIN Optional' })).toHaveValue('12-3456789');
+  });
+
+  it('should render warning message if Tax Status is different from server response', () => {
+    tree();
+
+    userEvent.click(screen.getByRole('button', { name: 'Tax Status Nonprofit' }));
+    userEvent.click(screen.getByRole('option', { name: 'For-profit' }));
+    expect(
+      screen.getByText(
+        'Changing your tax status will affect the fees shown on your contribution pages. Failure to match Stripe tax settings may result in a loss of funds.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('should not render warning message by default', () => {
+    tree();
+
+    expect(
+      screen.queryByText(
+        'Changing your tax status will affect the fees shown on your contribution pages. Failure to match Stripe tax settings may result in a loss of funds.'
+      )
+    ).not.toBeInTheDocument();
   });
 
   it('should be accessible', async () => {

--- a/spa/src/components/settings/Organization/Organization.tsx
+++ b/spa/src/components/settings/Organization/Organization.tsx
@@ -1,10 +1,12 @@
+import { useMemo } from 'react';
+import { ReactComponent as InfoIcon } from '@material-design-icons/svg/outlined/info.svg';
 import { Controller, useForm } from 'react-hook-form';
 import MaskedInput from 'react-input-mask';
 
+import { MenuItem, TextField } from 'components/base';
 import HeaderSection from 'components/common/HeaderSection';
 import SettingsSection from 'components/common/SettingsSection';
 import SubheaderSection from 'components/common/SubheaderSection';
-import { TextField, MenuItem } from 'components/base';
 import GlobalLoading from 'elements/GlobalLoading';
 import useUser from 'hooks/useUser';
 
@@ -15,6 +17,7 @@ import {
   StyledTextField,
   TaxStatusContainer,
   TaxStatusInfoTooltip,
+  WarningMessage,
   Wrapper
 } from './Organization.styled';
 
@@ -22,14 +25,34 @@ const Organization = () => {
   const { user, isLoading } = useUser();
   const currentOrganization = user?.organizations?.length === 1 ? user?.organizations?.[0] : undefined;
 
-  const { control } = useForm({
+  const { control, watch } = useForm({
     defaultValues: {
       // TODO: update values when BE returns the correct data
-      companyName: currentOrganization?.name,
-      companyTaxStatus: currentOrganization?.fiscal_status,
-      taxId: currentOrganization?.tax_id
+      companyName: currentOrganization?.name ?? '',
+      companyTaxStatus: currentOrganization?.fiscal_status ?? '',
+      taxId: currentOrganization?.tax_id ?? ''
     }
   });
+
+  const companyName = watch('companyName');
+  const companyTaxStatus = watch('companyTaxStatus');
+  const taxId = watch('taxId');
+
+  const isDifferent = useMemo(
+    () => ({
+      companyName: companyName !== currentOrganization?.name,
+      companyTaxStatus: companyTaxStatus !== currentOrganization?.fiscal_status,
+      taxId: taxId.replace(/-/g, '') !== currentOrganization?.tax_id
+    }),
+    [
+      companyName,
+      companyTaxStatus,
+      currentOrganization?.fiscal_status,
+      currentOrganization?.name,
+      currentOrganization?.tax_id,
+      taxId
+    ]
+  );
 
   if (isLoading) return <GlobalLoading />;
 
@@ -61,8 +84,8 @@ const Organization = () => {
                 name="companyTaxStatus"
                 control={control}
                 render={({ field }) => (
-                  <TextField fullWidth id="settings-company-tax-status" disabled label="Tax Status" {...field} select>
-                    <MenuItem value="nonprofit">Non-profit</MenuItem>
+                  <TextField fullWidth id="settings-company-tax-status" label="Tax Status" {...field} select>
+                    <MenuItem value="nonprofit">Nonprofit</MenuItem>
                     <MenuItem value="for-profit">For-profit</MenuItem>
                   </TextField>
                 )}
@@ -77,7 +100,7 @@ const Organization = () => {
               control={control}
               rules={{ pattern: { value: /[0-9]{2}-[0-9]{7}/, message: 'EIN must have 9 digits' } }}
               render={({ field }) => (
-                <MaskedInput mask="99-9999999" {...field} disabled>
+                <MaskedInput mask="99-9999999" {...field}>
                   {(inputProps: any) => (
                     <StyledTextField
                       id="settings-tax-id"
@@ -89,7 +112,6 @@ const Organization = () => {
                         </>
                       }
                       {...inputProps}
-                      disabled
                     />
                   )}
                 </MaskedInput>
@@ -97,6 +119,15 @@ const Organization = () => {
             />
           </InputWrapper>
         </SettingsSection>
+        {isDifferent.companyTaxStatus && (
+          <WarningMessage>
+            <InfoIcon />
+            <p>
+              Changing your tax status will affect the fees shown on your contribution pages. Failure to match Stripe
+              tax settings may result in a loss of funds.
+            </p>
+          </WarningMessage>
+        )}
       </Content>
     </Wrapper>
   );


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
This is the **third** PR of stacked PRs:

1. Org settings page: https://github.com/newsrevenuehub/rev-engine/pull/994
2. Link into AvatarMenu: https://github.com/newsrevenuehub/rev-engine/pull/993
3. Enhancement (Warn message) - (this PR) 
4. Handle Fiscal Sponsor in Org Settings - https://github.com/newsrevenuehub/rev-engine/pull/997

#### What's this PR do?
Adds warning message when user changes Tax status in Organization settings page.

#### Why are we doing this? How does it help us?
When a user changes tax status, their fees on donations change, so it's important to make that information pop out for the user.

#### How should this be manually tested? Please include detailed step-by-step instructions.
- Log into user with access to Org Settings
- Access Org Settings (`/settings/organization`)
- Change `Tax Status` dropdown option
- Make sure warning pops up on change and disappears when changing back to original value

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
yes

#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-3110

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
This changes are related to the tickets in these 2 epics:
https://news-revenue-hub.atlassian.net/browse/DEV-3067
https://news-revenue-hub.atlassian.net/browse/DEV-3018