### PR TITLE
DEV-3616 make MailchimpRevenueProgramForSwitchboard.mailchimp_server_prefix and .stripe_account_id default to empty string

### DIFF
--- a/apps/organizations/serializers.py
+++ b/apps/organizations/serializers.py
@@ -168,11 +168,11 @@ class MailchimpRevenueProgramForSwitchboard(serializers.ModelSerializer):
     """Primary consumer is switchboard API. This is a read-only serializer."""
 
     mailchimp_integration_connected = serializers.ReadOnlyField()
-    mailchimp_server_prefix = serializers.ReadOnlyField(allow_null=True)
+    mailchimp_server_prefix = serializers.SerializerMethodField()
     mailchimp_store = serializers.SerializerMethodField()
     mailchimp_one_time_contribution_product = serializers.SerializerMethodField()
     mailchimp_recurring_contribution_product = serializers.SerializerMethodField()
-    stripe_account_id = serializers.ReadOnlyField(allow_null=True)
+    stripe_account_id = serializers.SerializerMethodField()
     id = serializers.ReadOnlyField()
     name = serializers.ReadOnlyField()
     slug = serializers.ReadOnlyField()
@@ -190,6 +190,14 @@ class MailchimpRevenueProgramForSwitchboard(serializers.ModelSerializer):
             "mailchimp_one_time_contribution_product",
             "mailchimp_recurring_contribution_product",
         ]
+
+    def get_mailchimp_server_prefix(self, obj) -> str:
+        """This allows us to return an empty string. Otherwise, DRF will return null if value is None"""
+        return obj.mailchimp_server_prefix or ""
+
+    def get_stripe_account_id(self, obj) -> str:
+        """This allows us to return an empty string. Otherwise, DRF will return null if value is None"""
+        return obj.stripe_account_id or ""
 
     def get_mailchimp_store(self, obj) -> dict | None:
         return asdict(obj.mailchimp_store) if obj.mailchimp_store else None


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This updates the definition of `mailchimp_server_prefix` and `stripe_account_id` properties on `MailchimpRevenueProgramForSwitchboard` such that they return an empty string if their related db values are None. We're doing this so that Switchboard can type those fields in response as string and not have to worry about None/null (it was expecting only string, and broke when got null).

#### Why are we doing this? How does it help us?

Solve a bug in switchboard and simplify the interface.

#### How should this be manually tested? Please include detailed step-by-step instructions.

- In the Django admin, find an RP that has null value for payment provider (or with a payment provider that doesn't have stripe account id set) and a null value for mailchimp_server_prefix
- In the review app, log in as a superuser at https://dev-3616.revengine-review.org/api/v1/token/
- Now go to https://dev-3616.revengine-review.org/api/v1/revenue-programs/ID-OF-YOUR-RP/mailchimp/ . You should see empty string values for "stripe_account_id" and `"mailchimp_server_prefix" in the response data.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-3616](https://news-revenue-hub.atlassian.net/browse/DEV-3616)


#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No

[DEV-3616]: https://news-revenue-hub.atlassian.net/browse/DEV-3616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ