### PR TITLE
DEV-2947: Fix input field colors on contribution page

### DIFF
--- a/spa/src/components/donationPage/pageContent/DDonorAddress.styled.ts
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.styled.ts
@@ -24,7 +24,9 @@ export const CountrySelect = styled(BaseCountrySelect)`
     }
 
     .NreAutocompleteInput {
+      background: ${({ theme }) => theme.colors.cstm_inputBackground};
       border: 1px solid #080708;
+      border-color: ${({ theme }) => theme.colors.cstm_inputBorder};
       border-radius: 3px;
       height: 19px;
 
@@ -64,7 +66,9 @@ export const TextField = styled(BaseTextField)`
 
     .NreTextFieldInput,
     .Mui-error .NreTextFieldInput {
+      background: ${({ theme }) => theme.colors.cstm_inputBackground};
       border: 1px solid #080708;
+      border-color: ${({ theme }) => theme.colors.cstm_inputBorder};
       border-radius: 3px;
       height: 19px;
 

--- a/spa/src/styles/defaultTheme.d.ts
+++ b/spa/src/styles/defaultTheme.d.ts
@@ -8,6 +8,8 @@ import 'styled-components';
 declare module 'styled-components' {
   export interface DefaultTheme {
     colors: {
+      cstm_inputBackground?: string;
+      cstm_inputBorder?: string;
       cstm_mainBackground?: string;
       primary: '#20bfdd';
       primaryLight: '#c7eff7';


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Fixes appearance of the address fields on contribution pages that have styles.

#### Why are we doing this? How does it help us?

Fixes design bugs.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Create or edit a page with the default style. Confirm that fields on the page have the correct appearance (background color and outline) in the page editor.
2. Confirm the appearance is correct in the published version of the page.
3. Create a custom style and apply it to the page.
4. Confirm that the fields on the page have the correct colors in the page editor.
5. Confirm that the fields on the page have the correct colors in the published version of the page.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No; changes are visual only.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2947

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.