### PR TITLE
DEV-3688: Change unpublish modal for default page

### DIFF
--- a/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.stories.tsx
+++ b/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.stories.tsx
@@ -11,5 +11,11 @@ const Template: ComponentStory<typeof UnpublishModal> = (props) => <UnpublishMod
 export const Default = Template.bind({});
 Default.args = {
   open: true,
-  page: { name: 'Page Name' } as any
+  page: { id: 'mock-id', name: 'Page Name', revenue_program: {} } as any
+};
+
+export const PageIsDefault = Template.bind({});
+PageIsDefault.args = {
+  open: true,
+  page: { id: 'mock-id', name: 'Page Name', revenue_program: { default_donation_page: 'mock-id' } } as any
 };

--- a/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.styled.ts
+++ b/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.styled.ts
@@ -4,6 +4,10 @@ import styled from 'styled-components';
 
 export const ModalContent = styled(BaseModalContent)`
   width: 590px;
+
+  p {
+    font-family: Roboto, sans-serif;
+  }
 `;
 
 export const ModalHeaderIcon = styled(ReportOutlined)`

--- a/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.test.tsx
+++ b/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.test.tsx
@@ -2,16 +2,10 @@ import { axe } from 'jest-axe';
 import { fireEvent, render, screen } from 'test-utils';
 import UnpublishModal, { UnpublishModalProps } from './UnpublishModal';
 
+const mockPage = { id: 'mock-id', name: 'mock-page-name', revenue_program: { default_donation_page: 'default-id' } };
+
 function tree(props?: Partial<UnpublishModalProps>) {
-  return render(
-    <UnpublishModal
-      onClose={jest.fn()}
-      onUnpublish={jest.fn()}
-      open
-      page={{ name: 'mock-page-name' } as any}
-      {...props}
-    />
-  );
+  return render(<UnpublishModal onClose={jest.fn()} onUnpublish={jest.fn()} open page={mockPage as any} {...props} />);
 }
 
 describe('UnpublishModal', () => {
@@ -26,8 +20,36 @@ describe('UnpublishModal', () => {
   });
 
   describe('When open', () => {
+    describe('When the page is not the default for the revenue program', () => {
+      it('displays a "Unpublish Live Page" header', () => {
+        tree();
+        expect(screen.getByText('Unpublish Live Page')).toBeVisible();
+        expect(screen.queryByText('Unpublish Default Page')).not.toBeInTheDocument();
+      });
+
+      it('displays default content', () => {
+        tree();
+        expect(screen.getByTestId('unpublish-prompt')).toBeVisible();
+        expect(screen.queryByTestId('unpublish-default-prompt')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('When the page is the default for the revenue program', () => {
+      it('displays a "Unpublish Default Page" header', () => {
+        tree({ page: { ...mockPage, id: 'default-id' } as any });
+        expect(screen.getByText('Unpublish Default Page')).toBeVisible();
+        expect(screen.queryByText('Unpublish Live Page')).not.toBeInTheDocument();
+      });
+
+      it('displays default content', () => {
+        tree({ page: { ...mockPage, id: 'default-id' } as any });
+        expect(screen.getByTestId('unpublish-default-prompt')).toBeVisible();
+        expect(screen.queryByTestId('unpublish-prompt')).not.toBeInTheDocument();
+      });
+    });
+
     it('displays a prompt that includes the page name', () => {
-      tree({ page: { name: 'test-page-name' } as any });
+      tree({ page: { ...mockPage, name: 'test-page-name' } as any });
       expect(screen.getByTestId('unpublish-prompt')).toHaveTextContent(
         "Are you sure you want to unpublish 'test-page-name'?"
       );

--- a/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.tsx
+++ b/spa/src/components/common/Button/PublishButton/UnpublishModal/UnpublishModal.tsx
@@ -21,20 +21,36 @@ export function UnpublishModal({ onClose, onUnpublish, open, page }: UnpublishMo
     return null;
   }
 
+  const isDefault = page.revenue_program.default_donation_page === page.id;
+  const header = isDefault ? 'Unpublish Default Page' : 'Unpublish Live Page';
+  const content = isDefault ? (
+    <>
+      <p data-testid="unpublish-default-prompt">
+        Are you sure you want to unpublish your default contribution page, <strong>'{page.name}'</strong>? You will need
+        to update the link anywhere you are currently using it (e.g. buttons, email campaigns).
+      </p>
+      <p>
+        <strong>Unpublishing a default contribution page will remove the ability to redirect inactive links.</strong>
+      </p>
+    </>
+  ) : (
+    <>
+      <p data-testid="unpublish-prompt">
+        Are you sure you want to unpublish <strong>'{page.name}'</strong>?
+      </p>
+      <p>
+        Once unpublished, all links to this page will show an error when clicked. Be sure to replace links and buttons
+        on your website and email campaigns with the new page url.
+      </p>
+    </>
+  );
+
   return (
     <Modal onClose={onClose} open={!!open} width={590}>
       <ModalHeader icon={<ModalHeaderIcon />} onClose={onClose}>
-        <RedEmphasis>Unpublish Live Page</RedEmphasis>
+        <RedEmphasis>{header}</RedEmphasis>
       </ModalHeader>
-      <ModalContent>
-        <p data-testid="unpublish-prompt">
-          Are you sure you want to unpublish <strong>'{page.name}'</strong>?
-        </p>
-        <p>
-          Once unpublished, all links to this page will show an error when clicked. Be sure to replace links and buttons
-          on your website and email campaigns with the new page url.
-        </p>
-      </ModalContent>
+      <ModalContent>{content}</ModalContent>
       <ModalFooter>
         <Button color="secondary" onClick={onClose}>
           Cancel


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Changes the text in the unpublish modal for pages that are the default for their revenue program.

#### Why are we doing this? How does it help us?

Improved UX.

#### How should this be manually tested? Please include detailed step-by-step instructions.

I noticed some visual glitches locally when testing with a page with a custom font set, but they should be fixed now--think it would be good to QA this with pages with custom styles.

To test the default behavior is still present:

1. Edit a published page.
2. Unpublish it.
3. Confirm the modal header and content match the existing appearance (e.g. compare with a deployed tier).
4. Click Cancel.
5. Confirm that the modal closes and the page isn't unpublished.
6. Repeat steps 1-3 but click Unpublish.
7. Confirm the page is now unpublished.

To test new behavior:

1. Edit a published page that is the default for its revenue program.
2. Unpublish it.
3. Confirm the modal header and content match Figma ⚠️ The Figma may have outdated refs to "checkout pages" instead of "contribution page".
4. Click Cancel.
5. Confirm that the modal closes and the page isn't unpublished.
6. Repeat steps 1-3 but click Unpublish.
7. Confirm the page is now unpublished.
 
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Might want to document this new warning and how someone should decide what to do.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

Updated docs.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3688

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.