### PR TITLE
DEV-3509 | No longer set receipt_email when creating payment intent

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -433,7 +433,6 @@ class Contribution(IndexedTimeStampedModel):
             currency=self.currency,
             customer=self.provider_customer_id,
             metadata=metadata,
-            receipt_email=self.contributor.email,
             statement_descriptor_suffix=self.donation_page.revenue_program.stripe_statement_descriptor_suffix,
             stripe_account=self.donation_page.revenue_program.stripe_account_id,
             capture_method="manual" if self.status == ContributionStatus.FLAGGED else "automatic",

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -385,7 +385,6 @@ class TestContributionModel:
             amount=one_time_contribution.amount,
             currency=one_time_contribution.currency,
             customer=one_time_contribution.provider_customer_id,
-            receipt_email=one_time_contribution.contributor.email,
             metadata=metadata,
             statement_descriptor_suffix=(
                 (rp := one_time_contribution.donation_page.revenue_program).stripe_statement_descriptor_suffix

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -1200,7 +1200,6 @@ class TestCreateOneTimePaymentSerializer:
             "amount": contribution.amount,
             "currency": contribution.currency,
             "customer": contribution.provider_customer_id,
-            "receipt_email": contribution.contributor.email,
             "statement_descriptor_suffix": None,
             "stripe_account": contribution.donation_page.revenue_program.payment_provider.stripe_account_id,
             "capture_method": "manual",


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

The underlying bug we're trying to solve for is this:  a Stripe account can set its preferences around Stripe-sent receipt emails. Orgs want to be able to turn off Stripe sent receipt emails, and they have that ability in the Stripe dashboard.

However, we learned that in our code for creating payment intents in revengine, we are setting a `receipt_email` property. This has an undesired side-effect of causing the account-level receipt email to be overridden (in case that it's set to false).

In this PR, we no longer pass through a value for optional `receipt_email` parameter when creating a stripe.PaymentIntent. This will solve the problem moving forward.

That still leaves solving the problem for all existing PIs. We'll do that in [DEV-4129](https://news-revenue-hub.atlassian.net/browse/DEV-4129)


#### Why are we doing this? How does it help us?

Allow orgs to decide whether or not Stripe sends receipt emails on their behalf.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

In progress

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

No. But two existing tests were updated.

#### How should this change be communicated to end users?

We could let orgs that raised this as an issue that we've fixed it.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-3509](https://news-revenue-hub.atlassian.net/browse/DEV-3509)
- [DEV-4129](https://news-revenue-hub.atlassian.net/browse/DEV-4129)


#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:


No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

[DEV-4129](https://news-revenue-hub.atlassian.net/browse/DEV-4129)

[DEV-3509]: https://news-revenue-hub.atlassian.net/browse/DEV-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEV-4129]: https://news-revenue-hub.atlassian.net/browse/DEV-4129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ