### PR TITLE
DEV-4145: Replicate OrgAdmin page publish limit error for HubAdmin

### DIFF
--- a/apps/organizations/serializers.py
+++ b/apps/organizations/serializers.py
@@ -83,10 +83,12 @@ class RevenueProgramForDonationPageListSerializer(serializers.ModelSerializer):
     The field requirements here are determined by what the SPA needs
     """
 
+    organization = OrganizationInlineSerializer()
+
     class Meta:
         model = RevenueProgram
-        fields = _RP_FOR_DONATION_PAGE_LIST_SERIALIZER_FIELDS
-        read_only_fields = _RP_FOR_DONATION_PAGE_LIST_SERIALIZER_FIELDS
+        fields = _RP_FOR_DONATION_PAGE_LIST_SERIALIZER_FIELDS + ("organization",)
+        read_only_fields = fields
 
 
 class RevenueProgramForPageDetailSerializer(serializers.ModelSerializer):

--- a/apps/organizations/serializers.py
+++ b/apps/organizations/serializers.py
@@ -83,8 +83,6 @@ class RevenueProgramForDonationPageListSerializer(serializers.ModelSerializer):
     The field requirements here are determined by what the SPA needs
     """
 
-    organization = OrganizationInlineSerializer()
-
     class Meta:
         model = RevenueProgram
         fields = _RP_FOR_DONATION_PAGE_LIST_SERIALIZER_FIELDS + ("organization",)

--- a/spa/cypress/fixtures/pages/list-pages-1-live.json
+++ b/spa/cypress/fixtures/pages/list-pages-1-live.json
@@ -1,33 +1,47 @@
 [
   {
-      "id": 29,
-      "name": "Aspen Journalism",
-      "published_date": "2020-09-17T00:00:00",
-      "page_screenshot": null,
-      "slug": "donate",
-      "revenue_program": {
-          "id": 10,
-          "name": "Aspen Journalism RP",
-          "slug": "aspenjournalism",
-          "twitter_handle": "",
-          "website_url": "",
-          "contact_email": "",
-          "address": ", , "
+    "id": 29,
+    "name": "Aspen Journalism",
+    "published_date": "2020-09-17T00:00:00",
+    "page_screenshot": null,
+    "slug": "donate",
+    "revenue_program": {
+      "id": 10,
+      "name": "Aspen Journalism RP",
+      "slug": "aspenjournalism",
+      "twitter_handle": "",
+      "website_url": "",
+      "contact_email": "",
+      "address": ", , ",
+      "organization": {
+        "id": 10,
+        "plan": {
+          "name": "Free",
+          "publish_limit": 1
+        }
       }
+    }
   },
   {
-      "id": 483,
-      "name": "Another",
-      "page_screenshot": null,
-      "slug": "my-other-page",
-      "revenue_program": {
-          "id": 11,
-          "name": "Another RP",
-          "slug": "aspenjournalism-part-deux",
-          "twitter_handle": "",
-          "website_url": "",
-          "contact_email": "",
-          "address": ", , "
+    "id": 483,
+    "name": "Another",
+    "page_screenshot": null,
+    "slug": "my-other-page",
+    "revenue_program": {
+      "id": 11,
+      "name": "Another RP",
+      "slug": "aspenjournalism-part-deux",
+      "twitter_handle": "",
+      "website_url": "",
+      "contact_email": "",
+      "address": ", , ",
+      "organization": {
+        "id": 10,
+        "plan": {
+          "name": "Free",
+          "publish_limit": 1
+        }
       }
+    }
   }
 ]

--- a/spa/cypress/fixtures/pages/list-pages-1.json
+++ b/spa/cypress/fixtures/pages/list-pages-1.json
@@ -11,7 +11,14 @@
       "twitter_handle": "",
       "website_url": "",
       "contact_email": "",
-      "address": ", , "
+      "address": ", , ",
+      "organization": {
+        "id": 10,
+        "plan": {
+          "name": "Free",
+          "publish_limit": 1
+        }
+      }
     }
   },
   {
@@ -26,7 +33,14 @@
       "twitter_handle": "",
       "website_url": "",
       "contact_email": "",
-      "address": ", , "
+      "address": ", , ",
+      "organization": {
+        "id": 10,
+        "plan": {
+          "name": "Free",
+          "publish_limit": 1
+        }
+      }
     }
   }
 ]

--- a/spa/cypress/fixtures/pages/live-page-1.json
+++ b/spa/cypress/fixtures/pages/live-page-1.json
@@ -134,7 +134,8 @@
     "id": 123,
     "fontSizes": ["12px", "16px", "24px", "32px", "48px", "84px", "96px"],
     "font": {
-      "body": "'Roboto', sans-serif", "heading": "'Roboto', sans-serif"
+      "body": "'Roboto', sans-serif",
+      "heading": "'Roboto', sans-serif"
     },
     "radii": ["20px", "40px", "80px"],
     "colors": {
@@ -157,7 +158,13 @@
     "name": "MyRevProgram",
     "contact_email": "myrevprogram@mycompany.com",
     "address": "123 Fake Street, Durham, NC 27701",
-    "organization": 14,
+    "organization": {
+      "id": 10,
+      "plan": {
+        "name": "Free",
+        "publish_limit": 1
+      }
+    },
     "default_donation_page": null,
     "google_analytics_v3_id": "UA-2222222",
     "google_analytics_v3_domain": "www.google.com",

--- a/spa/cypress/fixtures/pages/live-page-element-validation.json
+++ b/spa/cypress/fixtures/pages/live-page-element-validation.json
@@ -15,7 +15,14 @@
     "google_analytics_v3_domain": null,
     "google_analytics_v3_id": null,
     "google_analytics_v4_id": null,
-    "facebook_pixel_id": null
+    "facebook_pixel_id": null,
+    "organization": {
+      "id": 10,
+      "plan": {
+        "name": "Free",
+        "publish_limit": 1
+      }
+    }
   },
   "payment_provider": {
     "id": 2,

--- a/spa/cypress/fixtures/pages/patch-page.json
+++ b/spa/cypress/fixtures/pages/patch-page.json
@@ -15,7 +15,14 @@
     "google_analytics_v3_domain": null,
     "google_analytics_v3_id": null,
     "google_analytics_v4_id": null,
-    "facebook_pixel_id": null
+    "facebook_pixel_id": null,
+    "organization": {
+      "id": 10,
+      "plan": {
+        "name": "Free",
+        "publish_limit": 1
+      }
+    }
   },
   "payment_provider": {
     "id": 2,

--- a/spa/cypress/fixtures/pages/unpublished-page-1.json
+++ b/spa/cypress/fixtures/pages/unpublished-page-1.json
@@ -10,7 +10,13 @@
     "created": "2021-07-20T16:39:40.559524Z",
     "modified": "2021-07-20T16:39:40.559524Z",
     "name": "MyProgram",
-    "organization": 14,
+    "organization": {
+      "id": 10,
+      "plan": {
+        "name": "Free",
+        "publish_limit": 1
+      }
+    },
     "default_donation_page": null,
     "google_analytics_v3_id": "UA-2222222",
     "google_analytics_v3_domain": "www.google.com",
@@ -42,19 +48,8 @@
   "plan": {
     "name": "FREE",
     "label": "Free",
-    "sidebar_elements": [
-      "DRichText",
-      "DImage"
-    ],
-    "page_elements": [
-      "DAmount",
-      "DDonorAddress",
-      "DDonorInfo",
-      "DFrequency",
-      "DPayment",
-      "DReason",
-      "DRichText"
-    ],
+    "sidebar_elements": ["DRichText", "DImage"],
+    "page_elements": ["DAmount", "DDonorAddress", "DDonorInfo", "DFrequency", "DPayment", "DReason", "DRichText"],
     "page_limit": 1,
     "custom_thank_you_page_enabled": false
   }

--- a/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
@@ -3,18 +3,21 @@ import { axe } from 'jest-axe';
 import { act, render, screen, waitFor } from 'test-utils';
 import { AxiosError } from 'axios';
 import { GENERIC_ERROR } from 'constants/textConstants';
-import useContributionPageList from 'hooks/useContributionPageList';
 import { useEditablePageContext } from 'hooks/useEditablePage';
 import useUser from 'hooks/useUser';
 import PublishButton from './PublishButton';
 import { PLAN_NAMES } from 'constants/orgPlanConstants';
 import { useAlert } from 'react-alert';
+import { orgHasPublishPageLimit } from 'utilities/organizationPageLimit';
 
 jest.mock('react-alert', () => ({
   ...jest.requireActual('react-alert'),
   useAlert: jest.fn()
 }));
-jest.mock('hooks/useContributionPageList');
+jest.mock('utilities/organizationPageLimit');
+jest.mock('hooks/useContributionPageList', () => () => ({
+  useContributionPageList: jest.fn()
+}));
 jest.mock('hooks/useEditablePage');
 jest.mock('hooks/useUser');
 jest.mock('components/common/Modal/MaxPagesPublishedModal/MaxPagesPublishedModal');
@@ -51,7 +54,7 @@ const user = {
 describe('PublishButton', () => {
   const useAlertMock = useAlert as jest.Mock;
   const useEditablePageContextMock = useEditablePageContext as jest.Mock;
-  const useContributionPageListMock = useContributionPageList as jest.Mock;
+  const orgHasPublishPageLimitMock = orgHasPublishPageLimit as jest.Mock;
   const useUserMock = useUser as jest.Mock;
 
   function tree() {
@@ -61,7 +64,7 @@ describe('PublishButton', () => {
   beforeEach(() => {
     useAlertMock.mockReturnValue({ error: jest.fn() });
     useEditablePageContextMock.mockReturnValue({ isLoading: false, page: unpublishedPage });
-    useContributionPageListMock.mockReturnValue({ orgHasPublishPageLimit: () => true });
+    orgHasPublishPageLimitMock.mockReturnValue(true);
     useUserMock.mockReturnValue({ user });
   });
 
@@ -198,7 +201,7 @@ describe('PublishButton', () => {
 
       describe('And the user can publish a new page', () => {
         beforeEach(() => {
-          useContributionPageListMock.mockReturnValue({ orgHasPublishPageLimit: () => true });
+          orgHasPublishPageLimitMock.mockReturnValue(true);
         });
 
         it('shows an enabled button with label "Publish"', () => {
@@ -301,7 +304,7 @@ describe('PublishButton', () => {
       });
 
       describe("But the user can't publish new pages", () => {
-        beforeEach(() => useContributionPageListMock.mockReturnValue({ orgHasPublishPageLimit: () => false }));
+        beforeEach(() => orgHasPublishPageLimitMock.mockReturnValue(false));
 
         it('shows an enabled button with label "Publish"', () => {
           tree();

--- a/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { act, render, screen, waitFor } from 'test-utils';
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError } from 'axios';
 import { GENERIC_ERROR } from 'constants/textConstants';
 import useContributionPageList from 'hooks/useContributionPageList';
 import { useEditablePageContext } from 'hooks/useEditablePage';
@@ -25,7 +25,8 @@ jest.mock('./UnpublishModal/UnpublishModal');
 const unpublishedPage = {
   name: 'Contribution page',
   revenue_program: {
-    slug: 'news-revenue-hub'
+    slug: 'news-revenue-hub',
+    organization: { plan: { name: PLAN_NAMES.FREE } }
   },
   payment_provider: {
     stripe_verified: true
@@ -60,7 +61,7 @@ describe('PublishButton', () => {
   beforeEach(() => {
     useAlertMock.mockReturnValue({ error: jest.fn() });
     useEditablePageContextMock.mockReturnValue({ isLoading: false, page: unpublishedPage });
-    useContributionPageListMock.mockReturnValue({ userCanPublishPage: () => true });
+    useContributionPageListMock.mockReturnValue({ orgHasPublishPageLimit: () => true });
     useUserMock.mockReturnValue({ user });
   });
 
@@ -197,7 +198,7 @@ describe('PublishButton', () => {
 
       describe('And the user can publish a new page', () => {
         beforeEach(() => {
-          useContributionPageListMock.mockReturnValue({ userCanPublishPage: () => true });
+          useContributionPageListMock.mockReturnValue({ orgHasPublishPageLimit: () => true });
         });
 
         it('shows an enabled button with label "Publish"', () => {
@@ -300,7 +301,7 @@ describe('PublishButton', () => {
       });
 
       describe("But the user can't publish new pages", () => {
-        beforeEach(() => useContributionPageListMock.mockReturnValue({ userCanPublishPage: () => false }));
+        beforeEach(() => useContributionPageListMock.mockReturnValue({ orgHasPublishPageLimit: () => false }));
 
         it('shows an enabled button with label "Publish"', () => {
           tree();

--- a/spa/src/components/common/Button/PublishButton/PublishButton.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.tsx
@@ -18,6 +18,7 @@ import PublishedPopover from './PublishedPopover';
 import SuccessfulPublishModal from './SuccessfulPublishModal';
 import UnpublishModal from './UnpublishModal';
 import { Root, RootButton } from './PublishButton.styled';
+import { orgHasPublishPageLimit } from 'utilities/organizationPageLimit';
 
 const PublishButtonPropTypes = {
   className: PropTypes.string
@@ -47,7 +48,7 @@ function DisabledTooltip({ children, disabled }: { children: ReactElement; disab
 function PublishButton({ className }: PublishButtonProps) {
   const alert = useAlert();
   const { isLoading, page, savePageChanges } = useEditablePageContext();
-  const { orgHasPublishPageLimit } = useContributionPageList();
+  const { pages } = useContributionPageList();
   const { user } = useUser();
   const {
     open: openMaxPagesPublishedModal,
@@ -105,7 +106,7 @@ function PublishButton({ className }: PublishButtonProps) {
     }
 
     // If the user's hit their org's plan limit, stop them here.
-    if (!orgHasPublishPageLimit(page.revenue_program.organization)) {
+    if (!orgHasPublishPageLimit(page.revenue_program.organization, pages)) {
       handleOpenMaxPagesPublishedModal();
       return;
     }

--- a/spa/src/components/common/Button/PublishButton/PublishButton.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.tsx
@@ -47,7 +47,7 @@ function DisabledTooltip({ children, disabled }: { children: ReactElement; disab
 function PublishButton({ className }: PublishButtonProps) {
   const alert = useAlert();
   const { isLoading, page, savePageChanges } = useEditablePageContext();
-  const { userCanPublishPage } = useContributionPageList();
+  const { orgHasPublishPageLimit } = useContributionPageList();
   const { user } = useUser();
   const {
     open: openMaxPagesPublishedModal,
@@ -90,7 +90,6 @@ function PublishButton({ className }: PublishButtonProps) {
 
   const handleClick = (event: MouseEvent<HTMLElement>) => {
     // These should never happen, but TypeScript doesn't know that.
-
     if (!page) {
       throw new Error('page is not defined');
     }
@@ -100,15 +99,13 @@ function PublishButton({ className }: PublishButtonProps) {
     }
 
     // If the page has been published, show the popover.
-
     if (pageIsPublished(page)) {
       setAnchorEl(event.currentTarget);
       return;
     }
 
-    // If the user's hit their plan limit, stop them here.
-
-    if (!userCanPublishPage(user)) {
+    // If the user's hit their org's plan limit, stop them here.
+    if (!orgHasPublishPageLimit(page.revenue_program.organization)) {
       handleOpenMaxPagesPublishedModal();
       return;
     }
@@ -207,7 +204,7 @@ function PublishButton({ className }: PublishButtonProps) {
       <MaxPagesPublishedModal
         onClose={handleCloseMaxPagesPublishedModal}
         open={openMaxPagesPublishedModal}
-        currentPlan={user.organizations[0].plan.name}
+        currentPlan={page.revenue_program.organization.plan.name}
       />
       <PublishModal
         slugError={slugError}

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
@@ -40,8 +40,7 @@ describe('DonationUpgradePrompts', () => {
       isError: false,
       isLoading: false,
       newPageProperties: jest.fn(),
-      userCanCreatePage: jest.fn(),
-      orgHasPublishPageLimit: jest.fn()
+      userCanCreatePage: jest.fn()
     });
     useUserMock.mockReturnValue({ user: mockUser } as any);
     window.sessionStorage.clear();
@@ -131,8 +130,7 @@ describe('DonationUpgradePrompts', () => {
       isError: false,
       isLoading: true,
       newPageProperties: jest.fn(),
-      userCanCreatePage: jest.fn(),
-      orgHasPublishPageLimit: jest.fn()
+      userCanCreatePage: jest.fn()
     });
     tree();
     expect(screen.queryByTestId('mock-donation-core-upgrade-prompt')).not.toBeInTheDocument();
@@ -145,8 +143,7 @@ describe('DonationUpgradePrompts', () => {
       isError: true,
       isLoading: false,
       newPageProperties: jest.fn(),
-      userCanCreatePage: jest.fn(),
-      orgHasPublishPageLimit: jest.fn()
+      userCanCreatePage: jest.fn()
     });
     tree();
     expect(screen.queryByTestId('mock-donation-core-upgrade-prompt')).not.toBeInTheDocument();
@@ -164,8 +161,7 @@ describe('DonationUpgradePrompts', () => {
       isError: false,
       isLoading: false,
       newPageProperties: jest.fn(),
-      userCanCreatePage: jest.fn(),
-      orgHasPublishPageLimit: jest.fn()
+      userCanCreatePage: jest.fn()
     });
     tree();
     expect(screen.queryByTestId('mock-donation-core-upgrade-prompt')).not.toBeInTheDocument();

--- a/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
+++ b/spa/src/components/donations/DonationUpgradePrompts/DonationUpgradePrompts.test.tsx
@@ -41,7 +41,7 @@ describe('DonationUpgradePrompts', () => {
       isLoading: false,
       newPageProperties: jest.fn(),
       userCanCreatePage: jest.fn(),
-      userCanPublishPage: jest.fn()
+      orgHasPublishPageLimit: jest.fn()
     });
     useUserMock.mockReturnValue({ user: mockUser } as any);
     window.sessionStorage.clear();
@@ -132,7 +132,7 @@ describe('DonationUpgradePrompts', () => {
       isLoading: true,
       newPageProperties: jest.fn(),
       userCanCreatePage: jest.fn(),
-      userCanPublishPage: jest.fn()
+      orgHasPublishPageLimit: jest.fn()
     });
     tree();
     expect(screen.queryByTestId('mock-donation-core-upgrade-prompt')).not.toBeInTheDocument();
@@ -146,7 +146,7 @@ describe('DonationUpgradePrompts', () => {
       isLoading: false,
       newPageProperties: jest.fn(),
       userCanCreatePage: jest.fn(),
-      userCanPublishPage: jest.fn()
+      orgHasPublishPageLimit: jest.fn()
     });
     tree();
     expect(screen.queryByTestId('mock-donation-core-upgrade-prompt')).not.toBeInTheDocument();
@@ -165,7 +165,7 @@ describe('DonationUpgradePrompts', () => {
       isLoading: false,
       newPageProperties: jest.fn(),
       userCanCreatePage: jest.fn(),
-      userCanPublishPage: jest.fn()
+      orgHasPublishPageLimit: jest.fn()
     });
     tree();
     expect(screen.queryByTestId('mock-donation-core-upgrade-prompt')).not.toBeInTheDocument();

--- a/spa/src/hooks/useContributionPageList.test.ts
+++ b/spa/src/hooks/useContributionPageList.test.ts
@@ -249,35 +249,4 @@ describe('useContributionPageList', () => {
       ).toBe(false);
     });
   });
-
-  describe('orgHasPublishPageLimit', () => {
-    it('returns false while pages are loading', () => {
-      const { result } = hook();
-
-      expect(result.current.orgHasPublishPageLimit({ id: '1', plan: { page_limit: 0 } } as any)).toBe(false);
-    });
-
-    // There's one published and one unpublished page in mock data.
-
-    it('returns true if the current organization is under their page limit', async () => {
-      const { result, waitFor } = hook();
-
-      await waitFor(() => expect(result.current.pages?.length).toBe(2));
-      expect(result.current.orgHasPublishPageLimit({ id: '1', plan: { publish_limit: 2 } } as any)).toBe(true);
-    });
-
-    it('returns false if the current organization is at their page limit', async () => {
-      const { result, waitFor } = hook();
-
-      await waitFor(() => expect(result.current.pages?.length).toBe(2));
-      expect(result.current.orgHasPublishPageLimit({ id: '1', plan: { publish_limit: 1 } } as any)).toBe(false);
-    });
-
-    it('returns false if the current organization is above their page limit', async () => {
-      const { result, waitFor } = hook();
-
-      await waitFor(() => expect(result.current.pages?.length).toBe(2));
-      expect(result.current.orgHasPublishPageLimit({ id: '1', plan: { publish_limit: 0 } } as any)).toBe(false);
-    });
-  });
 });

--- a/spa/src/hooks/useContributionPageList.ts
+++ b/spa/src/hooks/useContributionPageList.ts
@@ -8,7 +8,7 @@ import axios from 'ajax/axios';
 import { GENERIC_ERROR } from 'constants/textConstants';
 import { SIGN_IN } from 'routes';
 import { ContributionPage } from './useContributionPage';
-import { Organization, User } from './useUser.types';
+import { User } from './useUser.types';
 import { USER_ROLE_HUB_ADMIN_TYPE, USER_SUPERUSER_TYPE } from 'constants/authConstants';
 
 export interface CreatePageProperties extends Partial<Omit<ContributionPage, 'revenue_program'>> {
@@ -53,11 +53,6 @@ export interface UseContributionPageListResult {
    * page limit of their organization. If pages are being fetched, this returns `false`.
    */
   userCanCreatePage: (user: User) => boolean;
-  /**
-   * Returns whether an Organization can have a new page published (limit hasn't been reached).
-   * If pages are being fetched, this returns `false`.
-   */
-  orgHasPublishPageLimit: (org: Organization) => boolean;
 }
 
 async function fetchPages() {
@@ -147,31 +142,8 @@ function useContributionPageList(): UseContributionPageListResult {
     },
     [pages]
   );
-  const orgHasPublishPageLimit = useCallback(
-    (org: Organization) => {
-      // If we don't know how many pages exist, assume no.
-      if (!pages) {
-        return false;
-      }
 
-      // Filter pages by the organization and then filter by published date.
-      // Compare the currently published pages with the organization's plan limit
-      // We don't consider dates here; e.g. if a page has a publish date a year away,
-      // it still counts as published.
-      return (
-        pages.filter(
-          (page) =>
-            // Filter pages by organization
-            page.revenue_program.organization.id === org?.id &&
-            // Filter pages that have been published
-            !!page.published_date
-        ).length < org.plan.publish_limit
-      );
-    },
-    [pages]
-  );
-
-  return { createPage, error, isError, isLoading, newPageProperties, pages, userCanCreatePage, orgHasPublishPageLimit };
+  return { createPage, error, isError, isLoading, newPageProperties, pages, userCanCreatePage };
 }
 
 export default useContributionPageList;

--- a/spa/src/hooks/useEditablePage.test.tsx
+++ b/spa/src/hooks/useEditablePage.test.tsx
@@ -133,8 +133,7 @@ describe('EditablePageContextProvider', () => {
       isLoading: true,
       createPage: jest.fn(),
       newPageProperties: jest.fn(),
-      userCanCreatePage: jest.fn(),
-      orgHasPublishPageLimit: jest.fn()
+      userCanCreatePage: jest.fn()
     });
     tree();
     expect(screen.getByTestId('is-loading')).toBeInTheDocument();

--- a/spa/src/hooks/useEditablePage.test.tsx
+++ b/spa/src/hooks/useEditablePage.test.tsx
@@ -134,7 +134,7 @@ describe('EditablePageContextProvider', () => {
       createPage: jest.fn(),
       newPageProperties: jest.fn(),
       userCanCreatePage: jest.fn(),
-      userCanPublishPage: jest.fn()
+      orgHasPublishPageLimit: jest.fn()
     });
     tree();
     expect(screen.getByTestId('is-loading')).toBeInTheDocument();

--- a/spa/src/utilities/organizationPageLimit.test.ts
+++ b/spa/src/utilities/organizationPageLimit.test.ts
@@ -1,0 +1,35 @@
+import { orgHasPublishPageLimit } from './organizationPageLimit';
+
+const mockPages = [
+  {
+    id: 'mock-page-id-1',
+    name: 'Page 1',
+    revenue_program: { name: 'mock-rp', organization: '1' },
+    slug: 'mock-rp-page-1'
+  },
+  {
+    id: 'mock-page-id-2',
+    name: 'Page 2',
+    published_date: new Date().toString(),
+    revenue_program: { name: 'mock-rp', organization: '1' },
+    slug: 'mock-rp-page-2'
+  }
+] as any;
+
+describe('orgHasPublishPageLimit', () => {
+  it('returns false while pages are loading', () => {
+    expect(orgHasPublishPageLimit({ id: '1', plan: { page_limit: 0 } } as any, mockPages)).toBe(false);
+  });
+
+  it('returns true if the current organization is under their page limit', async () => {
+    expect(orgHasPublishPageLimit({ id: '1', plan: { publish_limit: 2 } } as any, mockPages)).toBe(true);
+  });
+
+  it('returns false if the current organization is at their page limit', async () => {
+    expect(orgHasPublishPageLimit({ id: '1', plan: { publish_limit: 1 } } as any, mockPages)).toBe(false);
+  });
+
+  it('returns false if the current organization is above their page limit', async () => {
+    expect(orgHasPublishPageLimit({ id: '1', plan: { publish_limit: 0 } } as any, mockPages)).toBe(false);
+  });
+});

--- a/spa/src/utilities/organizationPageLimit.ts
+++ b/spa/src/utilities/organizationPageLimit.ts
@@ -1,0 +1,30 @@
+import { ContributionPage } from 'hooks/useContributionPage';
+import { Organization } from 'hooks/useUser.types';
+
+/**
+ * Returns whether an Organization can have a new page published (limit hasn't been reached).
+ * If pages are being fetched, this returns `false`.
+ */
+const orgHasPublishPageLimit = (org: Organization, pages?: ContributionPage[]) => {
+  // If we don't know how many pages exist, assume no.
+  if (!pages) {
+    return false;
+  }
+
+  // Filter pages by the organization and then filter by published date.
+  // Compare the currently published pages with the organization's plan limit
+  // We don't consider dates here; e.g. if a page has a publish date a year away,
+  // it still counts as published.
+  return (
+    pages.filter(
+      (page) =>
+        // Filter pages by organization
+        // Page list serializer only returns the organization id, not the full object (reduce payload size)
+        (page.revenue_program.organization as any) === org?.id &&
+        // Filter pages that have been published
+        !!page.published_date
+    ).length < org.plan.publish_limit
+  );
+};
+
+export { orgHasPublishPageLimit };


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a

#### What's this PR do?
- Create helper function to check for organization published page limit to use current organization instead of user's first org.
- Update Pages list serializer to include Organization ID only (so that we don't grow too much the payload response, but we need org.id in the Spa)
- Update tests

#### Why are we doing this? How does it help us?
- Show the error modal with the correct error for Hub admins and Super users (the same as Org admins see)

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no

#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
n/a
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
n/a
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-4145
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no