### PR TITLE
DEV-3477-animate-on-the-contributions-dashboard-upgrade-prompt

### DIFF
--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.styled.ts
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.styled.ts
@@ -9,3 +9,15 @@ export const Root = styled.div`
   right: 0;
   top: 58px;
 `;
+
+export const Highlight = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }) => theme.basePalette.greyscale.black};
+  box-shadow: -0.3px -2px 4px rgba(0, 0, 0, 0.1), 0px 2px 4px rgba(0, 0, 0, 0.2);
+`;

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'constants/authConstants';
 import { DONATIONS_CORE_UPGRADE_CLOSED } from 'hooks/useSessionState';
 import useUser from 'hooks/useUser';
-import { fireEvent, render, screen } from 'test-utils';
+import { act, fireEvent, render, screen, waitFor } from 'test-utils';
 import DonationUpgradePrompts from './DonationUpgradePrompts';
 import useContributionPageList from 'hooks/useContributionPageList';
 
@@ -53,6 +53,27 @@ describe('DonationUpgradePrompts', () => {
     it('shows a Core upgrade prompt', () => {
       tree();
       expect(screen.getByTestId('mock-donation-core-upgrade-prompt')).toBeInTheDocument();
+    });
+
+    describe('Prompt Highlight', () => {
+      it('shows a highlight', () => {
+        tree();
+        expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
+      });
+
+      it('hides the highlight after 1 second', async () => {
+        jest.useFakeTimers();
+        tree();
+        expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
+        act(() => {
+          jest.runAllTimers();
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
+        });
+
+        jest.useRealTimers();
+      });
     });
 
     it('hides the prompt when closed', () => {

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
@@ -206,34 +206,22 @@ describe('DonationUpgradePrompts', () => {
       expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
     });
 
-    it.skip('hides the highlight 1 second after animation', async () => {
+    it('hides the highlight 1 second after animation', () => {
       tree();
       expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
-      act(() => {
-        jest.runAllTimers();
-      });
-      await waitFor(() => {
-        expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
-      });
+      act(() => jest.advanceTimersByTime(animationTimeout));
+      act(() => jest.runAllTimers());
+      expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
     });
 
-    it.skip('animation flow is done correctly', async () => {
+    it('triggers fades in the correct order', () => {
       tree();
       expect(screen.getByTestId('show-animation-false')).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(animationTimeout);
-      });
-      await waitFor(() => {
-        expect(screen.getByTestId('show-animation-true')).toBeInTheDocument();
-      });
-      expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
-      act(() => {
-        jest.runOnlyPendingTimers();
-      });
+      act(() => jest.advanceTimersByTime(animationTimeout));
       expect(screen.getByTestId('show-animation-true')).toBeInTheDocument();
-      await waitFor(() => {
-        expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
-      });
+      expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
+      act(() => jest.runAllTimers());
+      expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
     });
   });
 });

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
@@ -55,27 +55,6 @@ describe('DonationUpgradePrompts', () => {
       expect(screen.getByTestId('mock-donation-core-upgrade-prompt')).toBeInTheDocument();
     });
 
-    describe('Prompt Highlight', () => {
-      it('shows a highlight', () => {
-        tree();
-        expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
-      });
-
-      it('hides the highlight after 1 second', async () => {
-        jest.useFakeTimers();
-        tree();
-        expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
-        act(() => {
-          jest.runAllTimers();
-        });
-        await waitFor(() => {
-          expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
-        });
-
-        jest.useRealTimers();
-      });
-    });
-
     it('hides the prompt when closed', () => {
       tree();
       expect(screen.getByTestId('mock-donation-core-upgrade-prompt')).toBeInTheDocument();
@@ -190,5 +169,71 @@ describe('DonationUpgradePrompts', () => {
     });
     tree();
     expect(screen.queryByTestId('mock-donation-core-upgrade-prompt')).not.toBeInTheDocument();
+  });
+
+  describe('Animation', () => {
+    const animationTimeout = 1000;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
+
+    it('initially hide animation', () => {
+      tree();
+      expect(screen.getByTestId('show-animation-false')).toBeInTheDocument();
+    });
+
+    it('show animation after 1s', () => {
+      tree();
+      expect(screen.getByTestId('show-animation-false')).toBeInTheDocument();
+      act(() => {
+        jest.advanceTimersByTime(animationTimeout);
+      });
+      expect(screen.getByTestId('show-animation-true')).toBeInTheDocument();
+    });
+
+    it('show highlight after animation', () => {
+      tree();
+      act(() => {
+        jest.advanceTimersByTime(animationTimeout);
+      });
+      expect(screen.getByTestId('show-animation-true')).toBeInTheDocument();
+      expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
+    });
+
+    it.skip('hides the highlight 1 second after animation', async () => {
+      tree();
+      expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
+      act(() => {
+        jest.runAllTimers();
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
+      });
+    });
+
+    it.skip('animation flow is done correctly', async () => {
+      tree();
+      expect(screen.getByTestId('show-animation-false')).toBeInTheDocument();
+      act(() => {
+        jest.advanceTimersByTime(animationTimeout);
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('show-animation-true')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('prompt-highlight-true')).toBeInTheDocument();
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+      expect(screen.getByTestId('show-animation-true')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId('prompt-highlight-false')).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
@@ -22,18 +22,14 @@ export function DonationUpgradePrompts() {
 
   useEffect(() => {
     if (showAnimation) {
-      console.log('start delay to hide highlight');
       setTimeout(() => {
-        console.log('hide highlight');
         setShowHighlight(false);
-      }, 1000);
+      }, 500);
     }
   }, [showAnimation]);
 
   useEffect(() => {
-    console.log('start delay to show animation');
     setTimeout(() => {
-      console.log('show animation');
       setShowAnimation(true);
     }, 1000);
   }, []);
@@ -49,9 +45,9 @@ export function DonationUpgradePrompts() {
     user?.revenue_programs[0].payment_provider_stripe_verified
   ) {
     return (
-      <Fade in={showAnimation} timeout={1000} data-testid={`show-animation-${showAnimation}`}>
+      <Fade in={showAnimation} timeout={500} data-testid={`show-animation-${showAnimation}`}>
         <Root>
-          <Fade in={showHighlight} timeout={500} data-testid={`prompt-highlight-${showHighlight}`}>
+          <Fade in={showHighlight} timeout={300} data-testid={`prompt-highlight-${showHighlight}`}>
             <Highlight />
           </Fade>
           <DonationCoreUpgradePrompt onClose={() => setCoreUpgradePromptClosed(true)} />

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
@@ -21,17 +21,21 @@ export function DonationUpgradePrompts() {
   const [showHighlight, setShowHighlight] = useState(true);
 
   useEffect(() => {
-    if (showAnimation) {
-      setTimeout(() => {
-        setShowHighlight(false);
-      }, 500);
-    }
+    if (!showAnimation) return;
+
+    const highlight = setTimeout(() => {
+      setShowHighlight(false);
+    }, 500);
+
+    return () => clearTimeout(highlight);
   }, [showAnimation]);
 
   useEffect(() => {
-    setTimeout(() => {
+    const animation = setTimeout(() => {
       setShowAnimation(true);
     }, 1000);
+
+    return () => clearTimeout(animation);
   }, []);
 
   // The published page check is meant to prevent the prompt from conflicting

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
@@ -1,10 +1,12 @@
+import { Fade } from '@material-ui/core';
+import useContributionPageList from 'hooks/useContributionPageList';
 import { DONATIONS_CORE_UPGRADE_CLOSED, useSessionState } from 'hooks/useSessionState';
 import useUser from 'hooks/useUser';
+import { useEffect, useState } from 'react';
+import { pageIsPublished } from 'utilities/editPageGetSuccessMessage';
 import { getUserRole } from 'utilities/getUserRole';
 import DonationCoreUpgradePrompt from './DonationCoreUpgradePrompt/DonationCoreUpgradePrompt';
-import { Root } from './DonationUpgradePrompts.styled';
-import useContributionPageList from 'hooks/useContributionPageList';
-import { pageIsPublished } from 'utilities/editPageGetSuccessMessage';
+import { Highlight, Root } from './DonationUpgradePrompts.styled';
 
 // This is a stopgap measure to add functionality to the Donations component in
 // the non-legacy way without refactoring the entire component. Eventually, this
@@ -15,10 +17,16 @@ export function DonationUpgradePrompts() {
   const { isOrgAdmin } = getUserRole(user);
   const { pages } = useContributionPageList();
   const [coreUpgradePromptClosed, setCoreUpgradePromptClosed] = useSessionState(DONATIONS_CORE_UPGRADE_CLOSED, false);
+  const [showHighlight, setShowHighlight] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setShowHighlight(false);
+    }, 1000);
+  });
 
   // The published page check is meant to prevent the prompt from conflicting
   // with the banners that <Donations> may show.
-
   if (
     pages &&
     pages.some((page) => pageIsPublished(page)) &&
@@ -28,9 +36,14 @@ export function DonationUpgradePrompts() {
     user?.revenue_programs[0].payment_provider_stripe_verified
   ) {
     return (
-      <Root>
-        <DonationCoreUpgradePrompt onClose={() => setCoreUpgradePromptClosed(true)} />
-      </Root>
+      <Fade in timeout={1000}>
+        <Root>
+          <Fade in={showHighlight} timeout={500}>
+            <Highlight data-testid={`prompt-highlight-${showHighlight}`} />
+          </Fade>
+          <DonationCoreUpgradePrompt onClose={() => setCoreUpgradePromptClosed(true)} />
+        </Root>
+      </Fade>
     );
   }
 

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.tsx
@@ -17,13 +17,26 @@ export function DonationUpgradePrompts() {
   const { isOrgAdmin } = getUserRole(user);
   const { pages } = useContributionPageList();
   const [coreUpgradePromptClosed, setCoreUpgradePromptClosed] = useSessionState(DONATIONS_CORE_UPGRADE_CLOSED, false);
+  const [showAnimation, setShowAnimation] = useState(false);
   const [showHighlight, setShowHighlight] = useState(true);
 
   useEffect(() => {
+    if (showAnimation) {
+      console.log('start delay to hide highlight');
+      setTimeout(() => {
+        console.log('hide highlight');
+        setShowHighlight(false);
+      }, 1000);
+    }
+  }, [showAnimation]);
+
+  useEffect(() => {
+    console.log('start delay to show animation');
     setTimeout(() => {
-      setShowHighlight(false);
+      console.log('show animation');
+      setShowAnimation(true);
     }, 1000);
-  });
+  }, []);
 
   // The published page check is meant to prevent the prompt from conflicting
   // with the banners that <Donations> may show.
@@ -36,10 +49,10 @@ export function DonationUpgradePrompts() {
     user?.revenue_programs[0].payment_provider_stripe_verified
   ) {
     return (
-      <Fade in timeout={1000}>
+      <Fade in={showAnimation} timeout={1000} data-testid={`show-animation-${showAnimation}`}>
         <Root>
-          <Fade in={showHighlight} timeout={500}>
-            <Highlight data-testid={`prompt-highlight-${showHighlight}`} />
+          <Fade in={showHighlight} timeout={500} data-testid={`prompt-highlight-${showHighlight}`}>
+            <Highlight />
           </Fade>
           <DonationCoreUpgradePrompt onClose={() => setCoreUpgradePromptClosed(true)} />
         </Root>


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?
Animate upgrade prompt show that it's more visible to the users.

#### Why are we doing this? How does it help us?
We want to make the upgrade prompt more visible for users.

#### How should this be manually tested? Please include detailed step-by-step instructions.
- Log in as a Free user, connect to stripe and publish a page
- Go in and out of the Contributions dashboard page
- You should see the prompt animating 

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
No

#### Have automated unit tests been added? If not, why?
Yes

#### How should this change be communicated to end users?
N/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-3477

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?
no

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no