### PR TITLE
DEV-3322: FIPS code -> ISO code for countries

### DIFF
--- a/spa/cypress/e2e/01-donationPage.cy.js
+++ b/spa/cypress/e2e/01-donationPage.cy.js
@@ -1,3 +1,6 @@
+// FIXME in DEV-3494
+/* eslint-disable cypress/unsafe-to-chain-command */
+
 import { LIVE_PAGE_DETAIL, AUTHORIZE_STRIPE_PAYMENT_ROUTE } from 'ajax/endpoints';
 import { PAYMENT_SUCCESS } from 'routes';
 import { getPaymentSuccessUrl, getPaymentElementButtonText } from 'components/paymentProviders/stripe/stripeFns';

--- a/spa/cypress/e2e/02-donationPageEdit.cy.js
+++ b/spa/cypress/e2e/02-donationPageEdit.cy.js
@@ -1,3 +1,6 @@
+// FIXME in DEV-3494
+/* eslint-disable cypress/unsafe-to-chain-command */
+
 // Util
 import { getEndpoint } from '../support/util';
 

--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -118,7 +118,7 @@
         "eslint": "^7.25.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-chai-friendly": "^0.7.2",
-        "eslint-plugin-cypress": "^2.12.1",
+        "eslint-plugin-cypress": "^2.13.2",
         "history": "^5.3.0",
         "http-proxy-middleware": "^2.0.6",
         "jest-axe": "^6.0.0",
@@ -19167,9 +19167,9 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
-      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.2.tgz",
+      "integrity": "sha512-LlwjnBTzuKuC0A4H0RxVjs0YeAWK+CD1iM9Dp8un3lzT713ePQxfpPstCD+9HSAss8emuE3b2hCNUST+NrUwKw==",
       "dev": true,
       "dependencies": {
         "globals": "^11.12.0"
@@ -51216,9 +51216,9 @@
       "requires": {}
     },
     "eslint-plugin-cypress": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
-      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.2.tgz",
+      "integrity": "sha512-LlwjnBTzuKuC0A4H0RxVjs0YeAWK+CD1iM9Dp8un3lzT713ePQxfpPstCD+9HSAss8emuE3b2hCNUST+NrUwKw==",
       "dev": true,
       "requires": {
         "globals": "^11.12.0"

--- a/spa/package.json
+++ b/spa/package.json
@@ -159,7 +159,7 @@
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-chai-friendly": "^0.7.2",
-    "eslint-plugin-cypress": "^2.12.1",
+    "eslint-plugin-cypress": "^2.13.2",
     "history": "^5.3.0",
     "http-proxy-middleware": "^2.0.6",
     "jest-axe": "^6.0.0",

--- a/spa/src/components/base/Select/CountrySelect.test.tsx
+++ b/spa/src/components/base/Select/CountrySelect.test.tsx
@@ -3,13 +3,13 @@ import { axe } from 'jest-axe';
 import { render, screen } from 'test-utils';
 import CountrySelect, { CountrySelectProps } from './CountrySelect';
 
-// This mock is to test that the select sorts on country name, not FIPS code.
+// This mock is to test that the select sorts on country name, not ISO code.
 
 jest.mock('country-code-lookup', () => ({
   countries: [
-    { country: 'CCC', fips: 'cc' },
-    { country: 'AAA', fips: 'bb' },
-    { country: 'BBB', fips: 'aa' }
+    { country: 'CCC', iso2: 'cc' },
+    { country: 'AAA', iso2: 'bb' },
+    { country: 'BBB', iso2: 'aa' }
   ]
 }));
 
@@ -33,7 +33,7 @@ describe('CountrySelect', () => {
   });
 
   it('selects the correct option based on the value prop', () => {
-    // Set the value to a FIPS code--note mocked country named BBB has FIPS code
+    // Set the value to an ISO code--note mocked country named BBB has ISO code
     // aa.
     tree({ value: 'aa' });
 
@@ -53,7 +53,7 @@ describe('CountrySelect', () => {
       tree({ onChange });
       expect(onChange).not.toBeCalled();
       userEvent.type(screen.getByTestId('autofill-proxy'), 'BBB');
-      expect(onChange.mock.calls).toEqual([[expect.anything(), { fipsCode: 'aa', label: 'BBB' }, 'select-option']]);
+      expect(onChange.mock.calls).toEqual([[expect.anything(), { isoCode: 'aa', label: 'BBB' }, 'select-option']]);
     });
 
     it("doesn't call onChange if the value doesn't match an option", () => {

--- a/spa/src/components/base/Select/CountrySelect.tsx
+++ b/spa/src/components/base/Select/CountrySelect.tsx
@@ -5,7 +5,7 @@ import { SearchableSelect, SearchableSelectProps } from './SearchableSelect';
 
 export interface CountryOption {
   label: string;
-  fipsCode: string;
+  isoCode: string;
 }
 
 export interface CountrySelectProps extends Omit<SearchableSelectProps<CountryOption>, 'options' | 'value'> {
@@ -13,13 +13,13 @@ export interface CountrySelectProps extends Omit<SearchableSelectProps<CountryOp
 }
 
 const options: CountryOption[] = countryCodes.countries
-  .filter(({ fips }) => fips !== '')
-  .map(({ fips, country }) => ({ label: country, fipsCode: fips }))
+  .filter(({ iso2 }) => iso2 !== '')
+  .map(({ iso2, country }) => ({ label: country, isoCode: iso2 }))
   .sort((a, b) => a.label.localeCompare(b.label));
 
 export function CountrySelect(props: CountrySelectProps) {
-  const { value: fipsValue, ...rest } = props;
-  const selected = useMemo(() => options.find(({ fipsCode }) => fipsValue === fipsCode), [fipsValue]);
+  const { value: isoValue, ...rest } = props;
+  const selected = useMemo(() => options.find(({ isoCode }) => isoCode === isoValue), [isoValue]);
 
   // Browser autofill doesn't play well with the MUI Autocomplete component, so
   // we render a hidden text input that browsers *will* autofill. When the input

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
@@ -11,8 +11,8 @@ import DDonorAddress, { DDonorAddressProps } from './DDonorAddress';
 
 jest.mock('country-code-lookup', () => ({
   countries: [
-    { country: 'AAA', fips: 'aaa' },
-    { country: 'BBB', fips: 'bbb' }
+    { country: 'AAA', iso2: 'aa' },
+    { country: 'BBB', iso2: 'bb' }
   ]
 }));
 jest.mock('react-google-autocomplete');
@@ -148,19 +148,19 @@ describe('DDonorAddress', () => {
   });
 
   describe('The Country select', () => {
-    it('displays a country select that shows the mailingCountry FIPS code set in context', () => {
-      tree({ mailingCountry: 'aaa' });
+    it('displays a country select that shows the mailingCountry ISO code set in context', () => {
+      tree({ mailingCountry: 'aa' });
       expect(screen.getByRole('textbox', { name: 'Country' })).toHaveValue('AAA');
     });
 
-    it('updates the country FIPS code in context when the user selects a country', () => {
+    it('updates the country ISO code in context when the user selects a country', () => {
       const setMailingCountry = jest.fn();
 
       tree({ setMailingCountry });
       userEvent.click(screen.getByLabelText('Open'));
       expect(setMailingCountry).not.toBeCalled();
       userEvent.click(screen.getByText('BBB'));
-      expect(setMailingCountry.mock.calls).toEqual([['bbb']]);
+      expect(setMailingCountry.mock.calls).toEqual([['bb']]);
     });
   });
 

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
@@ -79,13 +79,13 @@ function DDonorAddress({ element }: DDonorAddressProps) {
       }
 
       const addrFields = mapAddressComponentsToAddressFields(address_components);
-      const fips = address_components.find(({ types }) => types.includes('country'))?.short_name ?? '';
+      const isoCountry = address_components.find(({ types }) => types.includes('country'))?.short_name ?? '';
 
       setAddress(addrFields.address ?? '');
       setCity(addrFields.city ?? '');
       setState(addrFields.state ?? '');
       setZip(addrFields.zip ?? '');
-      setMailingCountry(fips);
+      setMailingCountry(isoCountry);
     }
   });
 
@@ -110,7 +110,7 @@ function DDonorAddress({ element }: DDonorAddressProps) {
   // underlying input will always show the label.
 
   function handleChangeCountry(event: ChangeEvent<Record<never, never>>, value: CountryOption) {
-    setMailingCountry(value.fipsCode);
+    setMailingCountry(value.isoCode);
   }
 
   return (

--- a/spa/src/hooks/useContributionPage/useContributionPage.types.ts
+++ b/spa/src/hooks/useContributionPage/useContributionPage.types.ts
@@ -436,7 +436,7 @@ export interface ContributionPage {
    */
   revenue_program: RevenueProgram;
   /**
-   * FIPS code of the country that the revenue program belongs to.
+   * ISO-3166 code of the country that the revenue program belongs to.
    */
   revenue_program_country: string;
   /**


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Updates CountrySelect to use ISO-3166-1 alpha-2 country codes instead of FIPS ones.

#### Why are we doing this? How does it help us?

This is what the Stripe API expects (see Jira for more backstory).

#### How should this be manually tested? Please include detailed step-by-step instructions.

This tests countries whose FIPS codes are different from their ISO codes.

1. Go to a contribution page.
2. Fill out fields as usual. Select Spain as your country. (The address fields don't need to match up to a real address in Spain.)
3. Confirm you're able to complete the contribution as normal.
4. Repeat steps 1-3, but selecting Poland as the country.
5. Repeat steps 1-3, but selecting United Kingdom as the country.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

CI started flagging some Cypress issues that aren't related to this PR. To keep scope on this small, I created a followup story to address those and temporarily disabled them.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3322

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.