### PR TITLE
DEV-3717: Prevent Plus users from connecting to Mailchimp

### DIFF
--- a/spa/src/hooks/useConnectMailchimp.test.tsx
+++ b/spa/src/hooks/useConnectMailchimp.test.tsx
@@ -412,7 +412,7 @@ describe('useConnectMailchimp hook', () => {
         }
       );
 
-      it('returns a sendUserToMailchimp function which redirects the user to the URL provided by the API', async () => {
+      it('returns a sendUserToMailchimp function which redirects the user to the URL provided by the API if the user has the access flag and is on the Core plan', async () => {
         const mailchimpURL = `https://login.mailchimp.com/oauth2/authorize?${queryString.stringify({
           response_type: 'code',
           client_id: NRE_MAILCHIMP_CLIENT_ID,

--- a/spa/src/hooks/useConnectMailchimp.test.tsx
+++ b/spa/src/hooks/useConnectMailchimp.test.tsx
@@ -428,6 +428,29 @@ describe('useConnectMailchimp hook', () => {
         expect(assignSpy.mock.calls).toEqual([[mailchimpURL]]);
       });
 
+      it("doesn't return a sendUserToMailchimp function if the user doesn't have the Mailchimp access flag", async () => {
+        useFeatureFlagsMock.mockReturnValue({ flags: [], isLoading: false, isError: false });
+
+        const { result, waitFor } = hook();
+
+        await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
+        expect(result.current.sendUserToMailchimp).toBeUndefined();
+      });
+
+      it.each([['FREE'], ['PLUS']])(
+        "doesn't return a sendUserToMailchimp function if the user is on the %s plan",
+        async (planName) => {
+          useUserMock.mockReturnValue({
+            ...mockUseUserResult,
+            user: { ...mockUser, organizations: [{ ...mockUser.organizations[0], plan: { name: planName } as any }] }
+          });
+          const { result, waitFor } = hook();
+
+          await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
+          expect(result.current.sendUserToMailchimp).toBeUndefined();
+        }
+      );
+
       it('returns a selectAudience function that makes a PATCH request that sets mailchimp_list_id', async () => {
         const { result, waitFor } = hook();
 

--- a/spa/src/hooks/useConnectMailchimp.tsx
+++ b/spa/src/hooks/useConnectMailchimp.tsx
@@ -97,10 +97,10 @@ export default function useConnectMailchimp(): UseConnectMailchimpResult {
     result.isLoading = false;
   }
 
-  // If we have access to Mailchimp through the feature flag, are on a paid
+  // If we have access to Mailchimp through the feature flag, are on the Core
   // plan, and Mailchimp status has loaded, allow the user to connect to it.
 
-  if (result.hasMailchimpAccess && result.organizationPlan !== 'FREE' && mailchimpData) {
+  if (result.hasMailchimpAccess && result.organizationPlan === 'CORE' && mailchimpData) {
     result.sendUserToMailchimp = sendUserToMailchimp;
   }
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Adds additional logic to the Mailchimp hook so that only Core users can connect to it.

#### Why are we doing this? How does it help us?

See Jira for more details--tl;dr is it will speed up Core onboarding.

#### How should this be manually tested? Please include detailed step-by-step instructions.

I'll make a table here with different user configurations and expected outcome--although laborious, we should test them all.

| Plan | Has Feature Flag? | Mailchimp toggle on Integrations page                         |
| ---- | ----------------- | ------------------------------------------------------------- |
| Free | No                | Disabled and does nothing when clicked                        |
| Free | Yes               | Disabled and does nothing when clicked                        |
| Core | No                | Disabled and does nothing when clicked                        |
| Core | Yes               | Enabled and begins Mailchimp integration process when clicked |
| Plus | No                | Disabled and does nothing when clicked                        |
| Plus | Yes               | Disabled and does nothing when clicked                        |

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

Not needed, I think.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3717

#### Do any changes need to be made before deployment to production (adding environment variables, for example)?

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.