### PR TITLE
DEV-4145: Show specific error to Hub admins if publish limit exceeded

### DIFF
--- a/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { act, render, screen, waitFor } from 'test-utils';
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError } from 'axios';
 import { GENERIC_ERROR } from 'constants/textConstants';
 import useContributionPageList from 'hooks/useContributionPageList';
 import { useEditablePageContext } from 'hooks/useEditablePage';
@@ -9,6 +9,7 @@ import useUser from 'hooks/useUser';
 import PublishButton from './PublishButton';
 import { PLAN_NAMES } from 'constants/orgPlanConstants';
 import { useAlert } from 'react-alert';
+import { USER_ROLE_HUB_ADMIN_TYPE, USER_ROLE_ORG_ADMIN_TYPE, USER_SUPERUSER_TYPE } from 'constants/authConstants';
 
 jest.mock('react-alert', () => ({
   ...jest.requireActual('react-alert'),
@@ -241,7 +242,7 @@ describe('PublishButton', () => {
           await act(() => Promise.resolve());
         });
 
-        it('shows an alert if publishing fails', async () => {
+        it('shows an alert if publishing fails with a generic error', async () => {
           const error = jest.fn();
           const savePageChanges = jest.fn();
 
@@ -253,6 +254,35 @@ describe('PublishButton', () => {
           userEvent.click(screen.getByText('onPublish'));
           await waitFor(() => expect(error).toBeCalled());
           expect(error.mock.calls).toEqual([[GENERIC_ERROR]]);
+        });
+
+        describe('if publishing fails because the org has reached its limit', () => {
+          const limitError = new Error();
+
+          (limitError as any).response = {
+            data: {
+              non_field_errors: ['Your organization has reached its limit of 1 published page']
+            }
+          };
+
+          it.each([
+            [GENERIC_ERROR, USER_ROLE_ORG_ADMIN_TYPE],
+            ['This organization has reached its limit of published pages.', USER_ROLE_HUB_ADMIN_TYPE],
+            ['This organization has reached its limit of published pages.', USER_SUPERUSER_TYPE]
+          ])('shows an "%s" alert if the user is a %s', async (errorMessage, role_type) => {
+            const error = jest.fn();
+            const savePageChanges = jest.fn();
+
+            useAlertMock.mockReturnValue({ error });
+            savePageChanges.mockRejectedValue(limitError);
+            useEditablePageContextMock.mockReturnValue({ savePageChanges, isLoading: false, page: unpublishedPage });
+            useUserMock.mockReturnValue({ user: { ...user, role_type } });
+            tree();
+            userEvent.click(screen.getByRole('button', { name: `Publish page ${publishedPage.name}` }));
+            userEvent.click(screen.getByText('onPublish'));
+            await waitFor(() => expect(error).toBeCalled());
+            expect(error.mock.calls).toEqual([[errorMessage]]);
+          });
         });
 
         it('causes publish modal to display field-level error message when slug error after publish attempt', async () => {

--- a/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.test.tsx
@@ -258,17 +258,18 @@ describe('PublishButton', () => {
 
         describe('if publishing fails because the org has reached its limit', () => {
           const limitError = new Error();
+          const errorMessage = 'Your organization has reached its limit of 1 published page';
 
           (limitError as any).response = {
             data: {
-              non_field_errors: ['Your organization has reached its limit of 1 published page']
+              non_field_errors: [errorMessage]
             }
           };
 
           it.each([
             [GENERIC_ERROR, USER_ROLE_ORG_ADMIN_TYPE],
-            ['This organization has reached its limit of published pages.', USER_ROLE_HUB_ADMIN_TYPE],
-            ['This organization has reached its limit of published pages.', USER_SUPERUSER_TYPE]
+            [errorMessage, USER_ROLE_HUB_ADMIN_TYPE],
+            [errorMessage, USER_SUPERUSER_TYPE]
           ])('shows an "%s" alert if the user is a %s', async (errorMessage, role_type) => {
             const error = jest.fn();
             const savePageChanges = jest.fn();

--- a/spa/src/components/common/Button/PublishButton/PublishButton.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.tsx
@@ -158,13 +158,10 @@ function PublishButton({ className }: PublishButtonProps) {
         // If there is a slug error, we pass it to the modal.
 
         setSlugError((error as AxiosError).response?.data?.slug);
-      } else if (
-        (isHubAdmin || isSuperUser) &&
-        /^Your organization has reached its limit/.test((error as AxiosError).response?.data?.non_field_errors?.[0])
-      ) {
-        // Hub admins trying to exceed the publish limit get a special message.
+      } else if ((isHubAdmin || isSuperUser) && (error as AxiosError).response?.data?.non_field_errors?.[0]) {
+        // Hub admins can see errors directly.
 
-        alert.error('This organization has reached its limit of published pages.');
+        alert.error((error as AxiosError).response?.data?.non_field_errors?.[0]);
       } else {
         alert.error(GENERIC_ERROR);
       }

--- a/spa/src/components/common/Button/PublishButton/PublishButton.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.tsx
@@ -18,6 +18,7 @@ import PublishedPopover from './PublishedPopover';
 import SuccessfulPublishModal from './SuccessfulPublishModal';
 import UnpublishModal from './UnpublishModal';
 import { Root, RootButton } from './PublishButton.styled';
+import { getUserRole } from 'utilities/getUserRole';
 
 const PublishButtonPropTypes = {
   className: PropTypes.string
@@ -151,9 +152,19 @@ function PublishButton({ className }: PublishButtonProps) {
 
       handleOpenSuccessfulPublishModal();
     } catch (error) {
-      // If there is a slug error, we pass it to the modal.
+      const { isHubAdmin, isSuperUser } = getUserRole(user);
+
       if ((error as AxiosError).response?.data?.slug) {
+        // If there is a slug error, we pass it to the modal.
+
         setSlugError((error as AxiosError).response?.data?.slug);
+      } else if (
+        (isHubAdmin || isSuperUser) &&
+        /^Your organization has reached its limit/.test((error as AxiosError).response?.data?.non_field_errors?.[0])
+      ) {
+        // Hub admins trying to exceed the publish limit get a special message.
+
+        alert.error('This organization has reached its limit of published pages.');
       } else {
         alert.error(GENERIC_ERROR);
       }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Allows Hub admins and superusers to see the error message returned by the API if publishing a page fails.

#### Why are we doing this? How does it help us?

Helps staff troubleshoot problems.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Updated existing.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4145

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.