### PR TITLE
DEV-2899: Remove signal payment success

### DIFF
--- a/spa/cypress/e2e/01-donationPage.cy.js
+++ b/spa/cypress/e2e/01-donationPage.cy.js
@@ -481,8 +481,7 @@ describe('User flow: happy path', () => {
             contributorEmail: 'foo@bar.com',
             pageSlug: livePageOne.slug,
             rpSlug: livePageOne.revenue_program.slug,
-            pathName: `/${livePageOne.slug}/`,
-            contributionUuid: fakeContributionUuid
+            pathName: `/${livePageOne.slug}/`
           })
         );
       });
@@ -622,8 +621,7 @@ describe('User flow: happy path', () => {
             contributorEmail: 'foo@bar.com',
             pageSlug: livePageOne.slug,
             rpSlug: livePageOne.revenue_program.slug,
-            pathName: `/${livePageOne.slug}/`,
-            contributionUuid: fakeContributionUuid
+            pathName: `/${livePageOne.slug}/`
           })
         );
       });
@@ -688,8 +686,7 @@ describe('User flow: happy path', () => {
           contributorEmail: 'foo@bar.com',
           pageSlug: livePageOne.slug,
           rpSlug: livePageOne.revenue_program.slug,
-          pathName: '',
-          contributionUuid: fakeContributionUuid
+          pathName: ''
         })
       );
     });
@@ -981,13 +978,6 @@ const successPageQueryParams = {
 describe('Payment success page', () => {
   beforeEach(() => {
     cy.intercept(
-      {
-        method: 'patch',
-        url: `http://revenueprogram.revengine-testabc123.com:3000/api/v1/payments/${fakeContributionUuid}/success/`
-      },
-      { statusCode: 204 }
-    ).as('signal-success');
-    cy.intercept(
       { method: 'GET', pathname: getEndpoint(LIVE_PAGE_DETAIL) },
       { fixture: 'pages/live-page-1', statusCode: 200 }
     ).as('getPageDetail');
@@ -999,7 +989,6 @@ describe('Payment success page', () => {
 
   specify('Using default thank you page', () => {
     cy.visit(paymentSuccessRoute, { qs: successPageQueryParams });
-    cy.wait('@signal-success');
     cy.wait('@fbTrackContribution');
     cy.wait('@fbTrackPurchase').then((intercept) => {
       const params = new URLSearchParams(intercept.request.url);
@@ -1013,7 +1002,6 @@ describe('Payment success page', () => {
   specify('Using off-site thank you page', () => {
     const externalThankYouPage = 'https://www.google.com';
     cy.visit(paymentSuccessRoute, { qs: { ...successPageQueryParams, next: externalThankYouPage } });
-    cy.wait('@signal-success');
     cy.wait('@fbTrackContribution');
     cy.wait('@fbTrackPurchase').then((intercept) => {
       const params = new URLSearchParams(intercept.request.url);
@@ -1036,7 +1024,6 @@ describe('Payment success page', () => {
     // unit test the function for creating the next URL that gets sent to Stripe, proving that if coming from
     // default donation page path (which will just be `/`), it sets `fromPath` to empty.
     cy.visit(paymentSuccessRoute, { qs: { ...successPageQueryParams, fromPath: '' } });
-    cy.wait('@signal-success');
     // get forwarded to right destination
     cy.url().should('equal', `http://revenueprogram.revengine-testabc123.com:3000/thank-you/`);
   });

--- a/spa/src/components/donationPage/live/PaymentSuccess.js
+++ b/spa/src/components/donationPage/live/PaymentSuccess.js
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import queryString from 'query-string';
 import urlJoin from 'url-join';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import axios from 'ajax/axios';
-import { LIVE_PAGE_DETAIL, getPaymentSuccessEndpoint } from 'ajax/endpoints';
+import { LIVE_PAGE_DETAIL } from 'ajax/endpoints';
 import { useAnalyticsContext } from 'components/analytics/AnalyticsContext';
 import { THANK_YOU_SLUG } from 'routes';
 import { HUB_GA_V3_ID } from 'appSettings';
@@ -15,12 +15,8 @@ function fetchPage(rpSlug, pageSlug) {
   return axios.get(LIVE_PAGE_DETAIL, { params: { revenue_program: rpSlug, page: pageSlug } }).then(({ data }) => data);
 }
 
-function patchPaymentSuccess(providerClientSecretId) {
-  return axios.patch(getPaymentSuccessEndpoint(providerClientSecretId));
-}
-
 // This is an interstitial page we use solely to call `trackConversion` from
-// our analytics. We use `stripe.confirmPayment` in our contribution page form, which
+// our analytics. We use `stripe.confirmPayment` & `stipe.confirmSetup` in our contribution page form, which
 // requires providing a return URL, which Stripe will send the user to after the
 // payment is processed. Some org's configure their page to go to a "custom", off-site
 // thank you page. In that case, we would not be able to track a conversion, so
@@ -29,8 +25,7 @@ function patchPaymentSuccess(providerClientSecretId) {
 export default function PaymentSuccess() {
   const history = useHistory();
   const { search } = useLocation();
-  const { amount, next, frequency, uid, email, pageSlug, rpSlug, fromPath, contributionUuid } =
-    queryString.parse(search);
+  const { amount, next, frequency, uid, email, pageSlug, rpSlug, fromPath } = queryString.parse(search);
 
   const { data: page, isSuccess: pageFetchSuccess } = useQuery(['getPage'], () => fetchPage(rpSlug, pageSlug));
 
@@ -49,15 +44,7 @@ export default function PaymentSuccess() {
     }
   }, [analyticsInstance]);
 
-  const { mutate: signalPaymentSuccess, isLoading: signalPaymentSuccessIsLoading } = useMutation((contributionUuid) => {
-    return patchPaymentSuccess(contributionUuid);
-  });
-
   const [conversionTracked, setConversionTracked] = useState(false);
-
-  useEffect(() => {
-    if (contributionUuid) signalPaymentSuccess(contributionUuid);
-  }, [signalPaymentSuccess, contributionUuid]);
 
   // after page is retrieved, we can load analytics instance, which has side effect of
   // tracking a page view
@@ -89,7 +76,7 @@ export default function PaymentSuccess() {
   }, [amount, analyticsInstance, analyticsReady, page, trackConversion]);
 
   useEffect(() => {
-    if (conversionTracked && !signalPaymentSuccessIsLoading) {
+    if (conversionTracked) {
       // if we're directing off-site to org-supplied thank you page...
       if (next) {
         const nextUrl = new URL(next);
@@ -116,7 +103,6 @@ export default function PaymentSuccess() {
     history,
     next,
     page,
-    signalPaymentSuccessIsLoading,
     trackConversion,
     uid
   ]);

--- a/spa/src/components/donationPage/live/PaymentSuccess.js
+++ b/spa/src/components/donationPage/live/PaymentSuccess.js
@@ -16,7 +16,7 @@ function fetchPage(rpSlug, pageSlug) {
 }
 
 // This is an interstitial page we use solely to call `trackConversion` from
-// our analytics. We use `stripe.confirmPayment` & `stipe.confirmSetup` in our contribution page form, which
+// our analytics. We use `stripe.confirmPayment` & `stripe.confirmSetup` in our contribution page form, which
 // requires providing a return URL, which Stripe will send the user to after the
 // payment is processed. Some org's configure their page to go to a "custom", off-site
 // thank you page. In that case, we would not be able to track a conversion, so

--- a/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentForm.js
@@ -28,7 +28,6 @@ function StripePaymentForm() {
     emailHash,
     stripeBillingDetails,
     stripeClientSecret,
-    contributionUuid,
     cancelPayment
   } = usePage();
   const { pathname } = useLocation();
@@ -65,8 +64,7 @@ function StripePaymentForm() {
       contributorEmail: contributorEmail,
       pageSlug: pageSlug,
       rpSlug: rpSlug,
-      pathName: pathname,
-      contributionUuid
+      pathName: pathname
     });
     try {
       // The stripe client secret will start with `seti_` if the contribution is recurring and was flagged on initial creation.

--- a/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
@@ -149,7 +149,6 @@ describe('getPaymentSuccessUrl', () => {
     expect(search.get('pageSlug')).toEqual(args.pageSlug);
     expect(search.get('rpSlug')).toEqual(args.rpSlug);
     expect(search.get('fromPath')).toEqual(args.pathName === '/' ? '' : args.pathName);
-    expect(search.get('contributionUuid')).toBe(args.contributionUuid);
   });
   // this test is here syntax in original implementation was flawed and caused `amount: 1` to
   // raise the missing args error.

--- a/spa/src/components/paymentProviders/stripe/stripeFns.ts
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.ts
@@ -146,7 +146,6 @@ export interface GetPaymentSuccessUrlArgs {
   pageSlug: string;
   pathName: string;
   rpSlug: string;
-  contributionUuid: string;
   thankYouRedirectUrl: string;
 }
 
@@ -159,8 +158,7 @@ export function getPaymentSuccessUrl({
   contributorEmail,
   pageSlug,
   rpSlug,
-  pathName,
-  contributionUuid
+  pathName
 }: GetPaymentSuccessUrlArgs) {
   const missingParams = Object.fromEntries(
     Object.entries({
@@ -171,8 +169,7 @@ export function getPaymentSuccessUrl({
       contributorEmail,
       pageSlug,
       rpSlug,
-      pathName,
-      contributionUuid
+      pathName
     }).filter(([, v]) => [undefined, null].includes(v as any))
   );
   if (Object.entries(missingParams).length) {
@@ -208,8 +205,6 @@ export function getPaymentSuccessUrl({
   // from specific page name. On other hand, if a revenue program has a default donation page
   // set up, that page can appear at rev-program-slug.revengine.com/ (with no page), in which
   // case, the thank-you page URL can be rev-program-slug.revengine.com/thank-you.
-
-  // contributionUuid
   paymentSuccessUrl.search = new URLSearchParams({
     amount,
     pageSlug,
@@ -218,7 +213,6 @@ export function getPaymentSuccessUrl({
     frequency: frequencyDisplayValue,
     fromPath: pathName === '/' ? '' : pathName,
     next: thankYouRedirectUrl,
-    contributionUuid,
     uid: emailHash
   }).toString();
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
This is a stacked PR:

1. https://github.com/newsrevenuehub/rev-engine/pull/985
2. This PR

#### What's this PR do?
- Remove function that sends successful payment signal to BE in interstitial page 
 
#### Why are we doing this? How does it help us?
- BE already handles payment success by listening to web hooks, so this function is no longer needed.

#### How should this be manually tested? Please include detailed step-by-step instructions.
- Create contributions (one time & with subscription) and make sure the contribution flow remains unchanged.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no

#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-2899

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
Related to ticket on epic:
https://news-revenue-hub.atlassian.net/browse/DEV-2744