### PR TITLE
DEV-3625: Make RP name and slug searchable

### DIFF
--- a/apps/organizations/admin.py
+++ b/apps/organizations/admin.py
@@ -253,7 +253,7 @@ class RevenueProgramAdmin(RevEngineBaseAdmin, CompareVersionAdmin, AdminImageMix
         ),
     )
 
-    search_fields = ["payment_provider__stripe_account_id"]
+    search_fields = ["name", "slug", "payment_provider__stripe_account_id"]
 
     list_display = ["name", "organization", "slug", "payment_provider_url"]
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Makes revenue program name and slugs searchable in Django admin.

#### Why are we doing this? How does it help us?

Helps support staff.

#### How should this be manually tested? Please include detailed step-by-step instructions.

To test new functionality:

1. Log into the Django admin and go to the revenue programs page.
2. Do a search for a revenue program by name.
3. Confirm the correct results are returned.
4. Do a search for a revenue program by slug.
5. Confirm the correct results are returned.

To test existing functionality:

1. Log into the Django admin and go to the revenue programs page.
2. Do a search for a revenue program by its Stripe payment provider ID.
3. Confirm the correct results are returned.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No. This is a config change and it doesn't appear we have test around this kind of thing.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3625

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.