### PR TITLE
DEV-3594 | make stripe_account_id nullable in MailchimpRevenueProgramForSwitchboard serializer

### DIFF
--- a/apps/organizations/serializers.py
+++ b/apps/organizations/serializers.py
@@ -133,7 +133,7 @@ class MailchimpRevenueProgramForSwitchboard(serializers.ModelSerializer):
     mailchimp_store = serializers.SerializerMethodField()
     mailchimp_one_time_contribution_product = serializers.SerializerMethodField()
     mailchimp_recurring_contribution_product = serializers.SerializerMethodField()
-    stripe_account_id = serializers.ReadOnlyField()
+    stripe_account_id = serializers.ReadOnlyField(allow_null=True)
     id = serializers.ReadOnlyField()
     name = serializers.ReadOnlyField()
     slug = serializers.ReadOnlyField()

--- a/apps/organizations/tests/test_serializers.py
+++ b/apps/organizations/tests/test_serializers.py
@@ -258,3 +258,9 @@ class TestMailchimpRevenueProgramForSwitchboard:
         assert serialized["mailchimp_store"] == asdict(mailchimp_store)
         assert serialized["mailchimp_recurring_contribution_product"] == asdict(mailchimp_product)
         assert serialized["mailchimp_one_time_contribution_product"] == asdict(mailchimp_product)
+
+    def test_stripe_account_id_is_nullable(self, mc_connected_rp):
+        mc_connected_rp.payment_provider.stripe_account_id = None
+        mc_connected_rp.payment_provider.save()
+        serialized = MailchimpRevenueProgramForSwitchboard(mc_connected_rp).data
+        assert serialized["stripe_account_id"] is None

--- a/apps/organizations/tests/test_serializers.py
+++ b/apps/organizations/tests/test_serializers.py
@@ -262,5 +262,6 @@ class TestMailchimpRevenueProgramForSwitchboard:
     def test_stripe_account_id_is_nullable(self, mc_connected_rp):
         mc_connected_rp.payment_provider.stripe_account_id = None
         mc_connected_rp.payment_provider.save()
+        assert mc_connected_rp.stripe_account_id is None
         serialized = MailchimpRevenueProgramForSwitchboard(mc_connected_rp).data
         assert serialized["stripe_account_id"] is None

--- a/apps/organizations/tests/test_serializers.py
+++ b/apps/organizations/tests/test_serializers.py
@@ -234,6 +234,18 @@ class TestMailchimpRevenueProgramForSwitchboard:
             new_callable=mocker.PropertyMock,
         )
         serialized = MailchimpRevenueProgramForSwitchboard(mc_connected_rp).data
+        assert set(serialized.keys()) == {
+            "id",
+            "name",
+            "slug",
+            "mailchimp_server_prefix",
+            "mailchimp_integration_connected",
+            "stripe_account_id",
+            "mailchimp_store",
+            "mailchimp_recurring_contribution_product",
+            "mailchimp_one_time_contribution_product",
+        }
+
         for field in (
             "id",
             "name",
@@ -243,7 +255,6 @@ class TestMailchimpRevenueProgramForSwitchboard:
             "stripe_account_id",
         ):
             assert serialized[field] == getattr(mc_connected_rp, field)
-
         assert serialized["mailchimp_store"] == asdict(mailchimp_store)
         assert serialized["mailchimp_recurring_contribution_product"] == asdict(mailchimp_product)
         assert serialized["mailchimp_one_time_contribution_product"] == asdict(mailchimp_product)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Makes `MailchimpRevenueProgramForSwitchboard.data["stripe_account_id"]` nullable 

#### Why are we doing this? How does it help us?

API was choking on non-null values for stripe account ID

#### How should this be manually tested? Please include detailed step-by-step instructions.

1. Log in as a superuser via SPA or /api/v1/token/
2. Find the ID of an RP that doesn't have stripe account ID.
3. Go to /api/v1/revenue-programs/YOUR-ID/mailchimp/.  It should 200, and there should be a key for `stripe_account_id` with the value null.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Updated existing


#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-3594
](https://news-revenue-hub.atlassian.net/jira/software/c/projects/DEV/boards/3?modal=detail&selectedIssue=DEV-3594)


#### Do any changes need to be made before deployment to production (adding environment variables, for example)?


No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A