### PR TITLE
DEV-3355: Change swag element to send nyt value

### DIFF
--- a/spa/cypress/e2e/01-donationPage.cy.js
+++ b/spa/cypress/e2e/01-donationPage.cy.js
@@ -176,6 +176,10 @@ describe('Donation page displays dynamic page elements', () => {
 
     cy.setUpDonation('One time', '365');
     cy.getByTestId('nyt-comp-sub').should('exist');
+    cy.getByTestId('nyt-comp-sub').click();
+    cy.getByTestId('nyt-comp-sub').within(() => {
+      cy.findByRole('checkbox').should('have.value', 'nyt');
+    });
   });
 });
 

--- a/spa/src/components/ContributorRouter.test.tsx
+++ b/spa/src/components/ContributorRouter.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { ComponentType } from 'react';
 import { Router } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { revEngineTheme } from 'styles/themes';
+import { act, render, screen, within } from 'test-utils';
 import ContributorRouter from './ContributorRouter';
 import useWebFonts from 'hooks/useWebFonts';
 import useRequest from 'hooks/useRequest';
@@ -216,7 +216,7 @@ describe('ContributorRouter', () => {
     );
     tree();
     expect(useWebFonts).toHaveBeenCalledWith(undefined);
-    jest.runOnlyPendingTimers();
+    act(() => jest.runOnlyPendingTimers());
     expect(useWebFonts).toHaveBeenLastCalledWith(mockData.styles.font);
   });
 });

--- a/spa/src/components/account/Profile/InfoTooltip.test.js
+++ b/spa/src/components/account/Profile/InfoTooltip.test.js
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import { render, screen, waitFor } from 'test-utils';
+import { act, render, screen, waitFor } from 'test-utils';
 import InfoTooltip from './InfoTooltip';
 
 function tree(props) {
@@ -40,12 +40,17 @@ describe('InfoTooltip', () => {
       const { container } = tree();
 
       expect(await axe(container)).toHaveNoViolations();
+
+      // Wait for pending updates.
+
+      await act(() => Promise.resolve());
     });
 
     it('is accessible when the tooltip is open', async () => {
-      const { container } = tree();
+      const { container } = tree({ title: 'test tooltip' });
 
       userEvent.click(screen.getByRole('button', { name: 'mock-label' }));
+      await waitFor(() => expect(screen.getByText('test tooltip')).toBeVisible());
       expect(await axe(container)).toHaveNoViolations();
     });
   });

--- a/spa/src/components/base/Link/Link.test.tsx
+++ b/spa/src/components/base/Link/Link.test.tsx
@@ -18,7 +18,7 @@ describe('Link', () => {
   });
 
   it('is accessible', async () => {
-    const { container } = tree();
+    const { container } = tree({ children: 'label' });
 
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/spa/src/components/base/Modal/ModalHeader.tsx
+++ b/spa/src/components/base/Modal/ModalHeader.tsx
@@ -42,7 +42,7 @@ const Root = styled('div')`
 `;
 
 export function ModalHeader({ children, className, closeAriaLabel, icon, onClose }: ModalHeaderProps) {
-  // The usage of data-no-autoFocus on the close button is to prevent it from
+  // The usage of data-no-autofocus on the close button is to prevent it from
   // being the first focused element when the modal first opens. See
   // react-focus-lock usage in <Modal>.
 
@@ -51,7 +51,7 @@ export function ModalHeader({ children, className, closeAriaLabel, icon, onClose
       {icon}
       <Content>{children}</Content>
       {onClose && (
-        <CloseButton aria-label={closeAriaLabel ?? 'Close'} data-no-autoFocus onClick={onClose}>
+        <CloseButton aria-label={closeAriaLabel ?? 'Close'} data-no-autofocus onClick={onClose}>
           <Close />
         </CloseButton>
       )}

--- a/spa/src/components/base/Tooltip/Tooltip.test.tsx
+++ b/spa/src/components/base/Tooltip/Tooltip.test.tsx
@@ -13,14 +13,18 @@ function tree() {
 describe('Tooltip', () => {
   afterEach(async () => await act(() => Promise.resolve()));
 
+  // Promise.resolve()s here are to allow for updates to occur.
+
   it('displays a tooltip', async () => {
     tree();
     expect(screen.getByText('Tooltip text')).toBeVisible();
+    await act(() => Promise.resolve());
   });
 
   it('is accessible', async () => {
     const { container } = tree();
 
+    await act(() => Promise.resolve());
     expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/spa/src/components/common/Button/ExportButton/ExportButton.test.tsx
+++ b/spa/src/components/common/Button/ExportButton/ExportButton.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import MockAdapter from 'axios-mock-adapter';
 import { axe } from 'jest-axe';
-import { fireEvent, render, screen, waitFor } from 'test-utils';
+import { act, fireEvent, render, screen, waitFor } from 'test-utils';
 import Axios from 'ajax/axios';
 import { useSnackbar } from 'notistack';
 
@@ -62,6 +62,10 @@ describe('ExportButton', () => {
     fireEvent.click(screen.getByRole('button', { name: /Export/i }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sending.../i })).toBeDisabled();
+
+    // Let pending update finish.
+
+    await act(() => Promise.resolve());
   });
 
   it('should show success system notification if export is confirmed in modal and succeeds', async () => {

--- a/spa/src/components/common/Modal/AudienceListModal/AudienceListModal.test.tsx
+++ b/spa/src/components/common/Modal/AudienceListModal/AudienceListModal.test.tsx
@@ -75,6 +75,7 @@ describe('AudienceListModal', () => {
     // "Open" is the aria-label of the autocomplete dropdown button
     userEvent.click(screen.getByRole('button', { name: /Open/i }));
     userEvent.click(screen.getByRole('option', { name: mockMailchimpStatus.audiences[0].name }));
+    expect(screen.getByRole('button', { name: 'Finish' })).toBeEnabled();
     userEvent.click(screen.getByRole('button', { name: 'Finish' }));
     await waitFor(() => expect(selectAudience).toBeCalled());
     expect(selectAudience.mock.calls).toEqual([[mockMailchimpStatus.audiences[0].id]]);

--- a/spa/src/components/common/Modal/MaxPagesPublishedModal/MaxPagesPublishedModal.tsx
+++ b/spa/src/components/common/Modal/MaxPagesPublishedModal/MaxPagesPublishedModal.tsx
@@ -39,17 +39,19 @@ export function MaxPagesPublishedModal({ currentPlan, onClose, open }: MaxPagesP
           </>
         )}
         {currentPlan === 'CORE' && (
-          <p>
+          <>
             <p>
               You've published the <RedEmphasis>maximum</RedEmphasis> number of live pages for the Core tier. Unpublish
               a published checkout page to make this page live.
             </p>
-            <strong>Want more published pages?</strong> Learn more about{' '}
-            <Link href={PRICING_URL} target="_blank">
-              Plus
-            </Link>
-            .
-          </p>
+            <p>
+              <strong>Want more published pages?</strong> Learn more about{' '}
+              <Link href={PRICING_URL} target="_blank">
+                Plus
+              </Link>
+              .
+            </p>
+          </>
         )}
       </ModalContent>
       <ModalFooter>

--- a/spa/src/components/common/SendTestEmail/SendTestEmail.test.tsx
+++ b/spa/src/components/common/SendTestEmail/SendTestEmail.test.tsx
@@ -99,6 +99,8 @@ describe('SendTestEmail', () => {
   });
 
   it('should show error notification if POST fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
     const info = jest.fn();
     const error = jest.fn();
     useAlertMock.mockReturnValue({ info, error } as any);
@@ -111,6 +113,7 @@ describe('SendTestEmail', () => {
     expect(error).toHaveBeenCalledWith('Error sending test email');
     expect(error).toHaveBeenCalledTimes(1);
     expect(info).toHaveBeenCalledTimes(0);
+    errorSpy.mockRestore();
   });
 
   it('is accessible', async () => {

--- a/spa/src/components/common/TextField/Searchbar/Searchbar.test.tsx
+++ b/spa/src/components/common/TextField/Searchbar/Searchbar.test.tsx
@@ -36,6 +36,9 @@ describe('Searchbar', () => {
 
   it('should be accessible', async () => {
     const { container } = tree();
-    expect(await axe(container)).toHaveNoViolations();
+    // axe seems to trip over contrast detection on this component.
+    // See https://github.com/nickcolley/jest-axe/issues/147
+
+    expect(await axe(container, { rules: { 'color-contrast': { enabled: false } } })).toHaveNoViolations();
   });
 });

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
@@ -281,17 +281,19 @@ describe('DDonorAddress', () => {
       // TODO: country field in DEV-2691
     });
 
-    it("defaults fields that don't appear in the API response to empty strings", () => {
+    it("defaults fields that don't appear in the API response to empty strings", async () => {
       tree();
-      usePlacesWidgetMock.mock.calls[0][0].onPlaceSelected({
-        address_components: [
-          {
-            long_name: '12345',
-            short_name: '12345',
-            types: ['postal_code']
-          }
-        ]
-      });
+      act(() =>
+        usePlacesWidgetMock.mock.calls[0][0].onPlaceSelected({
+          address_components: [
+            {
+              long_name: '12345',
+              short_name: '12345',
+              types: ['postal_code']
+            }
+          ]
+        })
+      );
       expect(screen.getByRole('textbox', { name: 'Address' })).toHaveValue('');
       expect(screen.getByRole('textbox', { name: 'City' })).toHaveValue('');
       expect(screen.getByRole('textbox', { name: 'State' })).toHaveValue('');

--- a/spa/src/components/donationPage/pageContent/DSwag.js
+++ b/spa/src/components/donationPage/pageContent/DSwag.js
@@ -96,6 +96,7 @@ function DSwag({ element, ...props }) {
                         inputProps={{ 'aria-label': 'controlled' }}
                         onChange={() => setNytCompSub(!nytCompSub)}
                         label="I'd like to include a New York Times subscription"
+                        value="nyt"
                       />
                     </motion.div>
                   )}

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'constants/authConstants';
 import { DONATIONS_CORE_UPGRADE_CLOSED } from 'hooks/useSessionState';
 import useUser from 'hooks/useUser';
-import { act, fireEvent, render, screen, waitFor } from 'test-utils';
+import { act, fireEvent, render, screen } from 'test-utils';
 import DonationUpgradePrompts from './DonationUpgradePrompts';
 import useContributionPageList from 'hooks/useContributionPageList';
 
@@ -179,7 +179,7 @@ describe('DonationUpgradePrompts', () => {
     });
 
     afterEach(() => {
-      jest.runOnlyPendingTimers();
+      act(() => jest.runOnlyPendingTimers());
       jest.useRealTimers();
     });
 

--- a/spa/src/components/errors/ChunkErrorBoundary.test.tsx
+++ b/spa/src/components/errors/ChunkErrorBoundary.test.tsx
@@ -16,6 +16,14 @@ const ChildWithError = () => {
 };
 
 describe('ChunkErrorBoundary', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => errorSpy.mockRestore());
+
   function tree(children: ReactNode) {
     return render(<ChunkErrorBoundary>{children}</ChunkErrorBoundary>);
   }

--- a/spa/src/components/errors/GenericErrorBoundary.test.js
+++ b/spa/src/components/errors/GenericErrorBoundary.test.js
@@ -19,29 +19,39 @@ function CustomFallbackComponent() {
   return <div data-testid={CUSTOM_FALLBACK_ID}></div>;
 }
 
-it('should render children by default', () => {
-  render(
-    <GenericErrorBoundary>
-      <ChildComponent />
-    </GenericErrorBoundary>
-  );
-  expect(screen.getByTestId(CHILD_ID)).toBeInTheDocument();
-});
+describe('GenericErrorBoundary', () => {
+  let errorSpy;
 
-it('should render default fallback component on error if fallback prop not provided', () => {
-  render(
-    <GenericErrorBoundary>
-      <BrokenChildComponent />
-    </GenericErrorBoundary>
-  );
-  expect(screen.getByText('Something went wrong loading this part of the page.')).toBeInTheDocument();
-});
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
 
-it('should render provided fallback component on error if fallback prop not provided', () => {
-  render(
-    <GenericErrorBoundary fallback={CustomFallbackComponent}>
-      <BrokenChildComponent />
-    </GenericErrorBoundary>
-  );
-  expect(screen.getByTestId(CUSTOM_FALLBACK_ID)).toBeInTheDocument();
+  afterEach(() => errorSpy.mockRestore());
+
+  it('should render children by default', () => {
+    render(
+      <GenericErrorBoundary>
+        <ChildComponent />
+      </GenericErrorBoundary>
+    );
+    expect(screen.getByTestId(CHILD_ID)).toBeInTheDocument();
+  });
+
+  it('should render default fallback component on error if fallback prop not provided', () => {
+    render(
+      <GenericErrorBoundary>
+        <BrokenChildComponent />
+      </GenericErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong loading this part of the page.')).toBeInTheDocument();
+  });
+
+  it('should render provided fallback component on error if fallback prop not provided', () => {
+    render(
+      <GenericErrorBoundary fallback={CustomFallbackComponent}>
+        <BrokenChildComponent />
+      </GenericErrorBoundary>
+    );
+    expect(screen.getByTestId(CUSTOM_FALLBACK_ID)).toBeInTheDocument();
+  });
 });

--- a/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
@@ -183,7 +183,7 @@ describe('serializeData', () => {
     mockForm.appendChild(mockElement);
   });
 
-  it.each([['swag_opt_out'], ['comp_subscription'], ['tribute_type_honoree'], ['tribute_type_in_memory_of']])(
+  it.each([['swag_opt_out'], ['tribute_type_honoree'], ['tribute_type_in_memory_of']])(
     'converts the %s form field to actual booleans',
     (fieldName) => {
       mockElement.setAttribute('name', fieldName);

--- a/spa/src/components/paymentProviders/stripe/stripeFns.ts
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.ts
@@ -42,7 +42,7 @@ export function getTotalAmount(
 }
 
 function serializeForm(form: HTMLFormElement) {
-  const booleans = ['swag_opt_out', 'comp_subscription', 'tribute_type_honoree', 'tribute_type_in_memory_of'];
+  const booleans = ['swag_opt_out', 'tribute_type_honoree', 'tribute_type_in_memory_of'];
   const tributesToConvert = { tribute_type_honoree: 'type_honoree', tribute_type_in_memory_of: 'type_in_memory_of' };
   const obj: Record<string, File | boolean | null | string> = {};
   const formData = new FormData(form);

--- a/spa/src/components/settings/Organization/Organization.test.tsx
+++ b/spa/src/components/settings/Organization/Organization.test.tsx
@@ -508,6 +508,8 @@ describe('Settings Organization Page', () => {
     });
 
     it('should show generic error if patch fails', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
       axiosMock.onPatch().networkError();
 
       tree();
@@ -524,6 +526,7 @@ describe('Settings Organization Page', () => {
       });
       expect(axiosMock.history.patch[0].url).toBe(`revenue-programs/1/`);
       expect(screen.getByText(GENERIC_ERROR)).toBeVisible();
+      errorSpy.mockRestore();
     });
   });
 

--- a/spa/src/elements/buttons/CircleButton.test.js
+++ b/spa/src/elements/buttons/CircleButton.test.js
@@ -1,7 +1,6 @@
-import { render, screen, fireEvent } from 'test-utils';
-
-import CircleButton from './CircleButton';
 import { faEdit } from '@fortawesome/free-solid-svg-icons';
+import { render, screen, fireEvent, waitFor } from 'test-utils';
+import CircleButton from './CircleButton';
 
 describe('Tooltips on CircleButton', () => {
   test('tooltip should show up on focus', async () => {
@@ -19,8 +18,8 @@ describe('Tooltips on CircleButton', () => {
     const editButton = screen.queryByTestId('edit-page-button');
 
     fireEvent.focusIn(editButton);
+    await waitFor(() => expect(screen.getByText('Test Tooltip Text')).toBeVisible());
 
-    await new Promise((r) => setTimeout(r, 2000));
     const ttext = screen.queryByText('Test Tooltip Text');
     expect(ttext).toBeInTheDocument();
   });


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Updates the swag block to send a `comp_subscription` value of `nyt` instead of a boolean. This is done in https://github.com/newsrevenuehub/rev-engine/pull/1154/commits/41c2051afdd7ed4f74074183c32cf08171c1900d.

Cleans up Jest warnings--not all of them, but those where I could find a fix through unit tests, or where the change was superficial. The cleanup is in f91514cabad51c68ef2a60d5cb5a2bb411aba491.

#### Why are we doing this? How does it help us?

This fell out of sync with the rest of the application.

I made the test updates because I was seeing repeated CI Jest failures and the output was hard to sort through.

#### How should this be manually tested? Please include detailed step-by-step instructions.

To test that NYT subscription options work:
1. Enable the NYT sub option on a contribution page.
2. Complete a contribution, choosing to receive an NYT subscription.
3. Confirm in Stripe that the `comp_subscription` metadata reflects that you selected to receive a subscription.

To test that opting out of a NYT subscription works:
1. Enable the NYT sub option on a contribution page.
2. Complete a contribution, leaving the NYT checkbox unchecked.
3. Confirm in Stripe that the contribution metadata doesn't contain `comp_subscription`.
4. Repeat steps 1-3 but instead of leaving the NYT checkbox unchecked, check the "Maximize my contribution" checkbox above it that hides swag options.
5. Repeat steps 1-3 but make a contribution below the threshold to receive swag.

To test that NYT-free contributions work:
1. Disable the NYT sub option on a contribution page.
2. Complete a contribution.
3. Confirm in Stripe that the contribution metadata doesn't contains `comp_subscription`. 

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

We don't have unit tests on DSwag but that it something potentially to tackle when we revise the swag editor.

There are still 2 test warnings left, but I wasn't able to find an easy solution for them.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3355

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.