### PR TITLE
Dev 3177 integrations callout details links and details modals

### DIFF
--- a/spa/src/components/base/IconList/IconList.stories.tsx
+++ b/spa/src/components/base/IconList/IconList.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ReactComponent as Mail } from '@material-design-icons/svg/filled/mail.svg';
+import { ReactComponent as GroupAdd } from '@material-design-icons/svg/filled/group_add.svg';
+import { ReactComponent as Diversity } from '@material-design-icons/svg/filled/diversity_2.svg';
+
+import IconList, { IconListProps } from './IconList';
+
+export default {
+  component: IconList,
+  title: 'Base/IconList'
+} as ComponentMeta<typeof IconList>;
+
+const Template: ComponentStory<typeof IconList> = (props: IconListProps) => <IconList {...props} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  list: [
+    { icon: <Mail />, text: 'Regularly thank, steward and bump up current contributors' },
+    { icon: <GroupAdd />, text: 'Re-engage lapsed donors' },
+    { icon: <Diversity />, text: 'Consistently market to new contributors, segmenting out those who already gave' }
+  ]
+};

--- a/spa/src/components/base/IconList/IconList.styled.ts
+++ b/spa/src/components/base/IconList/IconList.styled.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+export const List = styled.ul`
+  display: flex;
+  padding: 0;
+  flex-direction: column;
+  gap: 26px;
+`;
+
+export const Item = styled.li`
+  display: flex;
+  gap: 10px;
+`;
+
+export const Icon = styled.div`
+  height: 24px;
+  width: 24px;
+  border-radius: 50%;
+  background-color: ${(props) => props.theme.colors.account.purple[1]};
+  fill: ${(props) => props.theme.plan.free.background};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  > svg {
+    height: 16px;
+    width: 16px;
+  }
+`;
+
+export const Text = styled.p`
+  color: ${(props) => props.theme.colors.muiGrey[900]};
+  flex: 1;
+  margin: 0;
+  line-height: 28px;
+`;

--- a/spa/src/components/base/IconList/IconList.test.tsx
+++ b/spa/src/components/base/IconList/IconList.test.tsx
@@ -1,0 +1,47 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import IconList, { IconListProps } from './IconList';
+
+const list = [
+  { icon: 'mock-icon-1', text: 'mock-text-1' },
+  { icon: 'mock-icon-2', text: 'mock-text-2' },
+  { icon: 'mock-icon-3', text: 'mock-text-3' }
+];
+
+function tree(props?: Partial<IconListProps>) {
+  return render(<IconList list={list} {...props} />);
+}
+
+describe('IconList', () => {
+  it('renders nothing if list is empty', () => {
+    tree({ list: [] });
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('renders list', () => {
+    tree();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+  });
+
+  it('displays icons', () => {
+    tree();
+    expect(screen.getAllByTestId('list-item-icon')).toHaveLength(3);
+    expect(screen.getByText('mock-icon-1')).toBeInTheDocument();
+    expect(screen.getByText('mock-icon-2')).toBeInTheDocument();
+    expect(screen.getByText('mock-icon-3')).toBeInTheDocument();
+  });
+
+  it('displays texts', () => {
+    tree();
+    expect(screen.getAllByTestId('list-item-text')).toHaveLength(3);
+    expect(screen.getByText('mock-text-1')).toBeInTheDocument();
+    expect(screen.getByText('mock-text-2')).toBeInTheDocument();
+    expect(screen.getByText('mock-text-3')).toBeInTheDocument();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/IconList/IconList.tsx
+++ b/spa/src/components/base/IconList/IconList.tsx
@@ -1,0 +1,30 @@
+import PropTypes, { InferProps } from 'prop-types';
+import { Icon, Item, List, Text } from './IconList.styled';
+
+export type IconListProps = InferProps<typeof IconListPropTypes>;
+
+export const IconList = ({ list }: IconListProps) => {
+  if (list?.length === 0) return null;
+
+  return (
+    <List data-testid="list-item">
+      {list!.map(({ icon, text }) => (
+        <Item key={text}>
+          <Icon data-testid="list-item-icon">{icon}</Icon>
+          <Text data-testid="list-item-text">{text}</Text>
+        </Item>
+      ))}
+    </List>
+  );
+};
+
+const IconListPropTypes = {
+  list: PropTypes.arrayOf(
+    PropTypes.shape({
+      icon: PropTypes.node.isRequired,
+      text: PropTypes.string.isRequired
+    }).isRequired
+  )
+};
+
+export default IconList;

--- a/spa/src/components/base/Link/Link.tsx
+++ b/spa/src/components/base/Link/Link.tsx
@@ -8,6 +8,7 @@ export type LinkProps = MuiLinkProps;
  */
 export const Link = styled(MuiLink)`
   && {
+    cursor: pointer;
     color: ${({ theme }) => theme.basePalette.secondary.hyperlink};
     font-weight: 500;
 

--- a/spa/src/components/base/Modal/ModalHeader.tsx
+++ b/spa/src/components/base/Modal/ModalHeader.tsx
@@ -16,6 +16,7 @@ export interface ModalHeaderProps extends InferProps<typeof ModalHeaderPropTypes
 }
 
 const CloseButton = styled(IconButton)`
+  align-self: baseline;
   color: ${({ theme }) => theme.basePalette.greyscale.grey2};
   height: 24px;
   width: 24px;

--- a/spa/src/components/base/index.ts
+++ b/spa/src/components/base/index.ts
@@ -3,6 +3,7 @@ export * from './Checkbox/Checkbox';
 export * from './ColorPicker/ColorPicker';
 export * from './EditableList/EditableList';
 export * from './FormControlLabel/FormControlLabel';
+export * from './IconList/IconList';
 export * from './Link/Link';
 export * from './LinkButton/LinkButton';
 export * from './MenuItem/MenuItem';

--- a/spa/src/components/common/IntegrationCard/IntegrationCard.styled.ts
+++ b/spa/src/components/common/IntegrationCard/IntegrationCard.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import LaunchMui from '@material-ui/icons/Launch';
+import { Link as BaseLink } from 'components/base';
 
 export const Flex = styled.div`
   display: flex;
@@ -19,69 +19,13 @@ export const Flex = styled.div`
   }
 `;
 
-export const Header = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  position: relative;
-`;
-
-export const Image = styled.img`
-  height: 55px;
-  width: 55px;
-  border-radius: ${(props) => props.theme.muiBorderRadius.lg};
-`;
-
-export const Required = styled.p`
-  margin: 0;
-  position: absolute;
-  font-weight: 500;
-  top: 0;
-  right: 0;
-  font-size: ${(props) => props.theme.fontSizesUpdated.sm};
-  color: ${(props) => props.theme.colors.error.primary};
-`;
-
-export const CornerMessage = styled.div`
-  margin: 0;
-  position: absolute;
-  font-weight: 500;
-  top: 0;
-  right: 0;
-  font-size: ${(props) => props.theme.fontSizesUpdated.sm};
-  color: ${(props) => props.theme.colors.topbarBackground};
-`;
-
 export const Content = styled.div`
   flex-grow: 1;
   margin-top: 15px;
   margin-bottom: 15px;
   display: flex;
   flex-direction: column;
-  gap: 15px;
-`;
-
-export const Site = styled.a`
-  display: flex;
-  align-items: center;
-  text-decoration: none;
-  font-size: ${(props) => props.theme.fontSizesUpdated.sm};
-  color: ${(props) => props.theme.colors.muiGrey[600]};
-  cursor: pointer;
-
-  &:hover {
-    color: ${(props) => props.theme.colors.muiGrey[600]};
-    text-decoration: none;
-  }
-`;
-
-export const LaunchIcon = styled(LaunchMui)`
-  && {
-    color: ${(props) => props.theme.colors.muiGrey[600]};
-    margin-left: 5px;
-    height: 16px;
-    width: 16px;
-  }
+  gap: 5px;
 `;
 
 export const Description = styled.p`
@@ -115,9 +59,9 @@ export const Footer = styled.div<{ $active: boolean }>`
   }
 `;
 
-export const Title = styled.p`
-  font-size: ${(props) => props.theme.fontSizesUpdated.lg};
-  color: ${(props) => props.theme.colors.muiGrey[900]};
-  font-weight: 500;
-  margin: 0;
+export const Link = styled(BaseLink)`
+  && {
+    text-decoration: underline;
+    font-weight: 500;
+  }
 `;

--- a/spa/src/components/common/IntegrationCard/IntegrationCard.test.tsx
+++ b/spa/src/components/common/IntegrationCard/IntegrationCard.test.tsx
@@ -4,6 +4,8 @@ import { render, screen, waitFor } from 'test-utils';
 
 import IntegrationCard, { IntegrationCardProps } from './IntegrationCard';
 
+jest.mock('./IntegrationCardHeader/IntegrationCardHeader');
+
 const card = {
   image: 'mock-logo',
   title: 'mock-title',
@@ -21,27 +23,41 @@ describe('Integration Card', () => {
     return render(<IntegrationCard {...card} {...props} />);
   }
 
-  it('should render texts on card', () => {
+  it('should render description on card', () => {
     tree();
 
-    expect(screen.getByText(card.title)).toBeInTheDocument();
     expect(screen.getByText(card.description)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: card.site.label })).toHaveAttribute('href', card.site.url);
   });
 
-  it('should render image', () => {
+  it('should render view details if onViewDetails is a function', () => {
+    tree({ onViewDetails: jest.fn() });
+
+    expect(screen.getByRole('link', { name: 'View Details' })).toBeInTheDocument();
+  });
+
+  it('should not render view details by default', () => {
     tree();
-    expect(screen.getByRole('img', { name: `${card.title} logo` })).toHaveAttribute('src', card.image);
+
+    expect(screen.queryByRole('link', { name: 'View Details' })).not.toBeInTheDocument();
   });
 
-  it('should render required tag', () => {
-    tree();
-    expect(screen.getByText('*Required')).toBeVisible();
-  });
+  it('should render card header', () => {
+    const headerProps = {
+      image: 'mock-image',
+      title: 'mock-title',
+      site: {
+        label: 'mock-label',
+        url: 'mock-url'
+      },
+      isRequired: true,
+      isActive: true,
+      enableCornerMessage: true,
+      cornerMessage: 'mock-corner-message'
+    };
+    tree(headerProps);
 
-  it('should render corner message', () => {
-    tree({ isRequired: false, cornerMessage: 'mock-corner-message' });
-    expect(screen.getByText('mock-corner-message')).toBeVisible();
+    expect(screen.getByTestId('mock-integration-card-header')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-integration-card-header-props')).toHaveTextContent(JSON.stringify(headerProps));
   });
 
   it('should render active state', () => {

--- a/spa/src/components/common/IntegrationCard/IntegrationCard.tsx
+++ b/spa/src/components/common/IntegrationCard/IntegrationCard.tsx
@@ -2,54 +2,34 @@ import { Switch, SwitchProps, Tooltip } from 'components/base';
 import useModal from 'hooks/useModal';
 import PropTypes, { InferProps } from 'prop-types';
 
-import {
-  Title,
-  Flex,
-  Required,
-  CornerMessage,
-  Header,
-  Image,
-  Content,
-  Site,
-  Description,
-  Footer,
-  LaunchIcon
-} from './IntegrationCard.styled';
+import { Flex, Content, Description, Footer, Link } from './IntegrationCard.styled';
+import IntegrationCardHeader from './IntegrationCardHeader';
 
 export interface IntegrationCardProps extends InferProps<typeof IntegrationCardPropTypes> {
   onChange?: SwitchProps['onChange'];
 }
 
-const IntegrationCard = ({ className, isActive, onChange, ...card }: IntegrationCardProps) => {
+const IntegrationCard = ({ className, isActive, onChange, onViewDetails, ...card }: IntegrationCardProps) => {
   const { open: showTooltip, handleClose: handleCloseTooltip, handleOpen: handleOpenTooltip } = useModal();
-  const showCornerMessage = card.isRequired || !!card.cornerMessage;
-
-  const renderCornerMessage = (showMessage: boolean) => {
-    if (!showMessage) return null;
-    if (card.isRequired) {
-      return <Required>*Required</Required>;
-    }
-    if (card.cornerMessage && !isActive) {
-      return <CornerMessage>{card.cornerMessage}</CornerMessage>;
-    }
-    return null;
-  };
 
   return (
     <Flex className={className!} data-testid="integration-card">
-      <Header>
-        <Image src={card.image} aria-label={`${card.title} logo`} />
-        <Title>{card.title}</Title>
-        {renderCornerMessage(showCornerMessage)}
-      </Header>
+      <IntegrationCardHeader
+        image={card.image}
+        title={card.title}
+        site={card.site}
+        isRequired={card.isRequired}
+        isActive={isActive}
+        enableCornerMessage={true}
+        cornerMessage={card.cornerMessage}
+      />
       <Content>
-        <div style={{ display: 'flex' }}>
-          <Site href={card.site.url} rel="noopener noreferrer" target="_blank">
-            {card.site.label}
-            <LaunchIcon />
-          </Site>
-        </div>
         <Description>{card.description}</Description>
+        {onViewDetails && (
+          <Link role="link" onClick={onViewDetails}>
+            View Details
+          </Link>
+        )}
       </Content>
       <Footer $active={isActive!}>
         <p>{isActive! ? 'Connected' : card.toggleLabel ?? 'Not Connected'}</p>
@@ -97,6 +77,7 @@ const IntegrationCardPropTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool.isRequired,
   isActive: PropTypes.bool,
+  onViewDetails: PropTypes.func,
   onChange: PropTypes.func
 };
 

--- a/spa/src/components/common/IntegrationCard/IntegrationCardHeader/IntegrationCardHeader.styled.ts
+++ b/spa/src/components/common/IntegrationCard/IntegrationCardHeader/IntegrationCardHeader.styled.ts
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+import LaunchMui from '@material-ui/icons/Launch';
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+`;
+
+export const Image = styled.img`
+  height: 55px;
+  width: 55px;
+  border-radius: ${(props) => props.theme.muiBorderRadius.lg};
+`;
+
+export const Required = styled.p`
+  margin: 0;
+  position: absolute;
+  font-weight: 500;
+  top: 0;
+  right: 0;
+  font-size: ${(props) => props.theme.fontSizesUpdated.sm};
+  color: ${(props) => props.theme.colors.error.primary};
+`;
+
+export const CornerMessage = styled.div`
+  margin: 0;
+  position: absolute;
+  font-weight: 500;
+  top: 0;
+  right: 0;
+  font-size: ${(props) => props.theme.fontSizesUpdated.sm};
+  color: ${(props) => props.theme.colors.topbarBackground};
+`;
+
+export const Site = styled.a`
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  font-size: ${(props) => props.theme.fontSizesUpdated.sm};
+  color: ${(props) => props.theme.colors.muiGrey[600]};
+  cursor: pointer;
+
+  &:hover {
+    color: ${(props) => props.theme.colors.muiGrey[600]};
+    text-decoration: none;
+  }
+`;
+
+export const LaunchIcon = styled(LaunchMui)`
+  && {
+    color: ${(props) => props.theme.colors.muiGrey[600]};
+    margin-left: 5px;
+    height: 16px;
+    width: 16px;
+  }
+`;
+
+export const Title = styled.p`
+  font-size: ${(props) => props.theme.fontSizesUpdated.lg};
+  color: ${(props) => props.theme.colors.muiGrey[900]};
+  font-weight: 500;
+  margin: 0;
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+`;

--- a/spa/src/components/common/IntegrationCard/IntegrationCardHeader/IntegrationCardHeader.test.tsx
+++ b/spa/src/components/common/IntegrationCard/IntegrationCardHeader/IntegrationCardHeader.test.tsx
@@ -1,0 +1,57 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+
+import IntegrationCardHeader, { IntegrationCardHeaderProps } from './IntegrationCardHeader';
+
+const card = {
+  image: 'mock-logo',
+  title: 'mock-title',
+  isRequired: true,
+  site: {
+    label: 'mock-label',
+    url: 'mock-url'
+  }
+};
+
+describe('Integration Card', () => {
+  function tree(props?: Partial<IntegrationCardHeaderProps>) {
+    return render(<IntegrationCardHeader {...card} {...props} />);
+  }
+
+  it('should render texts on card header', () => {
+    tree();
+
+    expect(screen.getByText(card.title)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: card.site.label })).toHaveAttribute('href', card.site.url);
+  });
+
+  it('should render image', () => {
+    tree();
+    expect(screen.getByRole('img', { name: `${card.title} logo` })).toHaveAttribute('src', card.image);
+  });
+
+  it('should render required tag if enableCornerMessage = true', () => {
+    tree({ enableCornerMessage: true });
+    expect(screen.getByText('*Required')).toBeVisible();
+  });
+
+  it('should not render required tag by default', () => {
+    tree();
+    expect(screen.queryByText('*Required')).not.toBeInTheDocument();
+  });
+
+  it('should render corner message if enableCornerMessage = true', () => {
+    tree({ isRequired: false, cornerMessage: 'mock-corner-message', enableCornerMessage: true });
+    expect(screen.getByText('mock-corner-message')).toBeVisible();
+  });
+
+  it('should not render corner message by default', () => {
+    tree({ isRequired: false, cornerMessage: 'mock-corner-message' });
+    expect(screen.queryByText('mock-corner-message')).not.toBeInTheDocument();
+  });
+
+  it('should be accessible', async () => {
+    const { container } = tree();
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/common/IntegrationCard/IntegrationCardHeader/IntegrationCardHeader.tsx
+++ b/spa/src/components/common/IntegrationCard/IntegrationCardHeader/IntegrationCardHeader.tsx
@@ -1,0 +1,70 @@
+import PropTypes, { InferProps } from 'prop-types';
+
+import {
+  Header,
+  Image,
+  Required,
+  CornerMessage,
+  Site,
+  LaunchIcon,
+  Title,
+  TitleWrapper
+} from './IntegrationCardHeader.styled';
+
+export type IntegrationCardHeaderProps = InferProps<typeof IntegrationCardPropTypes>;
+
+const IntegrationCardHeader = ({
+  isActive = false,
+  enableCornerMessage = false,
+  isRequired,
+  cornerMessage,
+  title,
+  image,
+  site
+}: IntegrationCardHeaderProps) => {
+  const showCornerMessage = (isRequired || !!cornerMessage) && enableCornerMessage!;
+
+  const renderCornerMessage = (showMessage: boolean) => {
+    if (!showMessage) return null;
+    if (isRequired) {
+      return <Required>*Required</Required>;
+    }
+    if (cornerMessage && !isActive) {
+      return <CornerMessage>{cornerMessage}</CornerMessage>;
+    }
+    return null;
+  };
+
+  return (
+    <Header>
+      <Image src={image} aria-label={`${title} logo`} />
+      <TitleWrapper>
+        <Title>{title}</Title>
+        <div style={{ display: 'flex' }}>
+          <Site href={site.url} rel="noopener noreferrer" target="_blank">
+            {site.label}
+            <LaunchIcon />
+          </Site>
+        </div>
+      </TitleWrapper>
+      {renderCornerMessage(showCornerMessage)}
+    </Header>
+  );
+};
+
+const IntegrationCardPropTypes = {
+  image: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  isRequired: PropTypes.bool.isRequired,
+  cornerMessage: PropTypes.node,
+  site: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
+  }).isRequired,
+  isActive: PropTypes.bool,
+  enableCornerMessage: PropTypes.bool
+};
+
+IntegrationCardHeader.propTypes = IntegrationCardPropTypes;
+
+export default IntegrationCardHeader;

--- a/spa/src/components/common/IntegrationCard/IntegrationCardHeader/__mocks__/IntegrationCardHeader.tsx
+++ b/spa/src/components/common/IntegrationCard/IntegrationCardHeader/__mocks__/IntegrationCardHeader.tsx
@@ -1,0 +1,7 @@
+const IntegrationCardHeader = (props: any) => (
+  <div data-testid="mock-integration-card-header">
+    <div data-testid="mock-integration-card-header-props">{JSON.stringify(props)}</div>
+  </div>
+);
+
+export default IntegrationCardHeader;

--- a/spa/src/components/common/IntegrationCard/IntegrationCardHeader/index.ts
+++ b/spa/src/components/common/IntegrationCard/IntegrationCardHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './IntegrationCardHeader';

--- a/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpIntegrationCard.test.tsx
+++ b/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpIntegrationCard.test.tsx
@@ -16,7 +16,8 @@ describe('MailchimpIntegrationCard', () => {
       isLoading: false,
       isError: false,
       connectedToMailchimp: false,
-      requiresAudienceSelection: false
+      requiresAudienceSelection: false,
+      hasMailchimpAccess: false
     });
   });
 
@@ -30,7 +31,8 @@ describe('MailchimpIntegrationCard', () => {
       isLoading: false,
       isError: false,
       connectedToMailchimp: true,
-      requiresAudienceSelection: false
+      requiresAudienceSelection: false,
+      hasMailchimpAccess: true
     });
     tree();
 
@@ -42,7 +44,8 @@ describe('MailchimpIntegrationCard', () => {
       isLoading: true,
       isError: false,
       connectedToMailchimp: false,
-      requiresAudienceSelection: false
+      requiresAudienceSelection: false,
+      hasMailchimpAccess: false
     });
     tree();
     expect(screen.getByTestId('cornerMessage')).toBeEmptyDOMElement();
@@ -61,7 +64,8 @@ describe('MailchimpIntegrationCard', () => {
         isError: false,
         connectedToMailchimp: false,
         organizationPlan: organizationPlan as any,
-        requiresAudienceSelection: false
+        requiresAudienceSelection: false,
+        hasMailchimpAccess: true
       });
       tree();
       expect(screen.getByTestId('cornerMessage')).toHaveTextContent('Upgrade to Core');
@@ -81,7 +85,8 @@ describe('MailchimpIntegrationCard', () => {
         isError: false,
         connectedToMailchimp: false,
         organizationPlan: organizationPlan as any,
-        requiresAudienceSelection: false
+        requiresAudienceSelection: false,
+        hasMailchimpAccess: true
       });
       tree();
       expect(screen.getByTestId('cornerMessage')).toBeEmptyDOMElement();
@@ -101,7 +106,8 @@ describe('MailchimpIntegrationCard', () => {
         connectedToMailchimp: false,
         organizationPlan: organizationPlan as any,
         sendUserToMailchimp,
-        requiresAudienceSelection: false
+        requiresAudienceSelection: false,
+        hasMailchimpAccess: true
       });
       tree();
       expect(sendUserToMailchimp).not.toBeCalled();

--- a/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpIntegrationCard.tsx
+++ b/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpIntegrationCard.tsx
@@ -4,35 +4,60 @@ import useConnectMailchimp from 'hooks/useConnectMailchimp';
 
 import IntegrationCard from '../IntegrationCard';
 import { CornerMessage } from './MailchimpIntegrationCard.styled';
+import useModal from 'hooks/useModal';
+import MailchimpModal from './MailchimpModal';
 
 export function MailchimpIntegrationCard() {
-  const { isLoading, sendUserToMailchimp, connectedToMailchimp, organizationPlan = 'FREE' } = useConnectMailchimp();
+  const { open, handleToggle } = useModal();
+  const {
+    isLoading,
+    sendUserToMailchimp,
+    connectedToMailchimp,
+    organizationPlan = 'FREE',
+    hasMailchimpAccess
+  } = useConnectMailchimp();
   const freePlan = organizationPlan === 'FREE';
 
+  const mailchimpHeaderData = {
+    isActive: connectedToMailchimp,
+    isRequired: false,
+    cornerMessage: !isLoading && freePlan && <CornerMessage>Upgrade to Core</CornerMessage>,
+    title: 'Mailchimp',
+    image: MailchimpLogo,
+    site: {
+      label: 'mailchimp.com',
+      url: 'https://www.mailchimp.com'
+    }
+  };
+
   return (
-    <IntegrationCard
-      image={MailchimpLogo}
-      title="Mailchimp"
-      isRequired={false}
-      cornerMessage={!isLoading && freePlan && <CornerMessage>Upgrade to Core</CornerMessage>}
-      site={{
-        label: 'mailchimp.com',
-        url: 'https://www.mailchimp.com'
-      }}
-      description="Create custom segments and automations based on contributor data with the email platform newsrooms trust."
-      disabled={freePlan || isLoading}
-      toggleConnectedTooltipMessage={
-        <>
-          Connected to Mailchimp. Contact{' '}
-          <a href={HELP_URL} style={{ textDecoration: 'underline' }} target="_blank" rel="noreferrer">
-            Support
-          </a>{' '}
-          to disconnect.
-        </>
-      }
-      isActive={connectedToMailchimp}
-      onChange={sendUserToMailchimp}
-    />
+    <>
+      <IntegrationCard
+        {...mailchimpHeaderData}
+        description="Create custom segments and automations based on contributor data with the email platform newsrooms trust."
+        onViewDetails={hasMailchimpAccess ? handleToggle : undefined}
+        onChange={sendUserToMailchimp}
+        disabled={freePlan || isLoading}
+        toggleConnectedTooltipMessage={
+          <>
+            Connected to Mailchimp. Contact{' '}
+            <a href={HELP_URL} style={{ textDecoration: 'underline' }} target="_blank" rel="noreferrer">
+              Support
+            </a>{' '}
+            to disconnect.
+          </>
+        }
+      />
+      {open && (
+        <MailchimpModal
+          open={open}
+          onClose={handleToggle}
+          organizationPlan={organizationPlan}
+          sendUserToMailchimp={sendUserToMailchimp}
+          {...mailchimpHeaderData}
+        />
+      )}
+    </>
   );
 }
 

--- a/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.stories.tsx
+++ b/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.stories.tsx
@@ -1,0 +1,56 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import MailchimpLogo from 'assets/images/mailchimp.png';
+
+import MailchimpModal, { MailchimpModalProps } from './MailchimpModal';
+
+export default {
+  component: MailchimpModal,
+  title: 'Common/IntegrationCard/MailchimpModal'
+} as ComponentMeta<typeof MailchimpModal>;
+
+const Template: ComponentStory<typeof MailchimpModal> = (props: MailchimpModalProps) => <MailchimpModal {...props} />;
+
+export const FreePlan = Template.bind({});
+
+FreePlan.args = {
+  open: true,
+  organizationPlan: 'FREE',
+  isActive: false,
+  isRequired: false,
+  title: 'Mailchimp',
+  image: MailchimpLogo,
+  site: {
+    label: 'mailchimp.com',
+    url: 'https://www.mailchimp.com'
+  }
+};
+
+export const PaidPlanWithMailchimpNotConnected = Template.bind({});
+
+PaidPlanWithMailchimpNotConnected.args = {
+  open: true,
+  organizationPlan: 'CORE',
+  isActive: false,
+  isRequired: false,
+  title: 'Mailchimp',
+  image: MailchimpLogo,
+  site: {
+    label: 'mailchimp.com',
+    url: 'https://www.mailchimp.com'
+  }
+};
+
+export const PaidPlanWithMailchimpConnected = Template.bind({});
+
+PaidPlanWithMailchimpConnected.args = {
+  open: true,
+  organizationPlan: 'PLUS',
+  isActive: true,
+  isRequired: false,
+  title: 'Mailchimp',
+  image: MailchimpLogo,
+  site: {
+    label: 'mailchimp.com',
+    url: 'https://www.mailchimp.com'
+  }
+};

--- a/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.styled.tsx
+++ b/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.styled.tsx
@@ -1,0 +1,37 @@
+import { Button } from 'components/base';
+import styled from 'styled-components';
+
+export const Title = styled.h1`
+  line-height: ${(props) => props.theme.fontSizesUpdated.lg};
+  font-size: ${(props) => props.theme.fontSizesUpdated.lg};
+  font-weight: 600;
+  margin: 0;
+`;
+
+export const InfoIcon = styled.div`
+  height: 24px;
+  width: 24px;
+  color: ${(props) => props.theme.colors.muiLightBlue[800]};
+`;
+
+export const SupportText = styled.p`
+  margin: 35px 0 10px;
+`;
+
+export const CancelButton = styled(Button)`
+  && {
+    min-width: 123px;
+    font-weight: 600;
+    box-shadow: none;
+    border-radius: ${(props) => props.theme.muiBorderRadius.lg};
+  }
+`;
+
+export const ActionButton = styled(Button)`
+  && {
+    min-width: 123px;
+    font-weight: 600;
+    color: ${(props) => props.theme.colors.white};
+    border-radius: ${(props) => props.theme.muiBorderRadius.lg};
+  }
+`;

--- a/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.test.tsx
+++ b/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.test.tsx
@@ -1,0 +1,231 @@
+import { axe } from 'jest-axe';
+import { fireEvent, render, screen } from 'test-utils';
+
+import MailchimpModal, { MailchimpModalProps } from './MailchimpModal';
+import { DONATIONS_SLUG } from 'routes';
+
+jest.mock('../../IntegrationCardHeader/IntegrationCardHeader');
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush
+  })
+}));
+
+const onClose = jest.fn();
+
+const defaultProps = {
+  open: true,
+  onClose,
+  isActive: false,
+  isRequired: false,
+  cornerMessage: 'mock-corner-message',
+  title: 'mock-title',
+  image: 'mock-image',
+  site: {
+    label: 'mock-label',
+    url: 'mock-url'
+  },
+  organizationPlan: 'FREE' as any
+};
+
+describe('MailchimpModal', () => {
+  function tree(props?: Partial<MailchimpModalProps>) {
+    return render(<MailchimpModal {...defaultProps} {...props} />);
+  }
+
+  describe('Organization plan is FREE', () => {
+    it('should render bullet points', () => {
+      tree();
+      expect(screen.getByText('Regularly thank, steward and bump up current contributors.')).toBeVisible();
+      expect(screen.getByText('Re-engage lapsed donors.')).toBeVisible();
+      expect(
+        screen.getByText('Consistently market to new contributors, segmenting out those who already gave.')
+      ).toBeVisible();
+    });
+
+    it('should show upgrade prompt', () => {
+      tree();
+      expect(screen.getByText(/Upgrade for integrated email marketing and more features!/i)).toBeVisible();
+      expect(screen.getByRole('link', { name: 'Learn More' })).toHaveAttribute(
+        'href',
+        // PRICING_URL constant. Link is hardcoded so that if constant is mistakenly changed the test will fail
+        'https://fundjournalism.org/pricing/'
+      );
+    });
+
+    it('should render action buttons', () => {
+      tree();
+      expect(screen.getByRole('link', { name: /Upgrade/i })).toBeEnabled();
+      expect(screen.getByRole('button', { name: /Maybe later/i })).toBeEnabled();
+    });
+
+    it('should link "Upgrade" button to "I want RevEngine Core" page', () => {
+      tree();
+      expect(screen.getByRole('link', { name: /Upgrade/i })).toHaveAttribute(
+        'href',
+        // CORE_UPGRADE_URL constant. Link is hardcoded so that if constant is mistakenly changed the test will fail
+        'https://fundjournalism.org/i-want-revengine-core/'
+      );
+    });
+
+    it('should call onClose', () => {
+      tree();
+
+      const cancelButton = screen.getByRole('button', { name: /Maybe later/i });
+      expect(cancelButton).toBeEnabled();
+
+      fireEvent.click(cancelButton);
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should be accessible', async () => {
+      const { container } = tree();
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('Organization plan is not FREE', () => {
+    describe('Mailchimp is not connected', () => {
+      describe.each(['CORE', 'PLUS'])('%s plan', (plan: any) => {
+        it('should render integration card header', () => {
+          const headerProps = {
+            isActive: false,
+            isRequired: true,
+            cornerMessage: 'mock-corner-message',
+            title: 'mock-title',
+            image: 'mock-image',
+            site: {
+              label: 'mock-label',
+              url: 'mock-url'
+            },
+            enableCornerMessage: false
+          };
+          tree({ organizationPlan: plan, ...headerProps });
+          expect(screen.getByTestId('mock-integration-card-header')).toBeVisible();
+          expect(screen.getByTestId('mock-integration-card-header-props')).toHaveTextContent(
+            JSON.stringify(headerProps)
+          );
+        });
+
+        it('should not render "successfully connected" header', () => {
+          tree({ organizationPlan: plan });
+          expect(screen.queryByText(/Successfully Connected!/i)).not.toBeInTheDocument();
+        });
+
+        it('should render bullet points', () => {
+          tree({ organizationPlan: plan });
+          expect(screen.getByText('Integrate with Mailchimp to', { exact: false })).toBeVisible();
+          expect(screen.getByText('automate targeted', { exact: false })).toBeVisible();
+          expect(screen.getByText('emails.', { exact: false })).toBeVisible();
+          expect(screen.getByText('Regularly thank, steward and bump up current contributors.')).toBeVisible();
+          expect(screen.getByText('Re-engage lapsed donors.')).toBeVisible();
+          expect(
+            screen.getByText('Consistently market to new contributors, segmenting out those who already gave.')
+          ).toBeVisible();
+        });
+
+        it('should render action buttons', () => {
+          tree({ organizationPlan: plan });
+          expect(screen.getByRole('button', { name: /Connect/i })).toBeEnabled();
+          expect(screen.getByRole('button', { name: /Maybe later/i })).toBeEnabled();
+        });
+
+        it('should call "sendUserToMailchimp" when "Connect" button is clicked', () => {
+          const sendUserToMailchimp = jest.fn();
+          tree({ organizationPlan: plan, sendUserToMailchimp });
+          expect(sendUserToMailchimp).not.toHaveBeenCalled();
+          screen.getByRole('button', { name: /Connect/i }).click();
+          expect(sendUserToMailchimp).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call onClose', () => {
+          tree({ organizationPlan: plan });
+          expect(onClose).not.toHaveBeenCalled();
+          fireEvent.click(screen.getByRole('button', { name: /Maybe later/i }));
+          expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('should render "see support" section', () => {
+          tree({ organizationPlan: plan });
+          expect(screen.getByText(/for more integration details and tips./i)).toBeVisible();
+          expect(screen.getByRole('link', { name: /support/i })).toHaveAttribute(
+            'href',
+            // HELP_URL constant. Link is hardcoded so that if constant is mistakenly changed the test will fail
+            'https://fundjournalism.org/news-revenue-engine-help/'
+          );
+        });
+
+        it('should be accessible', async () => {
+          const { container } = tree({ organizationPlan: plan });
+          expect(await axe(container)).toHaveNoViolations();
+        });
+      });
+    });
+
+    describe('Mailchimp is connected', () => {
+      describe.each(['CORE', 'PLUS'])('%s plan', (plan: any) => {
+        it('should not render integration card header', () => {
+          tree({ organizationPlan: plan, isActive: true });
+          expect(screen.queryByTestId('mock-integration-card-header')).not.toBeInTheDocument();
+        });
+
+        it('should render "successfully connected" header', () => {
+          tree({ organizationPlan: plan, isActive: true });
+          expect(screen.getByText(/Successfully Connected!/i)).toBeInTheDocument();
+        });
+
+        it('should render texts', () => {
+          tree({ organizationPlan: plan, isActive: true });
+          expect(screen.getByText('What’s Next?')).toBeVisible();
+          // TODO: add tests for additional texts
+        });
+
+        it('should render action buttons', () => {
+          tree({ organizationPlan: plan, isActive: true });
+          const closeButtons = screen.getAllByRole('button', { name: /close/i });
+          expect(closeButtons).toHaveLength(2);
+          closeButtons.forEach((button) => expect(button).toBeEnabled());
+          expect(screen.getByRole('button', { name: /Go to contributions/i })).toBeEnabled();
+        });
+
+        it('should redirect user to Contributions page when "Go to contributions" is clicked', () => {
+          tree({ organizationPlan: plan, isActive: true });
+          expect(mockHistoryPush).not.toHaveBeenCalled();
+          screen.getByRole('button', { name: /Go to contributions/i }).click();
+          expect(mockHistoryPush).toHaveBeenCalledWith(DONATIONS_SLUG);
+        });
+
+        it('should call onClose', () => {
+          tree({ organizationPlan: plan, isActive: true });
+          expect(onClose).not.toHaveBeenCalled();
+          const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+          closeButtons.forEach((button, index) => {
+            fireEvent.click(button);
+            expect(onClose).toHaveBeenCalledTimes(index + 1);
+          });
+          expect(onClose).toHaveBeenCalledTimes(closeButtons.length);
+        });
+
+        it('should render "FAQ" section', () => {
+          tree({ organizationPlan: plan, isActive: true });
+          expect(screen.getByText('Need more help? Check our', { exact: false })).toBeVisible();
+          expect(screen.getByText(/for more integration details and tips./i)).toBeVisible();
+          expect(screen.getByRole('link', { name: /FAQ/i })).toHaveAttribute(
+            'href',
+            // FAQ_URL constant. Link is hardcoded so that if constant is mistakenly changed the test will fail
+            'https://news-revenue-hub.atlassian.net/servicedesk/customer/portal/11/article/2195423496'
+          );
+        });
+
+        it('should be accessible', async () => {
+          const { container } = tree({ organizationPlan: plan, isActive: true });
+          expect(await axe(container)).toHaveNoViolations();
+        });
+      });
+    });
+  });
+});

--- a/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.tsx
+++ b/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/MailchimpModal.tsx
@@ -1,0 +1,147 @@
+import { IconList, Modal, ModalContent, ModalFooter, ModalHeader } from 'components/base';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import PropTypes, { InferProps } from 'prop-types';
+import { ReactComponent as Mail } from '@material-design-icons/svg/filled/mail.svg';
+import { ReactComponent as GroupAdd } from '@material-design-icons/svg/filled/group_add.svg';
+import { ReactComponent as Diversity } from '@material-design-icons/svg/filled/diversity_2.svg';
+
+import { CancelButton, ActionButton, InfoIcon, Title, SupportText } from './MailchimpModal.styled';
+import { PLAN_NAMES, PLAN_LABELS } from 'constants/orgPlanConstants';
+import IntegrationCardHeader from '../../IntegrationCardHeader';
+import { CORE_UPGRADE_URL, FAQ_URL, HELP_URL } from 'constants/helperUrls';
+import { useHistory } from 'react-router-dom';
+import { DONATIONS_SLUG } from 'routes';
+import ModalUpgradePrompt from '../../ModalUpgradePrompt/ModalUpgradePrompt';
+
+export interface MailchimpModalProps extends InferProps<typeof MailchimpModalPropTypes> {
+  /**
+   * User is connected to mailchimp?
+   */
+  isActive: boolean;
+  organizationPlan: 'FREE' | 'CORE' | 'PLUS';
+}
+
+const LIST_CONTENT = {
+  NOT_CONNECTED: [
+    { icon: <Mail />, text: 'Regularly thank, steward and bump up current contributors.' },
+    { icon: <GroupAdd />, text: 'Re-engage lapsed donors.' },
+    { icon: <Diversity />, text: 'Consistently market to new contributors, segmenting out those who already gave.' }
+  ],
+  // TODO: Update copy
+  CONNECTED: []
+};
+
+const MailchimpModal = ({
+  open,
+  onClose,
+  isActive,
+  sendUserToMailchimp,
+  organizationPlan,
+  ...mailchimpHeaderData
+}: MailchimpModalProps) => {
+  const history = useHistory();
+
+  const handleCorrectState = (free: any, paidNotConnected: any, connected: any) => {
+    if ([PLAN_LABELS.CORE, PLAN_LABELS.PLUS].includes(organizationPlan) && !isActive) {
+      return paidNotConnected;
+    } else if ([PLAN_LABELS.CORE, PLAN_LABELS.PLUS].includes(organizationPlan) && isActive) {
+      return connected;
+    }
+    return free;
+  };
+
+  return (
+    <Modal width={isActive ? 660 : 566} open={open} onClose={onClose} aria-label="Mailchimp connection modal">
+      <ModalHeader
+        onClose={onClose}
+        icon={
+          isActive ? (
+            <InfoIcon>
+              <InfoOutlinedIcon />
+            </InfoIcon>
+          ) : undefined
+        }
+      >
+        {isActive ? (
+          <Title>Successfully Connected!</Title>
+        ) : (
+          <IntegrationCardHeader isActive={isActive} {...mailchimpHeaderData} />
+        )}
+      </ModalHeader>
+      <ModalContent>
+        <p style={{ marginBottom: 30, marginTop: 0 }}>
+          {handleCorrectState(
+            <>
+              Integrate with Mailchimp to <b>automate targeted</b> emails.
+            </>,
+            <>
+              Integrate with Mailchimp to <b>automate targeted</b> emails.
+            </>,
+            <b>What’s Next?</b>
+          )}
+        </p>
+        <IconList
+          list={handleCorrectState(LIST_CONTENT.NOT_CONNECTED, LIST_CONTENT.NOT_CONNECTED, LIST_CONTENT.CONNECTED)}
+        />
+        {handleCorrectState(
+          <ModalUpgradePrompt text="Upgrade for integrated email marketing and more features!" />,
+          <SupportText>
+            See{' '}
+            <a href={HELP_URL} style={{ textDecoration: 'underline' }} target="_blank" rel="noreferrer">
+              Support
+            </a>{' '}
+            for more integration details and tips.
+          </SupportText>,
+          <SupportText>
+            Need more help? Check our{' '}
+            <a href={FAQ_URL} style={{ textDecoration: 'underline' }} target="_blank" rel="noreferrer">
+              FAQ
+            </a>{' '}
+            for more integration details and tips.
+          </SupportText>
+        )}
+      </ModalContent>
+      <ModalFooter>
+        <CancelButton color="secondary" variant="contained" onClick={onClose}>
+          {isActive ? 'Close' : 'Maybe Later'}
+        </CancelButton>
+        <ActionButton
+          color="primaryDark"
+          variant="contained"
+          disableElevation
+          {...handleCorrectState(
+            { href: CORE_UPGRADE_URL },
+            { onClick: sendUserToMailchimp },
+            {
+              onClick: () => {
+                history.push(DONATIONS_SLUG);
+              }
+            }
+          )}
+        >
+          {handleCorrectState('Upgrade', 'Connect', 'Go to contributions')}
+        </ActionButton>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+const MailchimpModalPropTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  sendUserToMailchimp: PropTypes.func,
+  image: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  cornerMessage: PropTypes.node,
+  site: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
+  }).isRequired,
+  isActive: PropTypes.bool,
+  isRequired: PropTypes.bool.isRequired,
+  organizationPlan: PropTypes.oneOf(Object.keys(PLAN_NAMES)).isRequired
+};
+
+MailchimpModal.propTypes = MailchimpModalPropTypes;
+
+export default MailchimpModal;

--- a/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/index.ts
+++ b/spa/src/components/common/IntegrationCard/MailchimpIntegrationCard/MailchimpModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MailchimpModal';

--- a/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.stories.tsx
+++ b/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import ModalUpgradePrompt from './ModalUpgradePrompt';
+
+export default {
+  component: ModalUpgradePrompt,
+  title: 'Common/ModalUpgradePrompt'
+} as ComponentMeta<typeof ModalUpgradePrompt>;
+
+const Template: ComponentStory<typeof ModalUpgradePrompt> = (props) => <ModalUpgradePrompt {...props} />;
+
+export const Default = Template.bind({});

--- a/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.styled.ts
+++ b/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.styled.ts
@@ -1,0 +1,25 @@
+import { ReactComponent as CoreUpgradeIcon } from 'assets/icons/upgrade-core.svg';
+import styled from 'styled-components';
+
+export const Root = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.muiGrey[400]};
+  border-radius: 10px;
+  display: grid;
+  position: relative;
+  gap: 12px;
+  padding: 13px 13px 13px 55px;
+`;
+
+export const Text = styled.p`
+  color: ${({ theme }) => theme.colors.muiGrey[900]};
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
+  margin: 0;
+`;
+
+export const UpgradeIcon = styled(CoreUpgradeIcon)`
+  height: 30px;
+  left: 8px;
+  position: absolute;
+  top: 9px;
+  width: 30px;
+`;

--- a/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.test.tsx
+++ b/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.test.tsx
@@ -1,0 +1,31 @@
+import { PRICING_URL } from 'constants/helperUrls';
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import ModalUpgradePrompt, { ModalUpgradePromptProps } from './ModalUpgradePrompt';
+
+function tree(props?: Partial<ModalUpgradePromptProps>) {
+  return render(<ModalUpgradePrompt text="mock-text" {...props} />);
+}
+
+describe('ModalUpgradePrompt', () => {
+  it('displays a link to the pricing page', () => {
+    tree();
+
+    const link = screen.getByRole('link', { name: 'Learn More' });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', PRICING_URL);
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('displays the copywriting text', () => {
+    tree();
+    expect(screen.getByText('mock-text')).toBeInTheDocument();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.tsx
+++ b/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/ModalUpgradePrompt.tsx
@@ -1,0 +1,26 @@
+import { PRICING_URL } from 'constants/helperUrls';
+import PropTypes, { InferProps } from 'prop-types';
+import { Link } from 'components/base';
+import { Root, Text, UpgradeIcon } from './ModalUpgradePrompt.styled';
+
+const ModalUpgradePromptPropTypes = {
+  text: PropTypes.string.isRequired
+};
+
+export type ModalUpgradePromptProps = InferProps<typeof ModalUpgradePromptPropTypes>;
+
+export function ModalUpgradePrompt({ text }: ModalUpgradePromptProps) {
+  return (
+    <Root>
+      <UpgradeIcon />
+      <Text>{text}</Text>
+      <Link href={PRICING_URL} target="_blank">
+        Learn More
+      </Link>
+    </Root>
+  );
+}
+
+ModalUpgradePrompt.propTypes = ModalUpgradePromptPropTypes;
+
+export default ModalUpgradePrompt;

--- a/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/__mocks__/ModalUpgradePrompt.tsx
+++ b/spa/src/components/common/IntegrationCard/ModalUpgradePrompt/__mocks__/ModalUpgradePrompt.tsx
@@ -1,0 +1,7 @@
+import { ModalUpgradePromptProps } from '../ModalUpgradePrompt';
+
+export const ModalUpgradePrompt = ({ text }: ModalUpgradePromptProps) => (
+  <div data-testid="mock-modal-upgrade-prompt">{text}</div>
+);
+
+export default ModalUpgradePrompt;

--- a/spa/src/components/dashboard/Dashboard.test.tsx
+++ b/spa/src/components/dashboard/Dashboard.test.tsx
@@ -53,7 +53,8 @@ describe('Dashboard', () => {
       requiresAudienceSelection: false,
       isLoading: false,
       connectedToMailchimp: false,
-      isError: false
+      isError: false,
+      hasMailchimpAccess: true
     });
     useConnectStripeAccountMock.mockReturnValue({
       requiresVerification: false,
@@ -111,7 +112,8 @@ describe('Dashboard', () => {
       revenueProgram: 'mock-rp' as any,
       isLoading: false,
       connectedToMailchimp: false,
-      isError: false
+      isError: false,
+      hasMailchimpAccess: true
     });
     render(<Dashboard />);
     const audienceListModal = screen.getByTestId('mock-audience-list-modal');
@@ -125,7 +127,8 @@ describe('Dashboard', () => {
       revenueProgram: 'mock-rp' as any,
       isLoading: false,
       connectedToMailchimp: false,
-      isError: false
+      isError: false,
+      hasMailchimpAccess: true
     });
     render(<Dashboard />);
     expect(screen.queryByTestId('mock-audience-list-modal')).not.toBeInTheDocument();

--- a/spa/src/hooks/useConnectMailchimp.tsx
+++ b/spa/src/hooks/useConnectMailchimp.tsx
@@ -37,6 +37,10 @@ export interface UseConnectMailchimpResult {
    * User's organization plan
    */
   organizationPlan?: EnginePlan['name'];
+  /**
+   * User has Mailchimp feature flag enabled
+   */
+  hasMailchimpAccess: boolean;
 }
 
 const BASE_URL = window.location.origin;
@@ -75,7 +79,7 @@ export default function useConnectMailchimp(): UseConnectMailchimpResult {
 
   // If the user is loading or errored, return that status.
   if (isLoading || isError) {
-    return { isError, isLoading, connectedToMailchimp: false, requiresAudienceSelection: false };
+    return { isError, isLoading, connectedToMailchimp: false, requiresAudienceSelection: false, hasMailchimpAccess };
   }
 
   // If the user has no feature flag enabling mailchimp integration, has no revenue programs, no org or multiple orgs return that there's no action to take.
@@ -90,7 +94,8 @@ export default function useConnectMailchimp(): UseConnectMailchimpResult {
       isError: false,
       isLoading: false,
       connectedToMailchimp: false,
-      requiresAudienceSelection: false
+      requiresAudienceSelection: false,
+      hasMailchimpAccess
     };
   }
 
@@ -107,7 +112,8 @@ export default function useConnectMailchimp(): UseConnectMailchimpResult {
         !!user?.organizations?.[0]?.show_connected_to_mailchimp ||
         !!user?.revenue_programs?.[0]?.mailchimp_integration_connected,
       organizationPlan: user?.organizations?.[0]?.plan?.name,
-      requiresAudienceSelection: false
+      requiresAudienceSelection: false,
+      hasMailchimpAccess
     };
   }
 
@@ -125,6 +131,7 @@ export default function useConnectMailchimp(): UseConnectMailchimpResult {
     requiresAudienceSelection:
       !user?.revenue_programs?.[0]?.mailchimp_email_list?.id &&
       (user?.revenue_programs?.[0]?.mailchimp_email_lists?.length ?? 0) > 0,
-    revenueProgram: user?.revenue_programs?.[0]
+    revenueProgram: user?.revenue_programs?.[0],
+    hasMailchimpAccess
   };
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a

#### What's this PR do?
- Create Mailchimp "View details" modal
- Create Modal Upgrade prompt
- Implement Modal to Mailchimp Integration Card if user has feature flag enabled
- Create new base component "IconList"
- Make IntegrationCardHeader a separate component to be utilized in multiple locations
- Update Link and ModalHeader base components style (small updates)
- Update useConnectMailchimp hook to return feature flag
- Fix broken test 
 
#### Why are we doing this? How does it help us?
Adds a modal with more details about mailchimp connection for users. Modal shows unique information in each stage related to the connection. 

#### How should this be manually tested? Please include detailed step-by-step instructions.
6 test scenarios:
1. User with mailchimp feature flag disabled
   - "View details" should not show in Mailchimp integration card
   - Modal not accessible 
   - Everythin should work as usual
2. User with mailchimp feature flag enabled and Org plan = FREE
   - "View details" should show in Mailchimp integration card
   - Click that button to show Modal 
   - Modal with upgrade prompt should display
   - CTAs: Learn More, Maybe later, Upgrade
3. User with mailchimp feature flag enabled, Org plan = CORE, Mailchimp NOT connected
   - "View details" should show in Mailchimp integration card
   - Click that button to show Modal 
   - Modal with upgrade prompt should not display
   - CTAs: Support, Maybe later, Connect
4. User with mailchimp feature flag enabled, Org plan = PLUS, Mailchimp NOT connected
   - "View details" should show in Mailchimp integration card
   - Click that button to show Modal 
   - Modal with upgrade prompt should not display
   - CTAs: Support, Maybe later, Connect
5. User with mailchimp feature flag enabled, Org plan = CORE, Mailchimp connected
   - "View details" should show in Mailchimp integration card
   - Click that button to show Modal 
   - Modal header should be "Successfully Connected!"
   - CTAs: FAQ, Close, Go to Contributions
   - No bullet list copy as of yet (TODO)
6. User with mailchimp feature flag enabled, Org plan = PLUS, Mailchimp connected
   - "View details" should show in Mailchimp integration card
   - Click that button to show Modal 
   - Modal header should be "Successfully Connected!"
   - CTAs: FAQ, Close, Go to Contributions
   - No bullet list copy as of yet (TODO)

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
Yes

#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
Mailchimp modal added to help user with more information about what the connection does and how to connect.

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-3177

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
I think not.