### PR TITLE
DEV-4203: Select country with return key

### DIFF
--- a/spa/cypress/e2e/01-donationPage.cy.js
+++ b/spa/cypress/e2e/01-donationPage.cy.js
@@ -847,6 +847,19 @@ describe('User flow: unhappy paths', () => {
       .findByRole('button', { name: /Enter a valid amount/ })
       .should('have.attr', 'disabled');
   });
+
+  specify('User enters single character into country field, then hits enter', () => {
+    cy.visitDonationPage();
+    fillOutDonorInfoSection();
+    cy.get('[data-testid*="mailing_street"]').type('123 Main St');
+    cy.findByRole('button', { name: 'Address line 2 (Apt, suite, etc.)' }).click();
+    cy.get('[data-testid*="mailing_complement"]').type('Ap 1');
+    cy.get('[data-testid*="mailing_city"]').type('Big City');
+    cy.get('[data-testid*="mailing_state"]').type('NY');
+    cy.get('[data-testid*="mailing_postal_code"]').type('100738');
+    cy.get('#country').type('a{enter}');
+    cy.get('[data-testid="500-something-wrong"]').should('not.exist');
+  });
 });
 
 describe('StripePaymentForm unhappy paths', () => {

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
@@ -231,6 +231,7 @@ function DDonorAddress({ element }: DDonorAddressProps) {
         </Grid>
         <Grid item xs={12} md={zipAndCountryOnly ? 6 : 4}>
           <CountrySelect
+            autoHighlight
             error={!!errors.mailing_country}
             helperText={errors.mailing_country}
             id="country"


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Changes the country field in the donor address field to select options with the Return key.

#### Why are we doing this? How does it help us?

Prevents a bug where the Return key is interpreted as a form submission instead.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4203

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.