### PR TITLE
DEV-3614: Handle user with no organization in <Subscription>

### DIFF
--- a/spa/src/components/settings/Subscription/Subscription.test.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.test.tsx
@@ -29,6 +29,17 @@ describe('Subscription', () => {
     expect(document.body.textContent).toBe('');
   });
 
+  it('displays nothing if the user in context has no organizations', () => {
+    useUserMock.mockReturnValue({
+      isError: false,
+      isLoading: true,
+      refetch: jest.fn(),
+      user: { organizations: [] } as any
+    });
+    tree();
+    expect(document.body.textContent).toBe('');
+  });
+
   it("displays the plan the user's first organization has", () => {
     tree();
     expect(screen.getByText('Free Tier')).toBeVisible();

--- a/spa/src/components/settings/Subscription/Subscription.tsx
+++ b/spa/src/components/settings/Subscription/Subscription.tsx
@@ -9,15 +9,11 @@ import SubheaderSection from 'components/common/SubheaderSection';
 
 export function Subscription() {
   const { user } = useUser();
+  const firstOrg = user?.organizations[0];
 
-  if (!user) {
+  if (!user || !firstOrg) {
     return null;
   }
-
-  // This must exist--this route is wrapped by <SingleOrgUserOnlyRoute> by
-  // <Dashboard>.
-
-  const firstOrg = user.organizations[0];
 
   return (
     <Wrapper>


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Handles the case when a user has no organizations. This shouldn't happen in real life, but did occur when we were doing internal testing.

#### Why are we doing this? How does it help us?

Defensive coding.

#### How should this be manually tested? Please include detailed step-by-step instructions.

I'm not sure--the gist is that we would need to create a user that is able to log in, but is not tied to an organization.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3614

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.