### PR TITLE
DEV-3971: Fix page list search

### DIFF
--- a/spa/src/components/common/Button/ContributionPageButton/__mocks__/ContributionPageButton.tsx
+++ b/spa/src/components/common/Button/ContributionPageButton/__mocks__/ContributionPageButton.tsx
@@ -1,0 +1,7 @@
+import { ContributionPageButtonProps } from '../ContributionPageButton';
+
+export const ContributionPageButton = (props: ContributionPageButtonProps) => (
+  <div data-testid={`mock-contribution-page-button-${props.page.id}`}>
+    <button onClick={props.onClick}>{props.page.name}</button>
+  </div>
+);

--- a/spa/src/components/content/pages/Pages.tsx
+++ b/spa/src/components/content/pages/Pages.tsx
@@ -1,3 +1,4 @@
+import orderBy from 'lodash.orderby';
 import { useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import join from 'url-join';
@@ -12,30 +13,6 @@ import { isStringInStringCaseInsensitive } from 'utilities/isStringInString';
 import AddPage from './AddPage';
 import { Content, PageUsage } from './Pages.styled';
 
-/**
- * Custom sort function for contribution pages. Sorts by revenue program name,
- * then page name.
- */
-function comparePages(a: ContributionPage, b: ContributionPage) {
-  if (a.revenue_program.name < b.revenue_program.name) {
-    return -1;
-  }
-
-  if (a.revenue_program.name > b.revenue_program.name) {
-    return 1;
-  }
-
-  if (a.name < b.name) {
-    return -1;
-  }
-
-  if (a.name > b.name) {
-    return 1;
-  }
-
-  return 0;
-}
-
 function Pages() {
   const history = useHistory();
   const [pageSearchQuery, setPageSearchQuery] = useState('');
@@ -48,18 +25,19 @@ function Pages() {
     // Filter by search query, then sort. A page might not have a slug.
 
     if (pageSearchQuery === '') {
-      return [...pages].sort(comparePages);
+      return orderBy(pages, ['revenue_program.name', 'name']);
     }
 
-    return pages
-      .filter(
+    return orderBy(
+      pages.filter(
         (page) =>
           (page.slug && isStringInStringCaseInsensitive(page.slug, pageSearchQuery)) ||
           isStringInStringCaseInsensitive(page.name, pageSearchQuery) ||
           isStringInStringCaseInsensitive(page.revenue_program.name, pageSearchQuery) ||
           isStringInStringCaseInsensitive(page.revenue_program.slug, pageSearchQuery)
-      )
-      .sort(comparePages);
+      ),
+      ['revenue_program.name', 'name']
+    );
   }, [pageSearchQuery, pages]);
 
   const handleEditPage = (page: ContributionPage) =>

--- a/spa/src/hooks/useContributionPage/useContributionPage.types.ts
+++ b/spa/src/hooks/useContributionPage/useContributionPage.types.ts
@@ -373,9 +373,9 @@ export interface ContributionPage {
    */
   plan: EnginePlan;
   /**
-   * Slug of the page that's used in URLs.
+   * Slug of the page that's used in URLs. This is null when the page is unpublished.
    */
-  slug: string;
+  slug: string | null;
   /**
    * ID of the template used to create the page initially.
    */

--- a/spa/src/hooks/usePayment.test.ts
+++ b/spa/src/hooks/usePayment.test.ts
@@ -133,6 +133,13 @@ describe('usePayment', () => {
         expect(axiosMock.history.post[0].headers['X-CSRFTOKEN']).toBe('mock-csrf-token');
       });
 
+      it("rejects and doesn't do a POST if the page has no slug", async () => {
+        const { result } = hook();
+
+        await expect(result.current.createPayment!(mockFormData, { ...mockPage, slug: null })).rejects.toThrow();
+        expect(axiosMock.history.post.length).toBe(0);
+      });
+
       it("rejects and doesn't do a POST if mailing country is undefined or an empty string", async () => {
         const { result } = hook();
 

--- a/spa/src/hooks/usePayment.ts
+++ b/spa/src/hooks/usePayment.ts
@@ -104,6 +104,13 @@ export function usePayment() {
   );
   const createPayment = useCallback(
     async (paymentData: PaymentData, page: ContributionPage) => {
+      // A published page should always have a slug, so this shouldn't happen in
+      // practice.
+
+      if (page.slug === null) {
+        throw new Error('Page has no slug set');
+      }
+
       if (!paymentData.mailing_country || paymentData.mailing_country === '') {
         throw new Error('Country must be set');
       }
@@ -127,7 +134,7 @@ export function usePayment() {
             currency: page.currency ?? { code: 'USD', symbol: '$' },
             emailHash: data.email_hash,
             interval: paymentData.interval as ContributionInterval,
-            pageSlug: page.slug,
+            pageSlug: page.slug!,
             revenueProgramSlug: page.revenue_program.slug,
             stripe: {
               // Checked before the mutation runs.


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Updates the type declaration of contribution page slugs to reflect that they might be `null`.
- Updates page search on the pages list to:
    - Not try to search on null slugs (core problem in this story).
    - Memoize the results to avoid unnecessary work.
    - Flatten the results; previously we were creating a dictionary indexed by RP name, but we don't need that for display.
- Updates page list to move the loading spinner lower on the page, to the pages list, so that more of the UI loads upfront. 
- Adds logic to handle this scenario on a contribution page (but it should never happen in practice).

#### Why are we doing this? How does it help us?

Fixes a bug.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3971

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.