### PR TITLE
DEV-3390: add subscription settings

### DIFF
--- a/spa/src/components/DashboardRouter.tsx
+++ b/spa/src/components/DashboardRouter.tsx
@@ -56,7 +56,8 @@ function DashboardRouter() {
           ROUTES.VERIFY_EMAIL_SUCCESS,
           ROUTES.PROFILE,
           ROUTES.SETTINGS.INTEGRATIONS,
-          ROUTES.SETTINGS.ORGANIZATION
+          ROUTES.SETTINGS.ORGANIZATION,
+          ROUTES.SETTINGS.SUBSCRIPTION
         ]}
         render={() => <TrackPageView component={Main} />}
       />

--- a/spa/src/components/authentication/ProtectedRoute.test.tsx
+++ b/spa/src/components/authentication/ProtectedRoute.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from 'test-utils';
+import ProtectedRoute, { ProtectedRouteProps } from './ProtectedRoute';
+import isAuthenticated from 'utilities/isAuthenticated';
+import { SIGN_IN } from 'routes';
+
+jest.mock('utilities/isAuthenticated');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Redirect({ to }: { to: string }) {
+    return <div data-testid="mock-redirect">{to}</div>;
+  }
+}));
+jest.mock('hooks/useSentry', () => ({
+  ...jest.requireActual('hooks/useSentry'),
+  SentryRoute: () => <div data-testid="mock-sentry-route" />
+}));
+
+function tree(props?: Partial<ProtectedRouteProps>) {
+  return render(<ProtectedRoute {...props} />);
+}
+
+describe('ProtectedRoute', () => {
+  const isAuthenticatedMock = jest.mocked(isAuthenticated);
+
+  beforeEach(() => isAuthenticatedMock.mockReturnValue(false));
+
+  describe('when the contributor prop is true', () => {
+    it('displays a SentryRoute if the user is authenticated as a contributor', () => {
+      isAuthenticatedMock.mockImplementation((value?: boolean) => !!value);
+      tree({ contributor: true });
+      expect(screen.getByTestId('mock-sentry-route')).toBeInTheDocument();
+    });
+
+    it('displays a signin redirect if the user is authenticated as an admin only', () => {
+      isAuthenticatedMock.mockImplementation((value?: boolean) => !value);
+      tree({ contributor: true });
+      expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
+    });
+
+    it('displays a signin redirect if the user is not authenticated', () => {
+      isAuthenticatedMock.mockReturnValue(false);
+      tree({ contributor: true });
+      expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
+    });
+  });
+
+  describe('when the contributor prop is false', () => {
+    it('displays a SentryRoute if the user is authenticated as an admin', () => {
+      isAuthenticatedMock.mockImplementation((value?: boolean) => !value);
+      tree({ contributor: false });
+      expect(screen.getByTestId('mock-sentry-route')).toBeInTheDocument();
+    });
+
+    it('displays a signin redirect if the user is authenticated as a contributor only', () => {
+      isAuthenticatedMock.mockImplementation((value?: boolean) => !!value);
+      tree({ contributor: false });
+      expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
+    });
+
+    it('displays a signin redirect if the user is not authenticated', () => {
+      isAuthenticatedMock.mockReturnValue(false);
+      tree({ contributor: false });
+      expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
+    });
+  });
+});

--- a/spa/src/components/authentication/ProtectedRoute.tsx
+++ b/spa/src/components/authentication/ProtectedRoute.tsx
@@ -1,19 +1,25 @@
-import { Redirect } from 'react-router-dom';
-
+import { Redirect, RouteProps } from 'react-router-dom';
 import { SentryRoute } from 'hooks/useSentry';
-
-// Routes
 import { SIGN_IN } from 'routes';
 import isAuthenticated from 'utilities/isAuthenticated';
+
+export interface ProtectedRouteProps extends RouteProps {
+  /**
+   * If true, then the user must be a contributor, not an admin, to access this
+   * route.
+   */
+  contributor?: boolean;
+}
 
 /**
  * ProtectedRoute either verifies authentication status or redirects to SIGN_IN.
  * Accepts 'contributor' prop so isAuthenticated can check for the right user type.
  */
-function ProtectedRoute({ contributor, ...props }) {
+function ProtectedRoute({ contributor, ...props }: ProtectedRouteProps) {
   if (isAuthenticated(contributor)) {
     return <SentryRoute {...props} />;
   }
+
   return <Redirect to={SIGN_IN} />;
 }
 

--- a/spa/src/components/dashboard/Dashboard.js
+++ b/spa/src/components/dashboard/Dashboard.js
@@ -44,6 +44,7 @@ import flagIsActiveForUser from 'utilities/flagIsActiveForUser';
 import hasContributionsDashboardAccessToUser from 'utilities/hasContributionsDashboardAccessToUser';
 import { useEffect } from 'react';
 import { PageEditorRedirect } from 'components/pageEditor/PageEditorRedirect';
+import Subscription from 'components/settings/Subscription/Subscription';
 
 function Dashboard() {
   const { enqueueSnackbar } = useSnackbar();
@@ -88,7 +89,6 @@ function Dashboard() {
           <S.DashboardContent>
             <Switch>
               <Redirect exact from={DASHBOARD_SLUG} to={dashboardSlugRedirect} />
-
               {hasContributionsSectionAccess ? (
                 <SentryRoute path={DONATIONS_SLUG}>
                   <Donations />
@@ -122,6 +122,11 @@ function Dashboard() {
               <SentryRoute path={SETTINGS.ORGANIZATION}>
                 <SingleOrgUserOnlyRoute>
                   <Organization />
+                </SingleOrgUserOnlyRoute>
+              </SentryRoute>
+              <SentryRoute path={SETTINGS.SUBSCRIPTION}>
+                <SingleOrgUserOnlyRoute>
+                  <Subscription />
                 </SingleOrgUserOnlyRoute>
               </SentryRoute>
               <SentryRoute path={PROFILE}>

--- a/spa/src/components/settings/Subscription/Subscription.styled.ts
+++ b/spa/src/components/settings/Subscription/Subscription.styled.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;

--- a/spa/src/components/settings/Subscription/Subscription.styled.ts
+++ b/spa/src/components/settings/Subscription/Subscription.styled.ts
@@ -1,4 +1,10 @@
 import styled from 'styled-components';
+import { Link } from 'components/base';
+
+export const PricingLink = styled(Link)`
+  border-bottom: 1px solid ${({ theme }) => theme.colors.muiGrey[100]};
+  padding-bottom: 34px;
+`;
 
 export const Wrapper = styled.div`
   display: flex;

--- a/spa/src/components/settings/Subscription/Subscription.styled.ts
+++ b/spa/src/components/settings/Subscription/Subscription.styled.ts
@@ -1,12 +1,11 @@
 import styled from 'styled-components';
-import { Link } from 'components/base';
 
 export const Downgrade = styled.p`
   /* Gap in main layout is 40px. We want to leave 12px between it and header above it. */
   margin-top: -28px;
 `;
 
-export const PricingLink = styled(Link)`
+export const PricingLinkContainer = styled.p`
   border-bottom: 1px solid ${({ theme }) => theme.colors.muiGrey[100]};
   padding-bottom: 34px;
 `;

--- a/spa/src/components/settings/Subscription/Subscription.styled.ts
+++ b/spa/src/components/settings/Subscription/Subscription.styled.ts
@@ -1,7 +1,17 @@
 import styled from 'styled-components';
 import { Link } from 'components/base';
 
+export const Downgrade = styled.p`
+  /* Gap in main layout is 40px. We want to leave 12px between it and header above it. */
+  margin-top: -28px;
+`;
+
 export const PricingLink = styled(Link)`
+  border-bottom: 1px solid ${({ theme }) => theme.colors.muiGrey[100]};
+  padding-bottom: 34px;
+`;
+
+export const SubscriptionPlanContainer = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.colors.muiGrey[100]};
   padding-bottom: 34px;
 `;

--- a/spa/src/components/settings/Subscription/Subscription.test.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.test.tsx
@@ -1,0 +1,60 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import Subscription from './Subscription';
+import useUser from 'hooks/useUser';
+import { PLAN_LABELS } from 'constants/orgPlanConstants';
+import { HELP_URL, PRICING_URL } from 'constants/helperUrls';
+
+jest.mock('hooks/useUser');
+
+function tree() {
+  return render(<Subscription />);
+}
+
+describe('Subscription', () => {
+  const useUserMock = jest.mocked(useUser);
+
+  beforeEach(() => {
+    useUserMock.mockReturnValue({
+      isError: false,
+      isLoading: false,
+      refetch: jest.fn(),
+      user: { organizations: [{ plan: { name: PLAN_LABELS.FREE } }, { plan: { name: PLAN_LABELS.CORE } }] } as any
+    });
+  });
+
+  it('displays nothing if the user is not available in context', () => {
+    useUserMock.mockReturnValue({ isError: false, isLoading: true, refetch: jest.fn() });
+    tree();
+    expect(document.body.textContent).toBe('');
+  });
+
+  it("displays the plan the user's first organization has", () => {
+    tree();
+    expect(screen.getByText('Free Tier')).toBeVisible();
+  });
+
+  it('displays a link for a pricing comparison', () => {
+    tree();
+
+    const link = screen.getByRole('link', { name: 'View full pricing comparison' });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', PRICING_URL);
+  });
+
+  it('displays a link for help with downgrading or cancelling an account', () => {
+    tree();
+
+    const link = screen.getByRole('link', { name: 'Support' });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', HELP_URL);
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/settings/Subscription/Subscription.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.tsx
@@ -1,0 +1,20 @@
+import HeaderSection from 'components/common/HeaderSection';
+import SettingsSection from 'components/common/SettingsSection';
+import PropTypes, { InferProps } from 'prop-types';
+import { Wrapper } from './Subscription.styled';
+
+const SubscriptionPropTypes = {};
+
+export type SubscriptionProps = InferProps<typeof SubscriptionPropTypes>;
+
+export function Subscription(props: SubscriptionProps) {
+  return (
+    <Wrapper>
+      <HeaderSection title="Settings" />
+      <SettingsSection title="Subscription" subtitle="View and manage your plan." />
+    </Wrapper>
+  );
+}
+
+Subscription.propTypes = SubscriptionPropTypes;
+export default Subscription;

--- a/spa/src/components/settings/Subscription/Subscription.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.tsx
@@ -5,6 +5,7 @@ import { HELP_URL, PRICING_URL } from 'constants/helperUrls';
 import useUser from 'hooks/useUser';
 import SubscriptionPlan from './SubscriptionPlan';
 import { Downgrade, PricingLink, SubscriptionPlanContainer, Wrapper } from './Subscription.styled';
+import SubheaderSection from 'components/common/SubheaderSection';
 
 export function Subscription() {
   const { user } = useUser();
@@ -13,12 +14,15 @@ export function Subscription() {
     return null;
   }
 
+  // This must exist--this route is wrapped by <SingleOrgUserOnlyRoute> by
+  // <Dashboard>.
+
   const firstOrg = user.organizations[0];
 
   return (
     <Wrapper>
       <HeaderSection title="Settings" />
-      <SettingsSection title="Subscription" subtitle="View and manage your plan." />
+      <SubheaderSection title="Subscription" subtitle="View and manage your plan." />
       <SettingsSection hideBottomDivider title="Current Plan" />
       <SubscriptionPlanContainer>
         <SubscriptionPlan plan={firstOrg.plan.name} />

--- a/spa/src/components/settings/Subscription/Subscription.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.tsx
@@ -1,11 +1,10 @@
+import { Link } from 'components/base';
 import HeaderSection from 'components/common/HeaderSection';
 import SettingsSection from 'components/common/SettingsSection';
-import { PricingLink, Wrapper } from './Subscription.styled';
-import { Link } from 'components/base';
 import { HELP_URL, PRICING_URL } from 'constants/helperUrls';
 import useUser from 'hooks/useUser';
 import SubscriptionPlan from './SubscriptionPlan';
-import { PLAN_LABELS } from 'constants/orgPlanConstants';
+import { Downgrade, PricingLink, SubscriptionPlanContainer, Wrapper } from './Subscription.styled';
 
 export function Subscription() {
   const { user } = useUser();
@@ -21,22 +20,25 @@ export function Subscription() {
       <HeaderSection title="Settings" />
       <SettingsSection title="Subscription" subtitle="View and manage your plan." />
       <SettingsSection hideBottomDivider title="Current Plan" />
-      <SubscriptionPlan plan={firstOrg.plan.name} />
+      <SubscriptionPlanContainer>
+        <SubscriptionPlan plan={firstOrg.plan.name} />
+      </SubscriptionPlanContainer>
+      <SettingsSection
+        hideBottomDivider
+        title="Upgrade Plan"
+        subtitle="Increase your customization and insights by upgrading."
+      />
       <PricingLink href={PRICING_URL} target="_blank">
         View full pricing comparison
       </PricingLink>
-      {firstOrg.plan.name !== PLAN_LABELS.FREE && (
-        <>
-          <SettingsSection hideBottomDivider title="Downgrade or Cancel" />
-          <p>
-            To downgrade or cancel your plan, contact{' '}
-            <Link href={HELP_URL} target="_blank">
-              Support
-            </Link>
-            .
-          </p>
-        </>
-      )}
+      <SettingsSection hideBottomDivider title="Downgrade or Cancel" />
+      <Downgrade>
+        To downgrade or cancel your plan, contact{' '}
+        <Link href={HELP_URL} target="_blank">
+          Support
+        </Link>
+        .
+      </Downgrade>
     </Wrapper>
   );
 }

--- a/spa/src/components/settings/Subscription/Subscription.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.tsx
@@ -1,20 +1,44 @@
 import HeaderSection from 'components/common/HeaderSection';
 import SettingsSection from 'components/common/SettingsSection';
-import PropTypes, { InferProps } from 'prop-types';
-import { Wrapper } from './Subscription.styled';
+import { PricingLink, Wrapper } from './Subscription.styled';
+import { Link } from 'components/base';
+import { HELP_URL, PRICING_URL } from 'constants/helperUrls';
+import useUser from 'hooks/useUser';
+import SubscriptionPlan from './SubscriptionPlan';
+import { PLAN_LABELS } from 'constants/orgPlanConstants';
 
-const SubscriptionPropTypes = {};
+export function Subscription() {
+  const { user } = useUser();
 
-export type SubscriptionProps = InferProps<typeof SubscriptionPropTypes>;
+  if (!user) {
+    return null;
+  }
 
-export function Subscription(props: SubscriptionProps) {
+  const firstOrg = user.organizations[0];
+
   return (
     <Wrapper>
       <HeaderSection title="Settings" />
       <SettingsSection title="Subscription" subtitle="View and manage your plan." />
+      <SettingsSection hideBottomDivider title="Current Plan" />
+      <SubscriptionPlan plan={firstOrg.plan.name} />
+      <PricingLink href={PRICING_URL} target="_blank">
+        View full pricing comparison
+      </PricingLink>
+      {firstOrg.plan.name !== PLAN_LABELS.FREE && (
+        <>
+          <SettingsSection hideBottomDivider title="Downgrade or Cancel" />
+          <p>
+            To downgrade or cancel your plan, contact{' '}
+            <Link href={HELP_URL} target="_blank">
+              Support
+            </Link>
+            .
+          </p>
+        </>
+      )}
     </Wrapper>
   );
 }
 
-Subscription.propTypes = SubscriptionPropTypes;
 export default Subscription;

--- a/spa/src/components/settings/Subscription/Subscription.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.tsx
@@ -4,7 +4,7 @@ import SettingsSection from 'components/common/SettingsSection';
 import { HELP_URL, PRICING_URL } from 'constants/helperUrls';
 import useUser from 'hooks/useUser';
 import SubscriptionPlan from './SubscriptionPlan';
-import { Downgrade, PricingLink, SubscriptionPlanContainer, Wrapper } from './Subscription.styled';
+import { Downgrade, PricingLinkContainer, SubscriptionPlanContainer, Wrapper } from './Subscription.styled';
 import SubheaderSection from 'components/common/SubheaderSection';
 
 export function Subscription() {
@@ -32,9 +32,11 @@ export function Subscription() {
         title="Upgrade Plan"
         subtitle="Increase your customization and insights by upgrading."
       />
-      <PricingLink href={PRICING_URL} target="_blank">
-        View full pricing comparison
-      </PricingLink>
+      <PricingLinkContainer>
+        <Link href={PRICING_URL} target="_blank">
+          View full pricing comparison
+        </Link>
+      </PricingLinkContainer>
       <SettingsSection hideBottomDivider title="Downgrade or Cancel" />
       <Downgrade>
         To downgrade or cancel your plan, contact{' '}

--- a/spa/src/components/settings/Subscription/SubscriptionPlan.styled.ts
+++ b/spa/src/components/settings/Subscription/SubscriptionPlan.styled.ts
@@ -1,0 +1,40 @@
+import { EnginePlan } from 'hooks/useContributionPage';
+import styled from 'styled-components';
+
+const planColors = {
+  CORE: '#62ffe3',
+  FREE: '#f2ff59',
+  PLUS: '#f323ff'
+};
+
+export const PlanCost = styled.span`
+  color: ${({ theme }) => theme.colors.black};
+  font-size: ${({ theme }) => theme.fontSizesUpdated[20]};
+  font-weight: 500;
+  position: relative;
+`;
+
+export const PlanCostInterval = styled.span`
+  color: ${({ theme }) => theme.colors.muiGrey[600]};
+  font-size: ${({ theme }) => theme.fontSizesUpdated.sm};
+  font-weight: 400;
+  padding-left: 10px;
+  /*
+  Align to top of other text. Doing this via flexbox seems fiddly due to line
+  height etc.
+  */
+  position: relative;
+  top: -0.25em;
+`;
+
+export const PlanName = styled.span<{ $plan: EnginePlan['name'] }>`
+  background-color: ${({ $plan }) => planColors[$plan as keyof typeof planColors]};
+  color: ${({ theme }) => theme.colors.muiGrey[900]};
+  font: 400 ${({ theme }) => theme.fontSizesUpdated.lg} 'DM Mono', monospace;
+`;
+
+export const Root = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 345px;
+`;

--- a/spa/src/components/settings/Subscription/SubscriptionPlan.test.tsx
+++ b/spa/src/components/settings/Subscription/SubscriptionPlan.test.tsx
@@ -1,0 +1,48 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import { PLAN_ANNUAL_COSTS, PLAN_LABELS, PLAN_NAMES } from 'constants/orgPlanConstants';
+import SubscriptionPlan, { SubscriptionPlanProps } from './SubscriptionPlan';
+
+function tree(props?: Partial<SubscriptionPlanProps>) {
+  return render(<SubscriptionPlan plan={PLAN_LABELS.FREE} {...props} />);
+}
+
+describe('SubscriptionPlan', () => {
+  describe.each([[PLAN_LABELS.FREE], [PLAN_LABELS.CORE]])('When given the %s plan', (plan) => {
+    it('displays the correct plan label', () => {
+      tree({ plan });
+      expect(screen.getByText(`${PLAN_NAMES[plan]} Tier`)).toBeVisible();
+    });
+
+    it('displays the correct annual cost', () => {
+      tree({ plan });
+      expect(screen.getByText(`$${PLAN_ANNUAL_COSTS[plan]}`)).toBeVisible();
+      expect(screen.getByText('/year')).toBeVisible();
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ plan: PLAN_LABELS.FREE });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('When given the PLUS plan', () => {
+    it('displays the correct plan label', () => {
+      tree({ plan: PLAN_LABELS.PLUS });
+      expect(screen.getByText(`${PLAN_NAMES.PLUS} Tier`)).toBeVisible();
+    });
+
+    it("doesn't display an annual cost", () => {
+      tree({ plan: PLAN_LABELS.PLUS });
+      expect(screen.queryByText('$')).not.toBeInTheDocument();
+      expect(screen.queryByText('/year')).not.toBeInTheDocument();
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ plan: PLAN_LABELS.FREE });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/spa/src/components/settings/Subscription/SubscriptionPlan.tsx
+++ b/spa/src/components/settings/Subscription/SubscriptionPlan.tsx
@@ -1,0 +1,27 @@
+import { PLAN_ANNUAL_COSTS, PLAN_NAMES } from 'constants/orgPlanConstants';
+import PropTypes, { InferProps } from 'prop-types';
+import { PlanCost, PlanCostInterval, PlanName, Root } from './SubscriptionPlan.styled';
+import { EnginePlan } from 'hooks/useContributionPage';
+
+const SubscriptionPlanPropTypes = {
+  plan: PropTypes.oneOf(Object.keys(PLAN_NAMES)).isRequired
+};
+
+export type SubscriptionPlanProps = InferProps<typeof SubscriptionPlanPropTypes>;
+
+export function SubscriptionPlan({ plan }: SubscriptionPlanProps) {
+  return (
+    <Root>
+      <PlanName $plan={plan as EnginePlan['name']}>{PLAN_NAMES[plan as EnginePlan['name']]}</PlanName>
+      {plan in PLAN_ANNUAL_COSTS && (
+        <PlanCost>
+          ${PLAN_ANNUAL_COSTS[plan as keyof typeof PLAN_ANNUAL_COSTS]}
+          <PlanCostInterval>/year</PlanCostInterval>
+        </PlanCost>
+      )}
+    </Root>
+  );
+}
+
+SubscriptionPlan.propTypes = SubscriptionPlanPropTypes;
+export default SubscriptionPlan;

--- a/spa/src/components/settings/Subscription/SubscriptionPlan.tsx
+++ b/spa/src/components/settings/Subscription/SubscriptionPlan.tsx
@@ -4,16 +4,17 @@ import { PlanCost, PlanCostInterval, PlanName, Root } from './SubscriptionPlan.s
 import { EnginePlan } from 'hooks/useContributionPage';
 
 const SubscriptionPlanPropTypes = {
+  className: PropTypes.string,
   plan: PropTypes.oneOf(Object.keys(PLAN_NAMES)).isRequired
 };
 
 export type SubscriptionPlanProps = InferProps<typeof SubscriptionPlanPropTypes>;
 
-export function SubscriptionPlan({ plan }: SubscriptionPlanProps) {
+export function SubscriptionPlan({ className, plan }: SubscriptionPlanProps) {
   return (
-    <Root>
-      <PlanName $plan={plan as EnginePlan['name']}>{PLAN_NAMES[plan as EnginePlan['name']]}</PlanName>
-      {plan in PLAN_ANNUAL_COSTS && (
+    <Root className={className!}>
+      <PlanName $plan={plan as EnginePlan['name']}>{PLAN_NAMES[plan as EnginePlan['name']]} Tier</PlanName>
+      {PLAN_ANNUAL_COSTS[plan as keyof typeof PLAN_ANNUAL_COSTS] !== undefined && (
         <PlanCost>
           ${PLAN_ANNUAL_COSTS[plan as keyof typeof PLAN_ANNUAL_COSTS]}
           <PlanCostInterval>/year</PlanCostInterval>

--- a/spa/src/components/settings/Subscription/index.ts
+++ b/spa/src/components/settings/Subscription/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Subscription';

--- a/spa/src/constants/orgPlanConstants.ts
+++ b/spa/src/constants/orgPlanConstants.ts
@@ -1,0 +1,30 @@
+import { EnginePlan } from 'hooks/useContributionPage';
+
+/**
+ * Annual cost of each plan in USD. These are *only* for display purposes. These
+ * are not used for actual billing. Undefined here means that we don't have a
+ * cost to display.
+ */
+export const PLAN_ANNUAL_COSTS: Record<EnginePlan['name'], number | undefined> = {
+  CORE: 2000,
+  FREE: 0,
+  PLUS: undefined
+};
+
+/**
+ * Human-readable names of plans.
+ */
+export const PLAN_NAMES: Record<EnginePlan['name'], string> = {
+  CORE: 'Core',
+  FREE: 'Free',
+  PLUS: 'Plus'
+};
+
+/**
+ * A record of valid plan labels. The values are the same as the keys so you can
+ * write `PLAN_LABELS.FREE` and it will resolve to `'FREE'`.
+ */
+export const PLAN_LABELS = Object.keys(PLAN_NAMES).reduce((result, key) => ({ ...result, [key]: key }), {}) as Record<
+  EnginePlan['name'],
+  EnginePlan['name']
+>;

--- a/spa/src/routes.ts
+++ b/spa/src/routes.ts
@@ -15,8 +15,9 @@ export const PAYMENT_SUCCESS = '/payment/success/';
 
 // Settings
 export const SETTINGS = {
+  INTEGRATIONS: '/settings/integrations',
   ORGANIZATION: '/settings/organization',
-  INTEGRATIONS: '/settings/integrations'
+  SUBSCRIPTION: '/settings/subscription'
 };
 
 // Contributor

--- a/spa/src/utilities/isAuthenticated.js
+++ b/spa/src/utilities/isAuthenticated.js
@@ -1,8 +1,0 @@
-import { LS_CONTRIBUTOR, LS_USER } from 'appSettings';
-
-function isAuthenticated(for_contributor) {
-  if (for_contributor) return localStorage.getItem(LS_CONTRIBUTOR);
-  return localStorage.getItem(LS_USER);
-}
-
-export default isAuthenticated;

--- a/spa/src/utilities/isAuthenticated.test.ts
+++ b/spa/src/utilities/isAuthenticated.test.ts
@@ -1,0 +1,29 @@
+import { LS_CONTRIBUTOR, LS_USER } from 'appSettings';
+import isAuthenticated from './isAuthenticated';
+
+describe('isAuthenticated', () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  describe('when asked for a contributor', () => {
+    it("returns false if there isn't the appropriate local storage key", () => {
+      expect(isAuthenticated(true)).toBe(false);
+    });
+
+    it('returns true if there is the appropriate local storage key', () => {
+      window.localStorage.setItem(LS_CONTRIBUTOR, '');
+      expect(isAuthenticated(true)).toBe(true);
+    });
+  });
+
+  describe('when not asked for a contributor', () => {
+    it("returns false if there isn't the appropriate local storage key", () => {
+      expect(isAuthenticated()).toBe(false);
+    });
+
+    it('returns true if there is the appropriate local storage key', () => {
+      window.localStorage.setItem(LS_USER, '');
+      expect(isAuthenticated()).toBe(true);
+    });
+  });
+});

--- a/spa/src/utilities/isAuthenticated.ts
+++ b/spa/src/utilities/isAuthenticated.ts
@@ -1,0 +1,15 @@
+import { LS_CONTRIBUTOR, LS_USER } from 'appSettings';
+
+/**
+ * Returns whether the user is currently authenticated. **This is only
+ * advisory** because a user could manipulate their browser local storage.
+ */
+function isAuthenticated(forContributor?: boolean): boolean {
+  if (forContributor) {
+    return window.localStorage.getItem(LS_CONTRIBUTOR) !== null;
+  }
+
+  return window.localStorage.getItem(LS_USER) !== null;
+}
+
+export default isAuthenticated;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Adds a route at `/settings/subscription` that shows the user their current plan. This route is only accessibly directly by URL in this PR. Note that the PR doesn't implement the entire page as it appears in Figma. See Jira discussion.
- Converts some related modules to TypeScript and adds tests around them.

#### Why are we doing this? How does it help us?

Part of our Core plan work, and continues the TS/Jest migration.

#### How should this be manually tested? Please include detailed step-by-step instructions.

Happy path, for an org admin:

1. Visit `/settings/subscription/`.
2. Confirm the plan shown and its pricing is accurate.
3. Confirm the "View full pricing comparison" link opens in a new window and goes to our pricing page.
4. Confirm the "Support" link under "Downgrade or Cancel" goes to the support page.
5. Repeat steps 1-4 for orgs with all pricing plans. The Plus plan should show no cost (not free--just omit the pricing).

Route isn't viewable by Hub admins:

1. Visit `/settings/subscription/`.
2. Confirm you get redirected to the pages dashboard.
 
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

We'd want to document this settings page.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

Via documentation.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3390

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No. This change isn't linked anywhere yet.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

https://news-revenue-hub.atlassian.net/browse/DEV-3396