### PR TITLE
DEV-3651 | Solve for n+1 query on contributor admin

### DIFF
--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -42,12 +42,14 @@ class ContributorAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
         We use this approach (annotating) vs. defining a property on model in order to avoid
         n+1 queries when rendering the list view
         """
+        logger.debug("ContributorAdmin.get_queryset - annotating queryset with contributions_count")
         queryset = super().get_queryset(request)
         queryset = queryset.annotate(contributions_count=Count("contribution"))
         return queryset
 
     def contributions_count(self, obj: Contributor) -> int:
         """Number of contributions found for this contributor"""
+        logger.debug("ContributorAdmin.contributions_count - returning %s", obj.contributions_count)
         return obj.contributions_count
 
 

--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -1,7 +1,11 @@
 import logging
+from typing import Any
 
 from django.conf import settings
 from django.contrib import admin, messages
+from django.db.models import Count
+from django.db.models.query import QuerySet
+from django.http.request import HttpRequest
 from django.utils.html import format_html
 
 from reversion_compare.admin import CompareVersionAdmin
@@ -32,6 +36,16 @@ class ContributorAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
         "contributions_count",
         "most_recent_contribution",
     )
+
+    def get_queryset(self, request: HttpRequest) -> QuerySet[Any]:
+        """ """
+        queryset = super().get_queryset(request)
+        queryset = queryset.annotate(contributions_count=Count("contribution"))
+        return queryset
+
+    def contributions_count(self, obj):
+        """"""
+        return obj.contributions_count
 
 
 @admin.register(Contribution)

--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 from django.conf import settings
 from django.contrib import admin, messages
@@ -32,19 +31,23 @@ class ContributorAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
     search_fields = ("email",)
 
     readonly_fields = (
-        "email",
         "contributions_count",
+        "email",
         "most_recent_contribution",
     )
 
-    def get_queryset(self, request: HttpRequest) -> QuerySet[Any]:
-        """ """
+    def get_queryset(self, request: HttpRequest) -> QuerySet[Contributor]:
+        """We annotate the queryset with the number of contributions for each contributor
+
+        We use this approach (annotating) vs. defining a property on model in order to avoid
+        n+1 queries when rendering the list view
+        """
         queryset = super().get_queryset(request)
         queryset = queryset.annotate(contributions_count=Count("contribution"))
         return queryset
 
-    def contributions_count(self, obj):
-        """"""
+    def contributions_count(self, obj: Contributor) -> int:
+        """Number of contributions found for this contributor"""
         return obj.contributions_count
 
 

--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import uuid
 from dataclasses import asdict
+from functools import cached_property
 from typing import List
 from urllib.parse import quote_plus
 
@@ -41,7 +42,7 @@ class Contributor(IndexedTimeStampedModel):
     uuid = models.UUIDField(default=uuid.uuid4, primary_key=False, editable=False)
     email = models.EmailField(unique=True)
 
-    @property
+    @cached_property
     def contributions_count(self):
         return self.contribution_set.count()
 

--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import uuid
 from dataclasses import asdict
-from functools import cached_property
 from typing import List
 from urllib.parse import quote_plus
 
@@ -41,10 +40,6 @@ class ContributionStatusError(Exception):
 class Contributor(IndexedTimeStampedModel):
     uuid = models.UUIDField(default=uuid.uuid4, primary_key=False, editable=False)
     email = models.EmailField(unique=True)
-
-    @cached_property
-    def contributions_count(self):
-        return self.contribution_set.count()
 
     @property
     def most_recent_contribution(self):

--- a/apps/contributions/tests/test_admin.py
+++ b/apps/contributions/tests/test_admin.py
@@ -14,8 +14,8 @@ from reversion_compare.admin import CompareVersionAdmin
 
 import apps
 from apps.common.tests.test_utils import setup_request
-from apps.contributions.admin import ContributionAdmin
-from apps.contributions.models import Contribution, ContributionStatus
+from apps.contributions.admin import ContributionAdmin, ContributorAdmin
+from apps.contributions.models import Contribution, ContributionStatus, Contributor
 from apps.contributions.tests.factories import ContributionFactory
 from apps.organizations.tests.factories import (
     OrganizationFactory,
@@ -23,6 +23,17 @@ from apps.organizations.tests.factories import (
     RevenueProgramFactory,
 )
 from apps.pages.tests.factories import DonationPageFactory
+
+
+class TestContributorAdmin:
+    def test_contributions_count(self, client, admin_user):
+        """Number of contributions found for this contributor"""
+        contribution = ContributionFactory()
+        assert Contribution.objects.filter(contributor=contribution.contributor).count() == (expected := 1)
+        client.force_login(admin_user)
+        admin = ContributorAdmin(Contributor, AdminSite())
+        qs = admin.get_queryset(None)
+        assert qs.first().contributions_count == expected
 
 
 @mock.patch("apps.contributions.models.Contribution.fetch_stripe_payment_method", return_value=None)

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -39,14 +39,6 @@ from apps.users.choices import Roles
 
 @pytest.mark.django_db
 class TestContributorModel:
-    def test_contributions_count(self, contributor_user):
-        target_count = 3
-        ContributionFactory.create_batch(
-            size=target_count,
-            contributor=contributor_user,
-        )
-        assert contributor_user.contributions_count == target_count
-
     def test_most_recent_contribution(self, contributor_user):
         ContributionFactory.create_batch(size=3, contributor=contributor_user, status=ContributionStatus.PAID)
         ContributionFactory(contributor=contributor_user, status=ContributionStatus.REFUNDED)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR fixes an n+1 query in the list view for Contributor admin. 

It retires a property on the Contributor model — `contributions_count` — that was only used by the admin in favor of annotating contributions count on the queryset in the modeladmin. This solves for the n+1 query.


#### Why are we doing this? How does it help us?

FIx a bug in prod that causes the contributor admin not to load (which is blocking importing legacy contributions into revengine).


#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?


Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-3651](https://news-revenue-hub.atlassian.net/browse/DEV-3651)
- [DEV-3897](https://news-revenue-hub.atlassian.net/browse/DEV-3897)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:


No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

[DEV-3897](https://news-revenue-hub.atlassian.net/browse/DEV-3897)


[DEV-3651]: https://news-revenue-hub.atlassian.net/browse/DEV-3651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ