### PR TITLE
DEV-3443: Make address block deletable in list view

### DIFF
--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -258,11 +258,11 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
     page = serializers.PrimaryKeyRelatedField(many=False, queryset=DonationPage.objects.all(), write_only=True)
     first_name = serializers.CharField(max_length=40, write_only=True)
     last_name = serializers.CharField(max_length=80, write_only=True)
-    mailing_postal_code = serializers.CharField(max_length=20, write_only=True)
-    mailing_street = serializers.CharField(max_length=255, write_only=True)
-    mailing_city = serializers.CharField(max_length=40, write_only=True)
-    mailing_state = serializers.CharField(max_length=80, write_only=True)
-    mailing_country = serializers.CharField(max_length=80, write_only=True)
+    mailing_postal_code = serializers.CharField(max_length=20, write_only=True, required=False, default="")
+    mailing_street = serializers.CharField(max_length=255, write_only=True, required=False, default="")
+    mailing_city = serializers.CharField(max_length=40, write_only=True, required=False, default="")
+    mailing_state = serializers.CharField(max_length=80, write_only=True, required=False, default="")
+    mailing_country = serializers.CharField(max_length=80, write_only=True, required=False, default="")
     agreed_to_pay_fees = serializers.BooleanField(default=False, write_only=True)
 
     # See class-level doc string for info on why `default=''` here

--- a/spa/cypress/e2e/01-donationPage.cy.js
+++ b/spa/cypress/e2e/01-donationPage.cy.js
@@ -65,7 +65,8 @@ describe('Donation page displays dynamic page elements', () => {
 
       cy.contains(freq.displayName).click();
       cy.getByTestId('d-amount').find('h2').contains(adjective);
-      cy.getByTestId('pay-fees').scrollIntoView().find('label').contains(adjective, { matchCase: false });
+      cy.getByTestId('pay-fees').scrollIntoView();
+      cy.getByTestId('pay-fees').find('label').contains(adjective, { matchCase: false });
 
       if (rate) {
         cy.getByTestId('custom-amount-rate').contains(rate);
@@ -82,7 +83,8 @@ describe('Donation page displays dynamic page elements', () => {
       amounts.content.options[freq.value].forEach((amount) => {
         cy.contains(amount).click();
         const calculatedFee = calculateStripeFee(amount, freq.value, true);
-        cy.getByTestId('pay-fees').scrollIntoView().find('label').contains(calculatedFee);
+        cy.getByTestId('pay-fees').scrollIntoView();
+        cy.getByTestId('pay-fees').find('label').contains(calculatedFee);
       });
     });
   });

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
@@ -197,7 +197,7 @@ DDonorAddress.propTypes = DDonorAddressPropTypes;
 DDonorAddress.type = 'DDonorAddress';
 DDonorAddress.displayName = 'Contributor Address';
 DDonorAddress.description = 'Collect contributor address';
-DDonorAddress.required = true;
+DDonorAddress.required = false;
 DDonorAddress.unique = true;
 
 export default DDonorAddress;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
This is the second of 2 stacked PRs:
1. https://github.com/newsrevenuehub/rev-engine/pull/1093
2. This one

#### What's this PR do?
- Make address block deletable from list view

#### Why are we doing this? How does it help us?
Making address more flexible for contributions that don't need to know this information.

#### How should this be manually tested? Please include detailed step-by-step instructions.
- Make a contribution to an existing page with the address block.
- Edit that donation page, remove the address block, and save the page.
- Make another contribution and make sure everything works as expected.
- Add the address block once again, save, and make a contribution. Should still work as expected
- Create a new donation page, address block should initially be in the page.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
yes

#### Have automated unit tests been added? If not, why?
n/a

#### How should this change be communicated to end users?
Address block now deletable from donation pages

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-3443

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
Not a next step, but it's a related ticket https://news-revenue-hub.atlassian.net/browse/DEV-3442 