### PR TITLE
DEV-3135: Add state label configurability

### DIFF
--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -277,7 +277,7 @@ describe('Contribution page edit', () => {
   });
 
   describe('Contributor address editor', () => {
-    it('should render the DonorAmountEditor', () => {
+    it('should render the DonorAddressEditor', () => {
       cy.editElement('DDonorAddress');
       cy.getByTestId('donor-address-editor').should('exist');
     });

--- a/spa/src/components/base/Checkbox/Checkbox.tsx
+++ b/spa/src/components/base/Checkbox/Checkbox.tsx
@@ -14,7 +14,7 @@ export const Checkbox = styled(MuiCheckbox)`
       color: #157cb2;
 
       &.Mui-disabled {
-        color: ${({ theme }) => theme.colors.muiGrey[300]};
+        color: ${({ theme }) => theme.colors.muiGrey[400]};
       }
     }
 

--- a/spa/src/components/base/Checkbox/Checkbox.tsx
+++ b/spa/src/components/base/Checkbox/Checkbox.tsx
@@ -12,6 +12,10 @@ export const Checkbox = styled(MuiCheckbox)`
 
     &.Mui-checked {
       color: #157cb2;
+
+      &.Mui-disabled {
+        color: ${({ theme }) => theme.colors.muiGrey[300]};
+      }
     }
 
     svg {

--- a/spa/src/components/base/FormControlLabel/FormControlLabel.tsx
+++ b/spa/src/components/base/FormControlLabel/FormControlLabel.tsx
@@ -17,6 +17,10 @@ const StyledMuiFormControlLabel = styled(MuiFormControlLabel)`
       color: #282828;
       font: 16px Roboto, sans-serif;
       line-height: 24px;
+
+      &.Mui-disabled {
+        color: ${({ theme }) => theme.colors.muiGrey[600]};
+      }
     }
   }
 `;

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.stories.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.stories.tsx
@@ -22,7 +22,7 @@ function ComponentDemo(errors: Record<string, string> = {}) {
           } as any
         }
       >
-        <DDonorAddress />
+        <DDonorAddress element={{ content: {}, requiredFields: [], type: 'DDonorAddress', uuid: 'mock-uuid' }} />
       </DonationPageContext.Provider>
     </ul>
   );

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
@@ -7,7 +7,7 @@ import { usePlacesWidget } from 'react-google-autocomplete';
 import { act, render, screen } from 'test-utils';
 import { HUB_GOOGLE_MAPS_API_KEY } from 'appSettings';
 import { DonationPageContext, UsePageProps } from '../DonationPage';
-import DDonorAddress from './DDonorAddress';
+import DDonorAddress, { DDonorAddressProps } from './DDonorAddress';
 
 jest.mock('country-code-lookup', () => ({
   countries: [
@@ -60,7 +60,7 @@ const mockAddressComponents: google.maps.GeocoderAddressComponent[] = [
   }
 ];
 
-function tree(pageContext?: Partial<UsePageProps>) {
+function tree(pageContext?: Partial<UsePageProps>, props?: Partial<DDonorAddressProps>) {
   return render(
     <DonationPageContext.Provider
       value={
@@ -73,7 +73,10 @@ function tree(pageContext?: Partial<UsePageProps>) {
       }
     >
       <ul>
-        <DDonorAddress />
+        <DDonorAddress
+          element={{ content: {}, requiredFields: [], type: 'DDonorAddress', uuid: 'mock-uuid' }}
+          {...props}
+        />
       </ul>
     </DonationPageContext.Provider>
   );
@@ -121,6 +124,26 @@ describe('DDonorAddress', () => {
       // We don't have test IDs for helper text right now.
       // eslint-disable-next-line testing-library/no-node-access
       expect(document.getElementById(`${internalName}-helper-text`)).toHaveTextContent('test-error');
+    });
+  });
+
+  describe('The State field label', () => {
+    it('is State by default', () => {
+      tree();
+      expect(screen.getByRole('textbox', { name: 'State' })).toBeVisible();
+    });
+
+    it.each([
+      ['State/Province', ['province']],
+      ['State/Region', ['region']],
+      ['State/Province/Region', ['region', 'province']]
+    ])('is %s if configured', (name, additionalStateFieldLabels) => {
+      tree({}, { element: { content: { additionalStateFieldLabels } } } as any);
+
+      const field = screen.getByRole('textbox', { name });
+
+      expect(field).toBeVisible();
+      expect(field).toHaveAttribute('name', 'mailing_state');
     });
   });
 

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
@@ -2,13 +2,15 @@
 /// <reference types="google.maps" />
 
 import Grid from '@material-ui/core/Grid';
-import { ChangeEvent, useState } from 'react';
+import PropTypes, { InferProps } from 'prop-types';
+import { ChangeEvent, useMemo, useState } from 'react';
 import { usePlacesWidget } from 'react-google-autocomplete';
 import { HUB_GOOGLE_MAPS_API_KEY } from 'appSettings';
 import { CountryOption } from 'components/base';
 import { usePage } from 'components/donationPage/DonationPage';
 import DElement from 'components/donationPage/pageContent/DElement';
 import { CountrySelect, TextField } from './DDonorAddress.styled';
+import { DonorAddressElement } from 'hooks/useContributionPage';
 
 const mapAddrFieldToComponentTypes = {
   address: ['street_number', 'street_address', 'route'],
@@ -35,12 +37,33 @@ function mapAddressComponentsToAddressFields(addressComponents: google.maps.Geoc
   return { address, zip, city, state, country };
 }
 
-function DDonorAddress() {
+const DDonorAddressPropTypes = {
+  element: PropTypes.object.isRequired
+};
+
+export interface DDonorAddressProps extends InferProps<typeof DDonorAddressPropTypes> {
+  element: DonorAddressElement;
+}
+
+function DDonorAddress({ element }: DDonorAddressProps) {
   const { errors, mailingCountry, setMailingCountry } = usePage();
   const [address, setAddress] = useState('');
   const [city, setCity] = useState('');
   const [state, setState] = useState('');
   const [zip, setZip] = useState('');
+  const stateLabel = useMemo(() => {
+    let result = 'State';
+
+    if (element.content?.additionalStateFieldLabels?.includes('province')) {
+      result += '/Province';
+    }
+
+    if (element.content?.additionalStateFieldLabels?.includes('region')) {
+      result += '/Region';
+    }
+
+    return result;
+  }, [element.content?.additionalStateFieldLabels]);
 
   const { ref: addressInputRef } = usePlacesWidget<HTMLInputElement>({
     apiKey: HUB_GOOGLE_MAPS_API_KEY,
@@ -130,7 +153,7 @@ function DDonorAddress() {
             fullWidth
             id="mailing_state"
             name="mailing_state"
-            label="State"
+            label={stateLabel}
             value={state}
             onChange={(e) => setState(e.target.value)}
             helperText={errors.mailing_state}
@@ -168,6 +191,8 @@ function DDonorAddress() {
     </DElement>
   );
 }
+
+DDonorAddress.propTypes = DDonorAddressPropTypes;
 
 DDonorAddress.type = 'DDonorAddress';
 DDonorAddress.displayName = 'Contributor Address';

--- a/spa/src/components/pageEditor/editInterface/ElementEditor.tsx
+++ b/spa/src/components/pageEditor/editInterface/ElementEditor.tsx
@@ -1,5 +1,6 @@
 import {
   AmountElement,
+  DonorAddressElement,
   DonorInfoElement,
   FrequencyElement,
   PaymentElement,
@@ -8,7 +9,7 @@ import {
 import { useEditablePageBatch } from 'hooks/useEditablePageBatch';
 import { useMemo, useState } from 'react';
 import { getPageContributionIntervals } from 'utilities/getPageContributionIntervals';
-import { AmountEditor, FrequencyEditor, PaymentEditor, ReasonEditor } from '../elementEditors';
+import { AmountEditor, DonorAddressEditor, FrequencyEditor, PaymentEditor, ReasonEditor } from '../elementEditors';
 import { Content, ContentDetail, Header, Root } from './ElementEditor.styled';
 import EditSaveControls from './EditSaveControls';
 import ElementProperties from './pageElements/ElementProperties';
@@ -22,6 +23,7 @@ import ContributorInfoEditor from '../elementEditors/contributorInfo/Contributor
  */
 const editorComponents = {
   DAmount: AmountEditor,
+  DDonorAddress: DonorAddressEditor,
   DDonorInfo: ContributorInfoEditor,
   DFrequency: FrequencyEditor,
   DPayment: PaymentEditor,
@@ -36,6 +38,7 @@ const editorComponents = {
  */
 const editorHeaders = {
   DAmount: 'Contribution Amount',
+  DDonorAddress: 'Contributor Address',
   DDonorInfo: 'Contributor Info',
   DFrequency: 'Contribution Frequency',
   DPayment: 'Agree to Pay Fees',
@@ -54,6 +57,7 @@ export interface ElementEditorProps {
  */
 type ElementContent =
   | AmountElement['content']
+  | DonorAddressElement['content']
   | DonorInfoElement['content']
   | FrequencyElement['content']
   | PaymentElement['content']

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.js
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.js
@@ -1,9 +1,0 @@
-import * as S from './DonorAddressEditor.styled';
-
-function DonorAddressEditor() {
-  return <S.DonorAddressEditor data-testid="donor-address-editor">Nothing to configure here!</S.DonorAddressEditor>;
-}
-
-DonorAddressEditor.for = 'DDonorAddress';
-
-export default DonorAddressEditor;

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.stories.tsx
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import DonorAddressEditor from './DonorAddressEditor';
+
+export default {
+  component: DonorAddressEditor,
+  title: 'ElementEditors/DonorAddressEditor'
+} as ComponentMeta<typeof DonorAddressEditor>;
+
+const Template: ComponentStory<typeof DonorAddressEditor> = (props) => <DonorAddressEditor {...props} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  elementContent: {}
+};

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.styled.js
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.styled.js
@@ -1,5 +1,0 @@
-import styled from 'styled-components';
-
-export const DonorAddressEditor = styled.div`
-  margin: 3rem 0 3rem 6rem;
-`;

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.styled.ts
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.styled.ts
@@ -7,11 +7,13 @@ export const Checkboxes = styled.div`
 `;
 
 export const Header = styled.h4`
-  font-size: ${({ theme }) => theme.fontSizesUpdated.lg};
+  color: ${({ theme }) => theme.colors.muiGrey[900]};
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
   font-weight: 600;
+  margin-bottom: 10px;
 `;
 
 export const Tip = styled.p`
   color: ${({ theme }) => theme.colors.muiGrey[600]};
-  margin-bottom: 20px;
+  margin-bottom: 18px;
 `;

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.styles.ts
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.styles.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Checkboxes = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+`;
+
+export const Header = styled.h4`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.lg};
+  font-weight: 600;
+`;
+
+export const Tip = styled.p`
+  color: ${({ theme }) => theme.colors.muiGrey[600]};
+  margin-bottom: 20px;
+`;

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.test.tsx
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.test.tsx
@@ -1,0 +1,62 @@
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import DonorAddressEditor, { DonorAddressEditorProps } from './DonorAddressEditor';
+
+function tree(props?: Partial<DonorAddressEditorProps>) {
+  return render(<DonorAddressEditor elementContent={{}} onChangeElementContent={jest.fn()} {...props} />);
+}
+
+describe('DonorAddressEditor', () => {
+  it('displays explanatory text', () => {
+    tree();
+    expect(screen.getByText('Include additional labels above the address field for State.')).toBeVisible();
+  });
+
+  it('has a state checkbox which is disabled', () => {
+    tree();
+    expect(screen.getByRole('checkbox', { name: 'State (required)' })).toBeDisabled();
+  });
+
+  describe.each([
+    ['province', 'Province'],
+    ['region', 'Region']
+  ])('The %s checkbox', (key, name) => {
+    it(`is checked if '${key}' is in the element content`, () => {
+      tree({ elementContent: { additionalStateFieldLabels: [key, 'unrelated'] } } as any);
+      expect(screen.getByRole('checkbox', { name })).toBeChecked();
+    });
+
+    it(`is unchecked if '${key}' isn't in the element content`, () => {
+      tree({ elementContent: { additionalStateFieldLabels: ['unrelated'] } } as any);
+      expect(screen.getByRole('checkbox', { name })).not.toBeChecked();
+    });
+
+    it(`adds '${key}' to the element content when the user checks it`, () => {
+      const onChangeElementContent = jest.fn();
+
+      tree({ onChangeElementContent, elementContent: { additionalStateFieldLabels: ['unrelated'] } } as any);
+      expect(onChangeElementContent).not.toBeCalled();
+      userEvent.click(screen.getByRole('checkbox', { name }));
+      expect(onChangeElementContent.mock.calls).toEqual([[{ additionalStateFieldLabels: ['unrelated', key] }]]);
+    });
+
+    it(`removes '${key}' from the element content when the user checks it`, () => {
+      const onChangeElementContent = jest.fn();
+
+      tree({
+        onChangeElementContent,
+        elementContent: { additionalStateFieldLabels: ['unrelated', key] }
+      } as any);
+      expect(onChangeElementContent).not.toBeCalled();
+      userEvent.click(screen.getByRole('checkbox', { name }));
+      expect(onChangeElementContent.mock.calls).toEqual([[{ additionalStateFieldLabels: ['unrelated'] }]]);
+    });
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.tsx
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from 'components/base';
 import { DonorAddressElement, DonorAddressElementAdditionalStateFieldLabel } from 'hooks/useContributionPage';
 import PropTypes, { InferProps } from 'prop-types';
 import { ChangeEvent } from 'react';
-import { Checkboxes, Header, Tip } from './DonorAddressEditor.styles';
+import { Checkboxes, Header, Tip } from './DonorAddressEditor.styled';
 
 const DonorAddressEditorPropTypes = {
   elementContent: PropTypes.object.isRequired,

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.tsx
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.tsx
@@ -1,0 +1,75 @@
+import { FormControlLabel } from '@material-ui/core';
+import { Checkbox } from 'components/base';
+import { DonorAddressElement, DonorAddressElementAdditionalStateFieldLabel } from 'hooks/useContributionPage';
+import PropTypes, { InferProps } from 'prop-types';
+import { ChangeEvent } from 'react';
+import { Checkboxes, Header, Tip } from './DonorAddressEditor.styles';
+
+const DonorAddressEditorPropTypes = {
+  elementContent: PropTypes.object.isRequired,
+  onChangeElementContent: PropTypes.func.isRequired
+};
+
+export interface DonorAddressEditorProps extends InferProps<typeof DonorAddressEditorPropTypes> {
+  elementContent: DonorAddressElement['content'];
+  onChangeElementContent: (value: DonorAddressElement['content']) => void;
+}
+
+export function DonorAddressEditor({ elementContent, onChangeElementContent }: DonorAddressEditorProps) {
+  function handleCheckboxChange(
+    value: DonorAddressElementAdditionalStateFieldLabel,
+    event: ChangeEvent<HTMLInputElement>
+  ) {
+    if (event.target.checked) {
+      onChangeElementContent({
+        ...elementContent,
+        additionalStateFieldLabels: [...(elementContent.additionalStateFieldLabels ?? []), value]
+      });
+    } else {
+      onChangeElementContent({
+        ...elementContent,
+        additionalStateFieldLabels: (elementContent.additionalStateFieldLabels ?? []).filter(
+          (existing) => existing !== value
+        )
+      });
+    }
+  }
+
+  return (
+    <div data-testid="donor-address-editor">
+      <Header>State Label</Header>
+      <Tip>Include additional labels above the address field for State.</Tip>
+      <Checkboxes>
+        <FormControlLabel
+          control={<Checkbox checked disabled />}
+          label={
+            <>
+              State <span style={{ fontStyle: 'italic' }}>(required)</span>
+            </>
+          }
+        ></FormControlLabel>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={elementContent.additionalStateFieldLabels?.includes('province')}
+              onChange={(event) => handleCheckboxChange('province', event)}
+            />
+          }
+          label="Province"
+        ></FormControlLabel>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={elementContent.additionalStateFieldLabels?.includes('region')}
+              onChange={(event) => handleCheckboxChange('region', event)}
+            />
+          }
+          label="Region"
+        ></FormControlLabel>
+      </Checkboxes>
+    </div>
+  );
+}
+
+DonorAddressEditor.propTypes = DonorAddressEditorPropTypes;
+export default DonorAddressEditor;

--- a/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.tsx
+++ b/spa/src/components/pageEditor/elementEditors/donorAddress/DonorAddressEditor.tsx
@@ -1,5 +1,4 @@
-import { FormControlLabel } from '@material-ui/core';
-import { Checkbox } from 'components/base';
+import { Checkbox, FormControlLabel } from 'components/base';
 import { DonorAddressElement, DonorAddressElementAdditionalStateFieldLabel } from 'hooks/useContributionPage';
 import PropTypes, { InferProps } from 'prop-types';
 import { ChangeEvent } from 'react';

--- a/spa/src/hooks/useContributionPage/useContributionPage.types.ts
+++ b/spa/src/hooks/useContributionPage/useContributionPage.types.ts
@@ -114,6 +114,18 @@ export interface AmountElement extends ContributionPageElement {
   };
 }
 
+export type DonorAddressElementAdditionalStateFieldLabel = 'province' | 'region';
+
+export interface DonorAddressElement extends ContributionPageElement {
+  content: {
+    /**
+     * Additional labels to show on the State field. These are *not* displayed
+     * as-is, and order is not significant.
+     */
+    additionalStateFieldLabels?: DonorAddressElementAdditionalStateFieldLabel[];
+  };
+}
+
 export interface DonorInfoElement extends ContributionPageElement {
   content: {
     /**


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Updates the contributor address block editor so that it can take on additional labels.

#### Why are we doing this? How does it help us?

Better UX for non-USians.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit a contribution page and the Contribution Address block.
2. Check the Province checkbox and save changes.
3. Confirm that the field now shows as "State/Province" in the published page and that state is saved properly in a contribution.
4. Edit the page/block.
5. Check the Region checkbox and save changes.
6. Confirm that that the field now shows as "State/Province/Region" in the published page and that state is saved properly.
7. Create a new contribution page.
8. Confirm that the page only shows "State" as the label in the contributor address block.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

We probably want to document this new functionality.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

Mention this to international orgs, perhaps?

#### Are there any smells or added technical debt to note?

Hit a very strange test failure that only happened in CI that doesn't appear related to this PR. It might just be the phase of the moon but I got it to work in c1fc4caa3bfa6da4e5e322ea83fdd0a121c575c8. I don't understand why it failed.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3135

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.