### PR TITLE
DEV-3332: Special case Stripe connection status for users with > 1 RP

### DIFF
--- a/spa/src/hooks/useConnectStripeAccount.ts
+++ b/spa/src/hooks/useConnectStripeAccount.ts
@@ -128,9 +128,10 @@ export default function useConnectStripeAccount(): UseConnectStripeAccountResult
     return { isError: userIsError, isLoading: userIsLoading, displayConnectionSuccess, hideConnectionSuccess };
   }
 
-  // If the user has no revenue programs, return that there's no action to take.
+  // If the user has 0 or more than 1 revenue program, return that there's no
+  // action to take.
 
-  if (!user?.revenue_programs || user.revenue_programs.length === 0) {
+  if (!user?.revenue_programs || user.revenue_programs.length === 0 || user.revenue_programs.length > 1) {
     return {
       isError: false,
       isLoading: false,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Fixes a bug in the useConnectStripeAccount hook where a user with multiple revenue programs (e.g. a Hub admin) could end seeing an infinite spinner. The gist is that there was competing logic; if you are a Hub admin, Stripe status is never retrieved, but we didn't override the loading property in the hook result to tell consumers we had nothing to load.

#### Why are we doing this? How does it help us?

Makes life better for Hub admins.

#### How should this be manually tested? Please include detailed step-by-step instructions.

I have this deployed to the dev tier, because there is data there that triggered the bug. I don't think the bug/fix will manifest on the review app.

To test the regression:
1. Log into the admin dashboard as a Hub admin.
2. See you're able to edit as usual.

To test that things continue to work for regular user:
1. Create a new user.
2. Confirm you see the prompt in the corner to connect Stripe.
3. Connect Stripe for this user.
4. Confirm that you see the usual notification when Stripe is connected, and that the modal asking you to connect Stripe is no longer present.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3332

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.