### PR TITLE
DEV-2956: Fix color of contributor dashboard table rows

### DIFF
--- a/spa/src/components/base/Table/TableRow.tsx
+++ b/spa/src/components/base/Table/TableRow.tsx
@@ -3,16 +3,17 @@ import styled from 'styled-components';
 
 export const TableRow = styled(MuiTableRow)`
   && {
+    background-color: ${({ theme }) => theme.basePalette.greyscale.white};
     border: none;
   }
 
   &&:hover,
   &&:nth-child(odd):hover {
-    background-color: #bcd3f5;
+    background-color: ${({ theme }) => theme.colors.tableRowHover};
   }
 
   &&:nth-child(odd) {
-    background-color: #f1f1f1;
+    background-color: ${({ theme }) => theme.basePalette.greyscale.grey3};
   }
 `;
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Fixes styles in the table base component to use a white background for even rows instead of being transparent.

#### Why are we doing this? How does it help us?

Fixes appearance of donation table on styled contributor portal pages.

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Edit a revenue program's default page and assign it background colors (both main background and form panel background).
2. Make at least two contributions using the page.
3. Sign into the contributor portal for the revenue program.
4. Confirm that table of contributions looks correct (e.g. always gray/white background colors).
5. Repeat steps 1-4 for a revenue program whose default page uses the default style.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No, this is CSS only.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2956

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.