### PR TITLE
DEV-3942: Bump style quota for free plan to 2

### DIFF
--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -62,7 +62,7 @@ class Plan:
     page_elements: list[str] = field(default_factory=lambda: DEFAULT_PERMITTED_PAGE_ELEMENTS)
     page_limit: int = 2
     publish_limit: int = 1
-    style_limit: int = 1
+    style_limit: int = 2
     custom_thank_you_page_enabled: bool = False
 
 

--- a/apps/organizations/tests/test_models.py
+++ b/apps/organizations/tests/test_models.py
@@ -77,7 +77,7 @@ class TestPlans:
             "name": "FREE",
             "label": "Free",
             "page_limit": 2,
-            "style_limit": 1,
+            "style_limit": 2,
             "custom_thank_you_page_enabled": False,
             "sidebar_elements": DEFAULT_PERMITTED_SIDEBAR_ELEMENTS,
             "page_elements": DEFAULT_PERMITTED_PAGE_ELEMENTS,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Raises the style limit for free plans to 2. This is to facilitate each page having a style, now that we are linking pages to styles directly.

#### Why are we doing this? How does it help us?

Allows users to create two fully-fledged pages.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Updated test around style limit.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3942

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.