### PR TITLE
DEV-3611: Bring back revenue_programs for superusers

### DIFF
--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -68,10 +68,7 @@ class UserSerializer(serializers.ModelSerializer):
             return []
         qs = RevenueProgram.objects.all()
         role_assignment = obj.get_role_assignment()
-        # TODO: revert to commented line below after or as part of DEV-3589 has shipped. This is temporarily
-        # set like this to allow superusers to authenticate before solving bug.
-        # if not role_assignment and not obj.is_superuser:
-        if not role_assignment:
+        if not role_assignment and not obj.is_superuser:
             qs = qs.none()
         elif not obj.is_superuser and role_assignment.role_type != Roles.HUB_ADMIN:
             if role_assignment.role_type == Roles.ORG_ADMIN:

--- a/apps/users/tests/test_serializers.py
+++ b/apps/users/tests/test_serializers.py
@@ -116,7 +116,7 @@ class UserSerializerTest(APITestCase):
     def test_get_permitted_revenue_programs(self):
         super_user_data = self._get_serialized_data_for_user(self.superuser_user)
         su_rp_ids = self._ids_from_data(super_user_data["revenue_programs"])
-        self.assertEqual(su_rp_ids, [])
+        self.assertEqual(su_rp_ids, list(RevenueProgram.objects.values_list("pk", flat=True)))
 
         hub_admin_data = self._get_serialized_data_for_user(self.hub_admin_user)
         ha_rp_ids = self._ids_from_data(hub_admin_data["revenue_programs"])


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Brings back logic related to superusers and revenue programs that was temporarily commented out for perf in c0eb862850994807070a366089fbb459cde6e416.

#### Why are we doing this? How does it help us?

Fixes a bug with the style editor.

#### How should this be manually tested? Please include detailed step-by-step instructions.

To test the proximate bug:

1. Log in as a super user.
2. Click the Customize section.
3. Create a new style.
4. Associate it to a revenue program.
5. Save changes.
6. Confirm you can apply this style to a page in the revenue program.

This change brings back functionality that had performance problems initially, so careful testing in the app for slowness is important here. We probably want to deploy this to staging ahead of prod for this reason. We should test the areas where we saw timeouts and other sluggishness previously.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3611
https://news-revenue-hub.atlassian.net/browse/DEV-3589 (where this functionality was originally commented out)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.