### PR TITLE
DEV-3659 | Complete recurring payment fails in Django admin

### DIFF
--- a/apps/contributions/payment_managers.py
+++ b/apps/contributions/payment_managers.py
@@ -218,7 +218,7 @@ class StripePaymentManager(PaymentManager):
                         # if we don't explicitly convert to a dict
                         "payment_provider_data": dict(subscription),
                         "provider_subscription_id": subscription.id,
-                        "provider_payment_id": subscription.latest_invoice.payment_intent,
+                        "provider_payment_id": subscription.latest_invoice.payment_intent.id,
                     }
                 )
             except stripe.error.StripeError as stripe_error:


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR fixes a bug that caused accepting flagged payments in Django admin to fail.

The problem was that there was code that incorrectly assumed that value being passed was a string instead of an object (specifically, it assumed that the value for subscription.latest_invoice.payment_intent was an ID, not an object, when in reality that value is an object because we expand latest_invoice.payment_intent when creating the sub).

#### Why are we doing this? How does it help us?

Make accepting flagged payments work

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Just updated existing ones

#### How should this change be communicated to end users?

Tell Tristan he can accept payments from Django admin again.

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-3659](https://news-revenue-hub.atlassian.net/browse/DEV-3659)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No

[DEV-3659]: https://news-revenue-hub.atlassian.net/browse/DEV-3659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ