### PR TITLE
DEV-3456: Update URL for Core plan

### DIFF
--- a/spa/cypress/e2e/04-donations.cy.js
+++ b/spa/cypress/e2e/04-donations.cy.js
@@ -1,4 +1,5 @@
 import isEqual from 'lodash.isequal';
+import orderBy from 'lodash.orderby';
 
 import { NO_VALUE } from 'constants/textConstants';
 import { PAYMENT_STATUS_EXCLUDE_IN_CONTRIBUTIONS } from 'constants/paymentStatus';
@@ -153,10 +154,15 @@ describe('Donations list', () => {
     });
 
     it('should make donations sortable by payment date', () => {
+      const sortedData = orderBy(donationsData, 'last_payment_date');
+
       cy.wait('@getDonations');
       // will be in ascending order
       cy.getByTestId('donation-header-last_payment_date').click();
-      cy.wait('@getDonations');
+
+      cy.getByTestId('donation-row')
+        .first()
+        .should('have.attr', 'data-lastpaymentdate', sortedData[0].last_payment_date);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows
@@ -168,7 +174,9 @@ describe('Donations list', () => {
       });
       // will be in descending order
       cy.getByTestId('donation-header-last_payment_date').click();
-      cy.wait('@getDonations');
+      cy.getByTestId('donation-row')
+        .first()
+        .should('have.attr', 'data-lastpaymentdate', sortedData[sortedData.length - 1].last_payment_date);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows
@@ -179,11 +187,14 @@ describe('Donations list', () => {
           });
       });
     });
+
     it('should make donations sortable by amount', () => {
+      const sortedData = orderBy(donationsData, 'amount');
+
       cy.wait('@getDonations');
       // will be in ascending order
       cy.getByTestId('donation-header-amount').click();
-      cy.wait('@getDonations');
+      cy.getByTestId('donation-row').first().should('have.attr', 'data-amount', sortedData[0].amount);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows
@@ -195,7 +206,9 @@ describe('Donations list', () => {
       });
       // will be in descending order
       cy.getByTestId('donation-header-amount').click();
-      cy.wait('@getDonations');
+      cy.getByTestId('donation-row')
+        .first()
+        .should('have.attr', 'data-amount', sortedData[sortedData.length - 1].amount);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows
@@ -208,10 +221,12 @@ describe('Donations list', () => {
     });
 
     it('should make contributions sortable by contributor', () => {
+      const sortedData = orderBy(donationsData, 'contributor_email');
+
       cy.wait('@getDonations');
       // will be in ascending order
       cy.getByTestId('donation-header-contributor_email').click();
-      cy.wait('@getDonations');
+      cy.getByTestId('donation-row').first().should('have.attr', 'data-donor', sortedData[0].contributor_email);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows
@@ -223,7 +238,9 @@ describe('Donations list', () => {
       });
       // will be in descending order
       cy.getByTestId('donation-header-contributor_email').click();
-      cy.wait('@getDonations');
+      cy.getByTestId('donation-row')
+        .first()
+        .should('have.attr', 'data-donor', sortedData[sortedData.length - 1].contributor_email);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows
@@ -236,10 +253,12 @@ describe('Donations list', () => {
     });
 
     it('should make donations sortable by status', () => {
+      const sortedData = orderBy(donationsData, 'status');
+
       cy.wait('@getDonations');
       // will be in ascending order
       cy.getByTestId('donation-header-status').click();
-      cy.wait('@getDonations');
+      cy.getByTestId('donation-row').first().should('have.attr', 'data-status', sortedData[0].status);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows
@@ -251,7 +270,9 @@ describe('Donations list', () => {
       });
       // will be in descending order
       cy.getByTestId('donation-header-status').click();
-      cy.wait('@getDonations');
+      cy.getByTestId('donation-row')
+        .first()
+        .should('have.attr', 'data-status', sortedData[sortedData.length - 1].status);
       cy.getByTestId('donation-row').should(($rows) => {
         const rows = $rows.toArray();
         rows

--- a/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.test.tsx
+++ b/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.test.tsx
@@ -31,15 +31,6 @@ describe('MaxPagesReachedModal', () => {
   });
 
   describe('The link to upgrade', () => {
-    it('goes to the help URL if the free plan is recommended', () => {
-      tree({ open: true, recommendedPlan: 'FREE' });
-
-      const link = screen.getByRole('link', { name: 'Upgrade' });
-
-      expect(link).toHaveAttribute('href', HELP_URL);
-      expect(link).toHaveAttribute('target', '_blank');
-    });
-
     it('goes to the Core upgrade URL if the Core plan is recommended', () => {
       tree({ open: true, recommendedPlan: 'CORE' });
 

--- a/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.test.tsx
+++ b/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.test.tsx
@@ -1,4 +1,4 @@
-import { HELP_URL } from 'constants/helperUrls';
+import { CORE_UPGRADE_URL, HELP_URL } from 'constants/helperUrls';
 import { axe } from 'jest-axe';
 import { fireEvent, render, screen } from 'test-utils';
 import MaxPagesReachedModal, { MaxPagesReachedModalProps } from './MaxPagesReachedModal';
@@ -30,13 +30,33 @@ describe('MaxPagesReachedModal', () => {
     expect(screen.getByTestId('recommendation')).toHaveTextContent('Want to create more pages? Check out Plus.');
   });
 
-  it('shows a link to upgrade', () => {
-    tree({ open: true });
+  describe('The link to upgrade', () => {
+    it('goes to the help URL if the free plan is recommended', () => {
+      tree({ open: true, recommendedPlan: 'FREE' });
 
-    const link = screen.getByRole('link', { name: 'Upgrade' });
+      const link = screen.getByRole('link', { name: 'Upgrade' });
 
-    expect(link).toHaveAttribute('href', HELP_URL);
-    expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('href', HELP_URL);
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('goes to the Core upgrade URL if the Core plan is recommended', () => {
+      tree({ open: true, recommendedPlan: 'CORE' });
+
+      const link = screen.getByRole('link', { name: 'Upgrade' });
+
+      expect(link).toHaveAttribute('href', CORE_UPGRADE_URL);
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('goes to the help URL if the Plus plan is recommended', () => {
+      tree({ open: true, recommendedPlan: 'PLUS' });
+
+      const link = screen.getByRole('link', { name: 'Upgrade' });
+
+      expect(link).toHaveAttribute('href', HELP_URL);
+      expect(link).toHaveAttribute('target', '_blank');
+    });
   });
 
   it('calls the onClose prop when the modal is closed', () => {

--- a/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.test.tsx
+++ b/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.test.tsx
@@ -1,4 +1,4 @@
-import { CORE_UPGRADE_URL, HELP_URL } from 'constants/helperUrls';
+import { CORE_UPGRADE_URL, PRICING_URL } from 'constants/helperUrls';
 import { axe } from 'jest-axe';
 import { fireEvent, render, screen } from 'test-utils';
 import MaxPagesReachedModal, { MaxPagesReachedModalProps } from './MaxPagesReachedModal';
@@ -40,12 +40,12 @@ describe('MaxPagesReachedModal', () => {
       expect(link).toHaveAttribute('target', '_blank');
     });
 
-    it('goes to the help URL if the Plus plan is recommended', () => {
+    it('goes to the pricing URL if the Plus plan is recommended', () => {
       tree({ open: true, recommendedPlan: 'PLUS' });
 
       const link = screen.getByRole('link', { name: 'Upgrade' });
 
-      expect(link).toHaveAttribute('href', HELP_URL);
+      expect(link).toHaveAttribute('href', PRICING_URL);
       expect(link).toHaveAttribute('target', '_blank');
     });
   });

--- a/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
+++ b/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
@@ -1,5 +1,5 @@
 import { Button, LinkButton, Modal, ModalFooter } from 'components/base';
-import { CORE_UPGRADE_URL, HELP_URL, PRICING_URL } from 'constants/helperUrls';
+import { CORE_UPGRADE_URL, PRICING_URL } from 'constants/helperUrls';
 import { EnginePlan } from 'hooks/useContributionPage';
 import PropTypes, { InferProps } from 'prop-types';
 import {
@@ -38,7 +38,7 @@ export interface MaxPagesReachedModalProps extends InferProps<typeof MaxPagesRea
 }
 
 export function MaxPagesReachedModal({ currentPlan, onClose, open, recommendedPlan }: MaxPagesReachedModalProps) {
-  const upgradeUrl = recommendedPlan === 'CORE' ? CORE_UPGRADE_URL : HELP_URL;
+  const upgradeUrl = recommendedPlan === 'CORE' ? CORE_UPGRADE_URL : PRICING_URL;
 
   return (
     <Modal open={!!open}>

--- a/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
+++ b/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
@@ -25,10 +25,10 @@ const planNames: Record<EnginePlan['name'], string> = {
 };
 
 const MaxPagesReachedModalPropTypes = {
-  currentPlan: PropTypes.oneOf(Object.keys(planNames).filter((name) => name !== 'FREE')).isRequired,
+  currentPlan: PropTypes.oneOf(Object.keys(planNames)).isRequired,
   onClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
-  recommendedPlan: PropTypes.string
+  recommendedPlan: PropTypes.oneOf(Object.keys(planNames).filter((name) => name !== 'FREE'))
 };
 
 export interface MaxPagesReachedModalProps extends InferProps<typeof MaxPagesReachedModalPropTypes> {
@@ -37,12 +37,7 @@ export interface MaxPagesReachedModalProps extends InferProps<typeof MaxPagesRea
   recommendedPlan?: UpgradePlan;
 }
 
-export function MaxPagesReachedModal({
-  currentPlan,
-  onClose,
-  open,
-  recommendedPlan = 'CORE'
-}: MaxPagesReachedModalProps) {
+export function MaxPagesReachedModal({ currentPlan, onClose, open, recommendedPlan }: MaxPagesReachedModalProps) {
   const upgradeUrl = recommendedPlan === 'CORE' ? CORE_UPGRADE_URL : HELP_URL;
 
   return (
@@ -54,33 +49,37 @@ export function MaxPagesReachedModal({
         <PlanLimit data-testid="plan-limit">
           You've reached the <RedEmphasis>maximum</RedEmphasis> number of pages for the {planNames[currentPlan]} tier.
         </PlanLimit>
-        <Recommendation data-testid="recommendation">
-          <strong>Want to create more pages?</strong> Check out{' '}
-          {recommendedPlan !== 'PLUS' && planNames[recommendedPlan]}
-          {recommendedPlan === 'PLUS' && (
-            <PricingLink href={PRICING_URL} target="_blank">
-              {planNames[recommendedPlan]}
-            </PricingLink>
-          )}
-          .
-        </Recommendation>
-        {recommendedPlan === 'CORE' && (
-          <Card>
-            <CardHeader>
-              <CardHeaderHighlight>Core Tier</CardHeaderHighlight>
-            </CardHeader>
-            <BenefitsList>
-              <li>Mailchimp integration</li>
-              <li>Branded receipts</li>
-              <li>Branded contributor portal</li>
-              <li>2 live checkout pages</li>
-              <li>
+        {recommendedPlan && (
+          <>
+            <Recommendation data-testid="recommendation">
+              <strong>Want to create more pages?</strong> Check out{' '}
+              {recommendedPlan !== 'PLUS' && planNames[recommendedPlan]}
+              {recommendedPlan === 'PLUS' && (
                 <PricingLink href={PRICING_URL} target="_blank">
-                  And more!
+                  {planNames[recommendedPlan]}
                 </PricingLink>
-              </li>
-            </BenefitsList>
-          </Card>
+              )}
+              .
+            </Recommendation>
+            {recommendedPlan === 'CORE' && (
+              <Card>
+                <CardHeader>
+                  <CardHeaderHighlight>Core Tier</CardHeaderHighlight>
+                </CardHeader>
+                <BenefitsList>
+                  <li>Mailchimp integration</li>
+                  <li>Branded receipts</li>
+                  <li>Branded contributor portal</li>
+                  <li>2 live checkout pages</li>
+                  <li>
+                    <PricingLink href={PRICING_URL} target="_blank">
+                      And more!
+                    </PricingLink>
+                  </li>
+                </BenefitsList>
+              </Card>
+            )}
+          </>
         )}
       </ModalContent>
       <ModalFooter>

--- a/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
+++ b/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
@@ -16,6 +16,8 @@ import {
   RedEmphasis
 } from './MaxPagesReachedModal.styled';
 
+export type UpgradePlan = Exclude<EnginePlan['name'], 'FREE'>;
+
 const planNames: Record<EnginePlan['name'], string> = {
   CORE: 'Core',
   FREE: 'Free',
@@ -23,7 +25,7 @@ const planNames: Record<EnginePlan['name'], string> = {
 };
 
 const MaxPagesReachedModalPropTypes = {
-  currentPlan: PropTypes.oneOf(Object.keys(planNames)).isRequired,
+  currentPlan: PropTypes.oneOf(Object.keys(planNames).filter((name) => name !== 'FREE')).isRequired,
   onClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   recommendedPlan: PropTypes.string
@@ -32,7 +34,7 @@ const MaxPagesReachedModalPropTypes = {
 export interface MaxPagesReachedModalProps extends InferProps<typeof MaxPagesReachedModalPropTypes> {
   currentPlan: EnginePlan['name'];
   onClose: () => void;
-  recommendedPlan?: EnginePlan['name'];
+  recommendedPlan?: UpgradePlan;
 }
 
 export function MaxPagesReachedModal({

--- a/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
+++ b/spa/src/components/common/Modal/MaxPagesReachedModal/MaxPagesReachedModal.tsx
@@ -1,5 +1,5 @@
 import { Button, LinkButton, Modal, ModalFooter } from 'components/base';
-import { HELP_URL, PRICING_URL } from 'constants/helperUrls';
+import { CORE_UPGRADE_URL, HELP_URL, PRICING_URL } from 'constants/helperUrls';
 import { EnginePlan } from 'hooks/useContributionPage';
 import PropTypes, { InferProps } from 'prop-types';
 import {
@@ -41,6 +41,8 @@ export function MaxPagesReachedModal({
   open,
   recommendedPlan = 'CORE'
 }: MaxPagesReachedModalProps) {
+  const upgradeUrl = recommendedPlan === 'CORE' ? CORE_UPGRADE_URL : HELP_URL;
+
   return (
     <Modal open={!!open}>
       <ModalHeader icon={<ModalHeaderIcon />} onClose={onClose}>
@@ -83,7 +85,7 @@ export function MaxPagesReachedModal({
         <Button color="secondary" onClick={onClose}>
           Maybe Later
         </Button>
-        <LinkButton color="primaryDark" href={HELP_URL} target="_blank">
+        <LinkButton color="primaryDark" href={upgradeUrl} target="_blank">
           Upgrade
         </LinkButton>
       </ModalFooter>

--- a/spa/src/components/content/pages/AddPage.test.tsx
+++ b/spa/src/components/content/pages/AddPage.test.tsx
@@ -33,6 +33,12 @@ describe('AddPage', () => {
     useUserMock.mockReturnValue({ isLoading: false, user: {} });
   });
 
+  it('displays nothing if the user is not available in context', () => {
+    useUserMock.mockReturnValue({ isLoading: true });
+    tree();
+    expect(document.body.textContent).toBe('');
+  });
+
   it('displays a button', () => {
     tree();
     expect(screen.getByRole('button', { name: 'New Page' })).toBeVisible();
@@ -153,7 +159,7 @@ describe('AddPage', () => {
     });
   });
 
-  describe('When the user cannot create a new page', () => {
+  describe('When the user has exceeded the limit of the free plan', () => {
     beforeEach(() => {
       useContributionPageListMock.mockReturnValue({
         isLoading: false,
@@ -172,6 +178,48 @@ describe('AddPage', () => {
       tree();
       fireEvent.click(screen.getByRole('button', { name: 'New Page' }));
       expect(screen.getByText('Max Pages Reached')).toBeVisible();
+    });
+
+    it('recommends upgrading to the Core plan', () => {
+      tree();
+      fireEvent.click(screen.getByRole('button', { name: 'New Page' }));
+      expect(screen.getByTestId('recommendation')).toHaveTextContent('Check out Core.');
+    });
+
+    it('closes the modal if the user closes it', () => {
+      tree();
+      fireEvent.click(screen.getByRole('button', { name: 'New Page' }));
+      expect(screen.getByText('Max Pages Reached')).toBeVisible();
+      fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+      expect(screen.queryByText('Max Pages Reached')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('When the user has exceeded the limit of the Core plan', () => {
+    beforeEach(() => {
+      useContributionPageListMock.mockReturnValue({
+        isLoading: false,
+        userCanCreatePage: () => false
+      });
+      useUserMock.mockReturnValue({
+        isLoading: false,
+        user: {
+          organizations: [{ plan: { name: 'CORE' } }],
+          revenue_programs: [{ id: 'mock-rp-1' }]
+        }
+      });
+    });
+
+    it("shows a modal indicating they've hit the page limit", () => {
+      tree();
+      fireEvent.click(screen.getByRole('button', { name: 'New Page' }));
+      expect(screen.getByText('Max Pages Reached')).toBeVisible();
+    });
+
+    it('recommends upgrading to the Plus plan', () => {
+      tree();
+      fireEvent.click(screen.getByRole('button', { name: 'New Page' }));
+      expect(screen.getByTestId('recommendation')).toHaveTextContent('Check out Plus.');
     });
 
     it('closes the modal if the user closes it', () => {

--- a/spa/src/components/content/pages/AddPage.tsx
+++ b/spa/src/components/content/pages/AddPage.tsx
@@ -122,6 +122,7 @@ function AddPage() {
           currentPlan={user?.organizations[0].plan.name}
           onClose={handleTooManyModalClose}
           open={tooManyModalOpen}
+          recommendedPlan={user?.organizations[0].plan.name === 'FREE' ? 'CORE' : 'PLUS'}
         />
       )}
     </>

--- a/spa/src/constants/helperUrls.ts
+++ b/spa/src/constants/helperUrls.ts
@@ -1,3 +1,4 @@
+export const CORE_UPGRADE_URL = 'https://fundjournalism.org/i-want-revengine-core/';
 export const FAQ_URL = 'https://news-revenue-hub.atlassian.net/servicedesk/customer/portal/11/article/2195423496';
 export const HELP_URL = 'https://fundjournalism.org/news-revenue-engine-help/';
 export const PRICING_URL = 'https://fundjournalism.org/pricing/';


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Updates the URL that the max pages published modal points to for the Core upgrade.

#### Why are we doing this? How does it help us?

Gives users a better path to upgrade.

#### How should this be manually tested? Please include detailed step-by-step instructions.

As a free plan user:

1. Try to create too many pages.
2. Confirm the Upgrade button in the modal that appears goes to the proper URL.

As a Core plan user:

1. Try to create too many pages.
2. Confirm the Upgrade button in the modal that appears goes to the main pricing page.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3456

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.