### PR TITLE
DEV-4104: Fix page name field appearance

### DIFF
--- a/spa/src/components/pageEditor/PageName/PageName.styled.ts
+++ b/spa/src/components/pageEditor/PageName/PageName.styled.ts
@@ -54,9 +54,11 @@ export const TextField = styled(BaseTextField)`
     margin-right: 14px;
     width: 400px;
 
-    input[type='text'] {
+    .NreTextFieldInput {
+      background-color: #3d2947;
+      border: none;
       color: ${({ theme }) => theme.basePalette.greyscale.white};
-      height: 9px; /* works out to 34px total with padding */
+      height: 0; /* works out to 34px total with padding */
 
       &::selection {
         background-color: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Fixes appearance of page name field in the editor.

#### Why are we doing this? How does it help us?

Users can't see the text when the field is focused right now.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No, appearance changes only.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4104

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.