### PR TITLE
DEV-3798: hub admin spa optimizations

### DIFF
--- a/spa/src/components/common/Button/ContributionPageButton/ContributionPageButton.styled.ts
+++ b/spa/src/components/common/Button/ContributionPageButton/ContributionPageButton.styled.ts
@@ -46,9 +46,12 @@ export const PublishedBadge = styled.div`
 `;
 
 export const PreviewImage = styled.div`
-  background-position: top center;
-  background-repeat: no-repeat;
-  background-size: cover;
+  img {
+    height: 100%;
+    object-fit: cover;
+    object-position: top center;
+    width: 100%;
+  }
 `;
 
 export const PreviewPlaceholder = styled.div`

--- a/spa/src/components/common/Button/ContributionPageButton/ContributionPageButton.test.tsx
+++ b/spa/src/components/common/Button/ContributionPageButton/ContributionPageButton.test.tsx
@@ -1,5 +1,5 @@
 import { axe } from 'jest-axe';
-import { fireEvent, render, screen } from 'test-utils';
+import { fireEvent, render, screen, within } from 'test-utils';
 import ContributionPageButton, { ContributionPageButtonProps } from './ContributionPageButton';
 
 jest.mock('./DefaultPageButton');
@@ -25,7 +25,7 @@ describe('ContributionPageButton', () => {
   it('displays the page screenshot', () => {
     tree();
     expect(screen.queryByText('No preview')).not.toBeInTheDocument();
-    expect(screen.getByTestId('preview-image').style.backgroundImage).toBe('url(mock-page-screenshot)');
+    expect(within(screen.getByTestId('preview-image')).getByRole('img')).toHaveAttribute('src', 'mock-page-screenshot');
   });
 
   it('displays "No Preview" when the page has no screenshot', () => {

--- a/spa/src/components/common/Button/ContributionPageButton/ContributionPageButton.tsx
+++ b/spa/src/components/common/Button/ContributionPageButton/ContributionPageButton.tsx
@@ -26,11 +26,13 @@ export function ContributionPageButton({ page, ...other }: ContributionPageButto
       <Label>{page.name}</Label>
     );
 
+  // Lazy load images so that if in a long list of previews, we only load the
+  // ones visible to the user (or nearly visible)/
+
   const preview = page.page_screenshot ? (
-    <PreviewImage
-      data-testid="preview-image"
-      style={{ backgroundImage: `url(${page.page_screenshot})` }}
-    ></PreviewImage>
+    <PreviewImage data-testid="preview-image">
+      <img src={page.page_screenshot} alt="" loading="lazy" />
+    </PreviewImage>
   ) : (
     <PreviewPlaceholder>No preview</PreviewPlaceholder>
   );

--- a/spa/src/hooks/useContributionPageList.ts
+++ b/spa/src/hooks/useContributionPageList.ts
@@ -85,6 +85,9 @@ function useContributionPageList(): UseContributionPageListResult {
     retry: (failureCount, error) => {
       return (error as Error).name !== 'AuthenticationError' && failureCount < 1;
     },
+    // Retain data for 2 minutes, same as useUser. Mutations will invalidate
+    // the cache immediately.
+    staleTime: 120000,
     onError: (error) => {
       if ((error as Error).name === 'AuthenticationError') {
         history.push(SIGN_IN);


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Adds a stale time to page list retrieval to avoid duplicate requests when loading the admin dashboard.
- Reworks page previews to use [lazy-loaded images](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading#images_and_iframes).

#### Why are we doing this? How does it help us?

Speeds up load time for hub admins.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Updated existing tests.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3798

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.