### PR TITLE
DEV-3884: Implement new contributions list

### DIFF
--- a/spa/src/ajax/endpoints.ts
+++ b/spa/src/ajax/endpoints.ts
@@ -38,6 +38,10 @@ export function getRevenueProgramMailchimpStatusEndpoint(revenueProgramId: Reven
 }
 
 // Contributions
+export function getContributionsEndpoint(contributorId: number) {
+  return `/contributors/${contributorId}/contributions/`;
+}
+
 export const CONTRIBUTIONS = 'contributions/';
 export const EMAIL_CONTRIBUTIONS = 'email-contributions/';
 export const PROCESS_FLAGGED = 'process-flagged/';

--- a/spa/src/components/PortalRouter.test.tsx
+++ b/spa/src/components/PortalRouter.test.tsx
@@ -23,10 +23,12 @@ jest.mock('components/portal/PortalPage', () => ({ children }: { children: React
 jest.mock('components/authentication/ProtectedRoute', () => ({ render }: { render: () => React.ReactNode }) => (
   <div data-testid="mock-protected-router">{render()}</div>
 ));
+jest.mock('components/portal/ContributionsList/ContributionsList', () => () => (
+  <div data-testid="mock-contributions-list" />
+));
 jest.mock('components/portal/PortalEntry', () => () => <div data-testid="mock-portal-entry" />);
-jest.mock('components/contributor/ContributorVerify', () => () => <div data-testid="mock-contributor-verify" />);
-jest.mock('components/contributor/contributorDashboard/ContributorDashboard', () => () => (
-  <div data-testid="mock-contributor-dashboard" />
+jest.mock('components/portal/TokenVerification/TokenVerification', () => () => (
+  <div data-testid="mock-token-verification" />
 ));
 
 function tree(path: string) {
@@ -57,19 +59,19 @@ describe('PortalRouter', () => {
     expect(within(screen.getByTestId('mock-portal-page')).getByTestId('mock-portal-entry')).toBeInTheDocument();
   });
 
-  it('displays a PortalPage with ContributorDashboard at /portal/my-contributions/', async () => {
+  it('displays a PortalPage with ContributionsList at /portal/my-contributions/', async () => {
     tree('/portal/my-contributions/');
-    await screen.findByTestId('mock-contributor-dashboard');
-    expect(within(screen.getByTestId('mock-protected-router')).getByTestId('mock-portal-page')).toBeInTheDocument();
+    await screen.findByTestId('mock-contributions-list');
     expect(
-      within(screen.getByTestId('mock-portal-page')).getByTestId('mock-contributor-dashboard')
+      within(screen.getByTestId('mock-protected-router')).getByTestId('mock-contributions-list')
     ).toBeInTheDocument();
+    expect(within(screen.getByTestId('mock-portal-page')).getByTestId('mock-contributions-list')).toBeInTheDocument();
   });
 
-  it('displays a PortalPage with ContributorVerify at /portal/verification/', async () => {
+  it('displays a PortalPage with TokenVerification at /portal/verification/', async () => {
     tree('/portal/verification/');
-    await screen.findByTestId('mock-contributor-verify');
-    expect(within(screen.getByTestId('mock-portal-page')).getByTestId('mock-contributor-verify')).toBeInTheDocument();
+    await screen.findByTestId('mock-token-verification');
+    expect(within(screen.getByTestId('mock-portal-page')).getByTestId('mock-token-verification')).toBeInTheDocument();
   });
 
   it('redirects to /portal/ when no route matches', () => {

--- a/spa/src/components/PortalRouter.tsx
+++ b/spa/src/components/PortalRouter.tsx
@@ -6,46 +6,48 @@ import componentLoader from 'utilities/componentLoader';
 import ProtectedRoute from './authentication/ProtectedRoute';
 import PortalPage from './portal/PortalPage';
 import RouterSetup from './routes/RouterSetup';
+import { PortalAuthContextProvider } from 'hooks/usePortalAuth';
 
 // Split bundles
 const PortalEntry = lazy(() => componentLoader(() => import('components/portal/PortalEntry')));
-const ContributorVerify = lazy(() => componentLoader(() => import('components/contributor/ContributorVerify')));
-const ContributorDashboard = lazy(() =>
-  componentLoader(() => import('components/contributor/contributorDashboard/ContributorDashboard'))
+const PortalVerify = lazy(() => componentLoader(() => import('components/portal/TokenVerification/TokenVerification')));
+const TransactionsList = lazy(() =>
+  componentLoader(() => import('components/portal/ContributionsList/ContributionsList'))
 );
 
 function PortalRouter() {
   return (
-    <RouterSetup>
-      <ProtectedRoute
-        path={ROUTES.PORTAL.DASHBOARD}
-        // TODO: DEV-3886 Update to New Portal Dashboard
-        render={() => (
-          <PortalPage>
-            <ContributorDashboard />
-          </PortalPage>
-        )}
-        contributor
-      />
-      <SentryRoute
-        exact
-        path={ROUTES.PORTAL.ENTRY}
-        render={() => (
-          <PortalPage>
-            <PortalEntry />
-          </PortalPage>
-        )}
-      />
-      <SentryRoute
-        path={ROUTES.PORTAL.VERIFY}
-        render={() => (
-          <PortalPage>
-            <ContributorVerify />
-          </PortalPage>
-        )}
-      />
-      <Redirect to={ROUTES.PORTAL.ENTRY} />
-    </RouterSetup>
+    <PortalAuthContextProvider>
+      <RouterSetup>
+        <ProtectedRoute
+          path={ROUTES.PORTAL.CONTRIBUTIONS}
+          render={() => (
+            <PortalPage>
+              <TransactionsList />
+            </PortalPage>
+          )}
+          contributor
+        />
+        <SentryRoute
+          exact
+          path={ROUTES.PORTAL.ENTRY}
+          render={() => (
+            <PortalPage>
+              <PortalEntry />
+            </PortalPage>
+          )}
+        />
+        <SentryRoute
+          path={ROUTES.PORTAL.VERIFY}
+          render={() => (
+            <PortalPage>
+              <PortalVerify />
+            </PortalPage>
+          )}
+        />
+        <Redirect to={ROUTES.PORTAL.ENTRY} />
+      </RouterSetup>
+    </PortalAuthContextProvider>
   );
 }
 

--- a/spa/src/components/base/CircularProgress/CircularProgress.stories.tsx
+++ b/spa/src/components/base/CircularProgress/CircularProgress.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import CircularProgress from './CircularProgress';
+
+export default {
+  component: CircularProgress,
+  title: 'Base/CircularProgress',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A MUI-based progress indicator. See [the API](https://v4.mui.com/api/circular-progress/) for more details.'
+      }
+    }
+  }
+} as ComponentMeta<typeof CircularProgress>;
+
+const Template: ComponentStory<typeof CircularProgress> = (props) => <CircularProgress {...props} />;
+
+export const Indeterminate = Template.bind({});
+
+Indeterminate.args = {
+  variant: 'indeterminate'
+};
+
+export const Determinate = Template.bind({});
+
+Determinate.args = {
+  variant: 'determinate',
+  value: 75
+};

--- a/spa/src/components/base/CircularProgress/CircularProgress.test.tsx
+++ b/spa/src/components/base/CircularProgress/CircularProgress.test.tsx
@@ -1,0 +1,20 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import CircularProgress, { CircularProgressProps } from './CircularProgress';
+
+function tree(props?: Partial<CircularProgressProps>) {
+  return render(<CircularProgress aria-label="Loading" {...props} />);
+}
+
+describe('CircularProgress', () => {
+  it('displays a progress bar', () => {
+    tree();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/base/CircularProgress/CircularProgress.tsx
+++ b/spa/src/components/base/CircularProgress/CircularProgress.tsx
@@ -1,0 +1,19 @@
+import {
+  CircularProgress as MuiCircularProgress,
+  CircularProgressProps as MuiCircularProgressProps
+} from '@material-ui/core';
+import styled from 'styled-components';
+
+export type CircularProgressProps = MuiCircularProgressProps;
+
+const StyledMuiCircularProgress = styled(MuiCircularProgress)`
+  && .NreCircle {
+    color: ${({ theme }) => theme.basePalette.greyscale.grey1};
+  }
+`;
+
+export function CircularProgress(props: CircularProgressProps) {
+  return <StyledMuiCircularProgress {...props} classes={{ circle: 'NreCircle' }} />;
+}
+
+export default CircularProgress;

--- a/spa/src/components/base/index.ts
+++ b/spa/src/components/base/index.ts
@@ -1,5 +1,6 @@
 export * from './Button/Button';
 export * from './Checkbox/Checkbox';
+export * from './CircularProgress/CircularProgress';
 export * from './ColorPicker/ColorPicker';
 export * from './EditableList/EditableList';
 export * from './FormControlLabel/FormControlLabel';

--- a/spa/src/components/portal/ContributionsList/ContributionFetchError.stories.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionFetchError.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import ContributionFetchError from './ContributionFetchError';
+
+export default {
+  component: ContributionFetchError,
+  title: 'Contributor/ContributionFetchError'
+} as ComponentMeta<typeof ContributionFetchError>;
+
+const Template: ComponentStory<typeof ContributionFetchError> = (props) => <ContributionFetchError {...props} />;
+
+export const Default = Template.bind({});

--- a/spa/src/components/portal/ContributionsList/ContributionFetchError.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionFetchError.styled.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Root = styled.div`
+  align-items: center;
+  background-color: #f4ecee;
+  display: flex;
+  flex-direction: column;
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
+  gap: 20px;
+  height: 175px;
+  justify-content: center;
+
+  p {
+    color: ${({ theme }) => theme.basePalette.secondary.error};
+    margin: 0;
+  }
+`;

--- a/spa/src/components/portal/ContributionsList/ContributionFetchError.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionFetchError.test.tsx
@@ -1,0 +1,29 @@
+import { axe } from 'jest-axe';
+import { fireEvent, render, screen } from 'test-utils';
+import ContributionFetchError, { ContributionFetchErrorProps } from './ContributionFetchError';
+
+function tree(props?: Partial<ContributionFetchErrorProps>) {
+  return render(<ContributionFetchError onRetry={jest.fn()} {...props} />);
+}
+
+describe('ContributionFetchError', () => {
+  it('shows an error message', () => {
+    tree();
+    expect(screen.getByText('Error loading contributions.')).toBeInTheDocument();
+  });
+
+  it('shows a button that calls onRetry when clicked', () => {
+    const onRetry = jest.fn();
+
+    tree({ onRetry });
+    expect(onRetry).not.toBeCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+    expect(onRetry).toBeCalledTimes(1);
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/portal/ContributionsList/ContributionFetchError.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionFetchError.tsx
@@ -1,0 +1,25 @@
+import { Button } from 'components/base';
+import PropTypes, { InferProps } from 'prop-types';
+import { Root } from './ContributionFetchError.styled';
+
+const ContributionFetchErrorPropTypes = {
+  onRetry: PropTypes.func.isRequired
+};
+
+export interface ContributionFetchErrorProps extends InferProps<typeof ContributionFetchErrorPropTypes> {
+  onRetry: () => void;
+}
+
+export function ContributionFetchError({ onRetry }: ContributionFetchErrorProps) {
+  return (
+    <Root>
+      <p>Error loading contributions.</p>
+      <Button onClick={onRetry} color="error">
+        Try Again
+      </Button>
+    </Root>
+  );
+}
+
+ContributionFetchError.propTypes = ContributionFetchErrorPropTypes;
+export default ContributionFetchError;

--- a/spa/src/components/portal/ContributionsList/ContributionItem.stories.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionItem.stories.tsx
@@ -1,0 +1,44 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { PortalContribution } from 'hooks/usePortalContributionList';
+import ContributionItem from './ContributionItem';
+
+const ContributionItemDemo = (contribution: PortalContribution) => <ContributionItem contribution={contribution} />;
+
+export default {
+  args: {
+    amount: 12345,
+    card_brand: 'visa',
+    interval: 'one_time',
+    last4: '1234',
+    status: 'paid'
+  },
+  argTypes: {
+    amount: {
+      type: 'number'
+    },
+    card_brand: {
+      control: { type: 'select' },
+      options: ['amex', 'diners', 'discover', 'jcb', 'mastercard', 'unionpay', 'unknown', 'visa']
+    },
+    created: {
+      control: { type: 'date' }
+    },
+    interval: {
+      control: { type: 'select' },
+      options: ['one_time', 'month', 'year']
+    },
+    next_payment_date: {
+      control: { type: 'date' }
+    },
+    status: {
+      control: { type: 'select' },
+      options: ['canceled', 'failed', 'paid', 'processing']
+    }
+  },
+  component: ContributionItem,
+  title: 'Contributor/ContributionItem'
+} as ComponentMeta<typeof ContributionItemDemo>;
+
+const Template: ComponentStory<typeof ContributionItemDemo> = (props) => <ContributionItemDemo {...props} />;
+
+export const Default = Template.bind({});

--- a/spa/src/components/portal/ContributionsList/ContributionItem.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionItem.styled.ts
@@ -1,0 +1,111 @@
+import { PaymentStatus } from 'constants/paymentStatus';
+import styled from 'styled-components';
+
+export const Root = styled.div<{ $dimmed: boolean }>`
+  align-items: center;
+  background-color: ${(props) =>
+    props.$dimmed ? props.theme.basePalette.greyscale.grey4 : props.theme.basePalette.greyscale.white};
+  border-radius: ${({ theme }) => theme.muiBorderRadius.lg};
+  box-shadow:
+    0px 3px 4px 0px rgba(0, 0, 0, 0.12),
+    -2px 0px 2px 0px rgba(0, 0, 0, 0.08);
+  color: ${(props) =>
+    props.$dimmed ? props.theme.basePalette.greyscale.grey1 : props.theme.basePalette.greyscale.black};
+  display: grid;
+  gap: 12px;
+  grid-template-columns: [icon] 35px [date] minmax(200px, 1fr) [card] 150px [status] 100px [amount] minmax(100px, 1fr);
+  font-family: Roboto, sans-serif;
+  padding: 28px 12px;
+
+  @media (${({ theme }) => theme.breakpoints.phoneOnly}) {
+    grid-template-columns: [icon] 35px [date] 1fr [amount] minmax(100px, 1fr);
+    grid-template:
+      'status status status'
+      'icon date amount';
+    padding: 12px;
+  }
+`;
+
+export const Amount = styled.div<{ $status: PaymentStatus }>`
+  color: ${({ theme }) => theme.basePalette.primary.indigo};
+  font-size: ${({ theme }) => theme.fontSizesUpdated[20]};
+  font-weight: 600;
+  grid-area: amount;
+  text-align: right;
+
+  ${(props) => props.$status === 'canceled' && `color: ${props.theme.basePalette.greyscale.grey1};`}
+  ${(props) => props.$status === 'failed' && `color: ${props.theme.basePalette.secondary.error};`}
+`;
+
+export const CardInfo = styled.div`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
+  font-weight: 500;
+  grid-area: card;
+  padding-right: 8px; /* 20px total with gap */
+  text-align: right;
+
+  @media (${({ theme }) => theme.breakpoints.phoneOnly}) {
+    display: none;
+  }
+`;
+
+export const CreatedDate = styled.div`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
+`;
+
+export const DateContainer = styled.div`
+  grid-area: date;
+`;
+
+export const IntervalIconContainer = styled.div<{ $status: PaymentStatus }>`
+  align-items: center;
+  background-color: ${({ theme }) => theme.basePalette.greyscale.grey4};
+  border-radius: ${({ theme }) => theme.muiBorderRadius.lg};
+  display: flex;
+  grid-area: icon;
+  height: 35px;
+  justify-content: center;
+  width: 35px;
+
+  ${(props) => props.$status === 'failed' && `color: ${props.theme.basePalette.secondary.error}`}
+`;
+
+export const LastCardDigits = styled.span`
+  color: ${({ theme }) => theme.basePalette.greyscale.grey1};
+
+  &::before {
+    /* Leading dots */
+    content: '\\2022\\2022\\2022\\00a0';
+  }
+`;
+
+export const NextContributionDate = styled.div<{ $status: PaymentStatus }>`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.xs};
+  ${({ $status }) => $status === 'canceled' && 'text-decoration: line-through;'}
+
+  & strong {
+    font-weight: 500;
+  }
+`;
+
+export const Status = styled.div<{ $status: PaymentStatus }>`
+  grid-area: status;
+
+  &::before {
+    background-color: ${({ theme }) => theme.basePalette.greyscale.grey1};
+    border-radius: 7px;
+    content: '';
+    display: inline-block;
+    height: 14px;
+    margin-right: 6px;
+    position: relative;
+    top: 2px;
+    width: 14px;
+
+    ${(props) => props.$status === 'processing' && `background-color: ${props.theme.basePalette.primary.engineBlue};`}
+    ${(props) => props.$status === 'failed' && `background-color: ${props.theme.basePalette.secondary.error};`}
+    ${(props) => props.$status === 'paid' && `background-color: ${props.theme.basePalette.secondary.success};`}
+  }
+
+  font-size: ${({ theme }) => theme.fontSizesUpdated.xs};
+`;

--- a/spa/src/components/portal/ContributionsList/ContributionItem.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionItem.styled.ts
@@ -12,12 +12,13 @@ export const Root = styled.div<{ $dimmed: boolean }>`
   color: ${(props) =>
     props.$dimmed ? props.theme.basePalette.greyscale.grey1 : props.theme.basePalette.greyscale.black};
   display: grid;
-  gap: 12px;
+  gap: 0 12px;
   grid-template-columns: [icon] 35px [date] minmax(200px, 1fr) [card] 150px [status] 100px [amount] minmax(100px, 1fr);
   font-family: Roboto, sans-serif;
   padding: 28px 12px;
 
   @media (${({ theme }) => theme.breakpoints.phoneOnly}) {
+    gap: 12px;
     grid-template-columns: [icon] 35px [date] 1fr [amount] minmax(100px, 1fr);
     grid-template:
       'status status status'
@@ -41,7 +42,7 @@ export const CardInfo = styled.div`
   font-size: ${({ theme }) => theme.fontSizesUpdated.md};
   font-weight: 500;
   grid-area: card;
-  padding-right: 8px; /* 20px total with gap */
+  padding-right: 18px; /* 30px total with gap */
   text-align: right;
 
   @media (${({ theme }) => theme.breakpoints.phoneOnly}) {

--- a/spa/src/components/portal/ContributionsList/ContributionItem.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionItem.test.tsx
@@ -1,0 +1,88 @@
+import { axe } from 'jest-axe';
+import { PortalContribution } from 'hooks/usePortalContributionList';
+import { render, screen } from 'test-utils';
+import ContributionItem, { ContributionItemProps, formattedCardBrands, formattedStatuses } from './ContributionItem';
+
+const mockContribution: PortalContribution = {
+  amount: 12345,
+  card_brand: 'amex',
+  created: new Date().toISOString(),
+  credit_card_expiration_date: new Date().toISOString(),
+  interval: 'month',
+  is_cancelable: false,
+  is_modifiable: false,
+  last4: '7890',
+  last_payment_date: new Date().toISOString(),
+  next_payment_date: new Date().toISOString(),
+  payment_provider_id: 'mock-payment-provider-id',
+  payment_type: 'card',
+  provider_customer_id: 'mock-provider-customer-id',
+  revenue_program: 1,
+  status: 'paid'
+};
+
+function tree(props?: Partial<ContributionItemProps>) {
+  return render(<ContributionItem contribution={mockContribution} {...props} />);
+}
+
+describe('ContributionItem', () => {
+  it.each([
+    ['one_time', 'One time'],
+    ['month', 'Monthly'],
+    ['year', 'Yearly']
+  ])('shows the right icon for %s contributions', (interval, label) => {
+    tree({ contribution: { ...mockContribution, interval } as any });
+    expect(screen.getByLabelText(label)).toBeInTheDocument();
+  });
+
+  it("doesn't throw if the contribution has a malformed interval", () =>
+    expect(() => tree({ contribution: { ...mockContribution, interval: 'bad' } as any })).not.toThrow());
+
+  it('shows the date the contribution was made', () => {
+    const created = new Date('1/23/45').toISOString();
+
+    tree({ contribution: { ...mockContribution, created } });
+    expect(screen.getByTestId('created')).toHaveTextContent('January 23, 2045');
+  });
+
+  it("shows the date of the next contribution's payment if set", () => {
+    const next_payment_date = new Date('1/23/45').toISOString();
+
+    tree({ contribution: { ...mockContribution, next_payment_date } });
+    expect(screen.getByTestId('next-payment-date')).toHaveTextContent('Next contribution January 23, 2045');
+  });
+
+  it("shows a message if there isn't a next payment date", () => {
+    tree({ contribution: { ...mockContribution, next_payment_date: '' } });
+    expect(screen.getByTestId('next-payment-date')).toHaveTextContent('No future contribution');
+  });
+
+  it.each(Object.entries(formattedCardBrands))('shows a %s card as %s', (card_brand, label) => {
+    tree({ contribution: { ...mockContribution, card_brand } as any });
+    expect(screen.getByTestId('card-brand')).toHaveTextContent(label);
+  });
+
+  it('shows the last four digits of the card', () => {
+    tree({ contribution: { ...mockContribution, last4: '4567' } });
+    expect(screen.getByTestId('card-last4')).toHaveTextContent('4567');
+  });
+
+  it.each(Object.entries(formattedStatuses))('shows a %s status as %s', (status, label) => {
+    tree({ contribution: { ...mockContribution, status } as any });
+    expect(screen.getByTestId('status')).toHaveTextContent(label);
+  });
+
+  it.each([
+    [1234, '$12.34'],
+    [12300, '$123']
+  ])('displays a %i amount as %s', (amount, formattedAmount) => {
+    tree({ contribution: { ...mockContribution, amount } });
+    expect(screen.getByTestId('amount')).toHaveTextContent(formattedAmount);
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/portal/ContributionsList/ContributionItem.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionItem.tsx
@@ -1,0 +1,99 @@
+import { Autorenew, Today } from '@material-ui/icons';
+import PropTypes, { InferProps } from 'prop-types';
+import { PaymentStatus } from 'constants/paymentStatus';
+import { CardBrand, PortalContribution } from 'hooks/usePortalContributionList';
+import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
+import { getFrequencyAdjective } from 'utilities/parseFrequency';
+import {
+  Amount,
+  CardInfo,
+  CreatedDate,
+  DateContainer,
+  IntervalIconContainer,
+  LastCardDigits,
+  NextContributionDate,
+  Root,
+  Status
+} from './ContributionItem.styled';
+
+const TransactionItemPropTypes = {
+  contribution: PropTypes.object.isRequired
+};
+
+export interface ContributionItemProps extends InferProps<typeof TransactionItemPropTypes> {
+  contribution: PortalContribution;
+}
+
+function formatDate(timestamp: string) {
+  return new Date(timestamp).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+// Exported for testing only.
+
+export const formattedCardBrands: Record<CardBrand, string> = {
+  amex: 'Amex',
+  diners: "Diner's",
+  discover: 'Discover',
+  jcb: 'JCB',
+  mastercard: 'MC',
+  unionpay: 'UnionPay',
+  unknown: '',
+  visa: 'Visa'
+};
+
+// Exported for testing only.
+
+export const formattedStatuses: Record<PaymentStatus, string> = {
+  canceled: 'Canceled',
+  failed: 'Failed',
+  paid: 'Successful',
+  processing: 'Processing',
+  // These statuses will never be present in results returned by the API.
+  flagged: '',
+  rejected: ''
+};
+
+const intervalIcons = {
+  one_time: Today,
+  month: Autorenew,
+  year: Autorenew
+};
+
+export function ContributionItem({ contribution }: ContributionItemProps) {
+  // If we end up with an interval we don't know the icon for, fall back to
+  // displaying nothing.
+  const IntervalIcon = intervalIcons[contribution.interval] ?? (() => null);
+
+  return (
+    <Root $dimmed={contribution.status === 'canceled'}>
+      <IntervalIconContainer $status={contribution.status}>
+        <IntervalIcon aria-label={getFrequencyAdjective(contribution.interval)} />
+      </IntervalIconContainer>
+      <DateContainer>
+        <CreatedDate data-testid="created">{formatDate(contribution.created)}</CreatedDate>
+        <NextContributionDate $status={contribution.status} data-testid="next-payment-date">
+          {contribution.next_payment_date ? (
+            <>
+              Next contribution <strong>{formatDate(contribution.next_payment_date)}</strong>
+            </>
+          ) : (
+            <>No future contribution</>
+          )}
+        </NextContributionDate>
+      </DateContainer>
+      <CardInfo>
+        <span data-testid="card-brand">{formattedCardBrands[contribution.card_brand]}</span>{' '}
+        <LastCardDigits data-testid="card-last4">{contribution.last4}</LastCardDigits>
+      </CardInfo>
+      <Status $status={contribution.status} data-testid="status">
+        {formattedStatuses[contribution.status]}
+      </Status>
+      <Amount $status={contribution.status} data-testid="amount">
+        {formatCurrencyAmount(contribution.amount, true)}
+      </Amount>
+    </Root>
+  );
+}
+
+ContributionItem.propTypes = TransactionItemPropTypes;
+export default ContributionItem;

--- a/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
@@ -18,6 +18,12 @@ export const Columns = styled.div`
   max-width: 1600px;
 `;
 
+export const Loading = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+`;
+
 export const MainContent = styled.div``;
 
 export const Subhead = styled.h2`

--- a/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
@@ -22,6 +22,7 @@ export const MainContent = styled.div``;
 
 export const Subhead = styled.h2`
   font-size: ${({ theme }) => theme.fontSizesUpdated.lg};
+  margin-bottom: 12px;
 `;
 
 export const Description = styled.p`

--- a/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const List = styled.div`
+  display: grid;
+  gap: 12px;
+`;
+
+export const Root = styled.div`
+  background-color: ${({ theme }) => theme.basePalette.greyscale.grey4};
+`;
+
+export const Columns = styled.div`
+  display: grid;
+  gap: 40px;
+  grid-template-columns: 1fr 1fr;
+  margin: 0 auto;
+  padding: 40px;
+  max-width: 1600px;
+`;
+
+export const MainContent = styled.div``;
+
+export const Subhead = styled.h2`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.lg};
+`;
+
+export const Description = styled.p`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
+`;

--- a/spa/src/components/portal/ContributionsList/ContributionsList.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.test.tsx
@@ -1,0 +1,86 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import ContributionsList from './ContributionsList';
+import { PortalAuthContext, PortalAuthContextResult } from 'hooks/usePortalAuth';
+import { usePortalContributionList } from 'hooks/usePortalContributionList';
+
+jest.mock('hooks/usePortalContributionList');
+jest.mock('./ContributionItem');
+
+function tree(context?: Partial<PortalAuthContextResult>) {
+  return render(
+    <PortalAuthContext.Provider value={{ contributor: { id: 'mock-contributor-id' } as any, ...context }}>
+      <ContributionsList />
+    </PortalAuthContext.Provider>
+  );
+}
+
+describe('ContributionsList', () => {
+  const usePortalContributionsListMock = jest.mocked(usePortalContributionList);
+
+  beforeEach(() => {
+    usePortalContributionsListMock.mockReturnValue({
+      contributions: [],
+      isError: false,
+      isFetching: false,
+      isLoading: false
+    });
+  });
+
+  it('shows a Transactions heading', () => {
+    tree();
+    expect(screen.getByRole('heading', { name: 'Transactions' })).toBeInTheDocument();
+  });
+
+  it('fetches contributions for the current user', () => {
+    tree();
+    expect(usePortalContributionsListMock).toBeCalledWith('mock-contributor-id');
+  });
+
+  it('shows a spinner', () => {
+    usePortalContributionsListMock.mockReturnValue({
+      contributions: [],
+      isError: false,
+      isFetching: true,
+      isLoading: true
+    });
+    tree();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  describe('After contributions are fetched', () => {
+    it('shows a contribution item for each contribution', () => {
+      usePortalContributionsListMock.mockReturnValue({
+        contributions: [{ payment_provider_id: 'mock-id-1 ' }, { payment_provider_id: 'mock-id-2' }] as any,
+        isError: false,
+        isLoading: false,
+        isFetching: false
+      });
+      tree();
+      expect(screen.getByTestId('mock-contribution-item-mock-id-1')).toBeInTheDocument();
+      expect(screen.getByTestId('mock-contribution-item-mock-id-2')).toBeInTheDocument();
+    });
+
+    it('shows a message if the user has no contributions', () => {
+      usePortalContributionsListMock.mockReturnValue({
+        contributions: [],
+        isError: false,
+        isLoading: false,
+        isFetching: false
+      });
+      tree();
+      expect(screen.getByText('0 contributions to show')).toBeInTheDocument();
+    });
+
+    it("doesn't show a spinner", () => {
+      tree();
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/portal/ContributionsList/ContributionsList.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.tsx
@@ -2,17 +2,24 @@ import { ReactChild } from 'react';
 import { usePortalAuthContext } from 'hooks/usePortalAuth';
 import { usePortalContributionList } from 'hooks/usePortalContributionList';
 import ContributionItem from './ContributionItem';
-import { MainContent, List, Root, Subhead, Columns } from './ContributionsList.styled';
 import NoContributions from './NoContributions';
+import ContributionFetchError from './ContributionFetchError';
+import { MainContent, List, Root, Subhead, Columns, Loading } from './ContributionsList.styled';
 import { CircularProgress } from 'components/base';
 
 export function ContributionsList() {
   const { contributor } = usePortalAuthContext();
-  const { contributions, isLoading } = usePortalContributionList(contributor?.id);
+  const { contributions, isError, isLoading, refetch } = usePortalContributionList(contributor?.id);
   let content: ReactChild;
 
   if (isLoading) {
-    content = <CircularProgress aria-label="Loading contributions" variant="indeterminate" />;
+    content = (
+      <Loading>
+        <CircularProgress aria-label="Loading contributions" variant="indeterminate" />
+      </Loading>
+    );
+  } else if (isError) {
+    content = <ContributionFetchError onRetry={() => refetch()} />;
   } else if (contributions?.length > 0) {
     content = (
       <List>

--- a/spa/src/components/portal/ContributionsList/ContributionsList.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.tsx
@@ -1,0 +1,41 @@
+import { ReactChild } from 'react';
+import { usePortalAuthContext } from 'hooks/usePortalAuth';
+import { usePortalContributionList } from 'hooks/usePortalContributionList';
+import ContributionItem from './ContributionItem';
+import { MainContent, List, Root, Subhead, Columns } from './ContributionsList.styled';
+import NoContributions from './NoContributions';
+import { CircularProgress } from 'components/base';
+
+export function ContributionsList() {
+  const { contributor } = usePortalAuthContext();
+  const { contributions, isLoading } = usePortalContributionList(contributor?.id);
+  let content: ReactChild;
+
+  if (isLoading) {
+    content = <CircularProgress aria-label="Loading contributions" variant="indeterminate" />;
+  } else if (contributions?.length > 0) {
+    content = (
+      <List>
+        {contributions.map((contribution) => (
+          <ContributionItem contribution={contribution} key={contribution.payment_provider_id} />
+        ))}
+      </List>
+    );
+  } else {
+    content = <NoContributions />;
+  }
+
+  return (
+    <Root>
+      <Columns>
+        <MainContent>
+          <Subhead>Transactions</Subhead>
+          <p>View billing history, update payment details, and resend receipts.</p>
+          {content}
+        </MainContent>
+      </Columns>
+    </Root>
+  );
+}
+
+export default ContributionsList;

--- a/spa/src/components/portal/ContributionsList/NoContributions.stories.tsx
+++ b/spa/src/components/portal/ContributionsList/NoContributions.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import NoContributions from './NoContributions';
+
+export default {
+  component: NoContributions,
+  title: 'Contributor/NoContributions'
+} as ComponentMeta<typeof NoContributions>;
+
+const Template: ComponentStory<typeof NoContributions> = (props) => <NoContributions />;
+
+export const Default = Template.bind({});

--- a/spa/src/components/portal/ContributionsList/NoContributions.styled.ts
+++ b/spa/src/components/portal/ContributionsList/NoContributions.styled.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Root = styled.div`
+  align-items: center;
+  background-color: ${({ theme }) => theme.basePalette.greyscale.grey3};
+  color: ${({ theme }) => theme.basePalette.greyscale.grey1};
+  display: flex;
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
+  font-style: italic;
+  height: 175px;
+  justify-content: center;
+`;

--- a/spa/src/components/portal/ContributionsList/NoContributions.tsx
+++ b/spa/src/components/portal/ContributionsList/NoContributions.tsx
@@ -1,0 +1,7 @@
+import { Root } from './NoContributions.styled';
+
+export function NoContributions() {
+  return <Root>0 contributions to show</Root>;
+}
+
+export default NoContributions;

--- a/spa/src/components/portal/ContributionsList/__mocks__/ContributionFetchError.tsx
+++ b/spa/src/components/portal/ContributionsList/__mocks__/ContributionFetchError.tsx
@@ -1,0 +1,9 @@
+import { ContributionFetchErrorProps } from '../ContributionFetchError';
+
+export const ContributionFetchError = ({ onRetry }: ContributionFetchErrorProps) => (
+  <button data-testid="mock-contribution-fetch-error" onClick={onRetry}>
+    onRetry
+  </button>
+);
+
+export default ContributionFetchError;

--- a/spa/src/components/portal/ContributionsList/__mocks__/ContributionItem.tsx
+++ b/spa/src/components/portal/ContributionsList/__mocks__/ContributionItem.tsx
@@ -1,0 +1,7 @@
+import { ContributionItemProps } from '../ContributionItem';
+
+export const ContributionItem = (props: ContributionItemProps) => (
+  <div data-testid={`mock-contribution-item-${props.contribution.payment_provider_id}`} />
+);
+
+export default ContributionItem;

--- a/spa/src/components/portal/PortalPage.styled.ts
+++ b/spa/src/components/portal/PortalPage.styled.ts
@@ -11,7 +11,7 @@ export const PoweredBy = styled.div`
   font-size: ${(props) => props.theme.fontSizesUpdated.sm};
   color: ${(props) => props.theme.basePalette.greyscale.black};
   background: ${(props) => props.theme.basePalette.greyscale.grey4};
-  padding-bottom: 45px;
+  padding: 45px 0;
 
   & > span {
     font-family: ${(props) => props.theme.systemFont};
@@ -21,8 +21,6 @@ export const PoweredBy = styled.div`
 export const Header = styled.header`
   background: ${(props) => props.theme.basePalette.primary.indigo};
   background-size: cover;
-  height: 60px;
-  min-height: 60px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -37,4 +35,10 @@ export const Logo = styled.img`
   width: auto;
   max-width: 100%;
   margin: 0 auto;
+`;
+
+export const Root = styled.div`
+  display: grid;
+  grid-template-rows: 60px 1fr 145px;
+  min-height: 100vh;
 `;

--- a/spa/src/components/portal/PortalPage.tsx
+++ b/spa/src/components/portal/PortalPage.tsx
@@ -7,7 +7,7 @@ import usePortal from 'hooks/usePortal';
 import useWebFonts from 'hooks/useWebFonts';
 import React from 'react';
 import NRELogo from 'assets/images/nre-logo-blue.svg';
-import { PoweredBy, Header, Logo } from './PortalPage.styled';
+import { PoweredBy, Header, Logo, Root } from './PortalPage.styled';
 import { HOME_PAGE_URL } from 'constants/helperUrls';
 
 function PortalPage({ children }: { children: React.ReactNode }) {
@@ -26,21 +26,23 @@ function PortalPage({ children }: { children: React.ReactNode }) {
   return (
     <TrackPageView>
       <SegregatedStyles page={renderCustomStyles && page}>
-        {renderCustomStyles ? (
-          <DonationPageHeader page={page} />
-        ) : (
-          <Header>
-            <Logo src={NRELogo} alt="News Revenue Engine" />
-          </Header>
-        )}
-        {children}
-        <PoweredBy>
-          <span>Powered by</span>
-          {/* eslint-disable-next-line react/jsx-no-target-blank */}
-          <a href={HOME_PAGE_URL} target="_blank" aria-label="News Revenue Engine">
-            <PoweredByNRELogo style={{ width: 145 }} />
-          </a>
-        </PoweredBy>
+        <Root>
+          {renderCustomStyles ? (
+            <DonationPageHeader page={page} />
+          ) : (
+            <Header>
+              <Logo src={NRELogo} alt="News Revenue Engine" />
+            </Header>
+          )}
+          {children}
+          <PoweredBy>
+            <span>Powered by</span>
+            {/* eslint-disable-next-line react/jsx-no-target-blank */}
+            <a href={HOME_PAGE_URL} target="_blank" aria-label="News Revenue Engine">
+              <PoweredByNRELogo style={{ width: 145 }} />
+            </a>
+          </PoweredBy>
+        </Root>
       </SegregatedStyles>
     </TrackPageView>
   );

--- a/spa/src/components/portal/TokenVerification/TokenError.stories.tsx
+++ b/spa/src/components/portal/TokenVerification/TokenError.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import TokenError from './TokenError';
+
+export default {
+  component: TokenError,
+  title: 'Contributor/TokenError'
+} as ComponentMeta<typeof TokenError>;
+
+const Template: ComponentStory<typeof TokenError> = () => <TokenError />;
+
+export const Default = Template.bind({});

--- a/spa/src/components/portal/TokenVerification/TokenError.styled.ts
+++ b/spa/src/components/portal/TokenVerification/TokenError.styled.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const Root = styled.div`
+  align-self: stretch;
+  background-color: ${({ theme }) => theme.basePalette.greyscale.grey4};
+  padding: 50px;
+`;
+
+export const Text = styled.p`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
+  margin: 1em auto;
+  max-width: 630px;
+`;

--- a/spa/src/components/portal/TokenVerification/TokenError.test.tsx
+++ b/spa/src/components/portal/TokenVerification/TokenError.test.tsx
@@ -1,0 +1,29 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import TokenError from './TokenError';
+
+function tree() {
+  return render(<TokenError />);
+}
+
+describe('TokenError', () => {
+  it('displays an error message', () => {
+    tree();
+    expect(screen.getByText('We were unable to log you in.')).toBeInTheDocument();
+  });
+
+  it('displays a link to get another magic link', () => {
+    tree();
+
+    const link = screen.getByRole('link');
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/portal/');
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/portal/TokenVerification/TokenError.tsx
+++ b/spa/src/components/portal/TokenVerification/TokenError.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+import { PORTAL } from 'routes';
+import { Root, Text } from './TokenError.styled';
+
+export function TokenError() {
+  return (
+    <Root>
+      <Text>We were unable to log you in.</Text>
+      <Text>
+        Magic links have short expiration times. If your link expired, <Link to={PORTAL.ENTRY}>go here</Link> to get
+        another.
+      </Text>
+    </Root>
+  );
+}
+
+export default TokenError;

--- a/spa/src/components/portal/TokenVerification/TokenVerification.test.tsx
+++ b/spa/src/components/portal/TokenVerification/TokenVerification.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from 'test-utils';
+import TokenVerification from './TokenVerification';
+import { PortalAuthContext, PortalAuthContextResult } from 'hooks/usePortalAuth';
+import { useLocation } from 'react-router-dom';
+
+jest.mock('elements/GlobalLoading');
+jest.mock('./TokenError');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Redirect: ({ to }: { to: string }) => <div data-testid="mock-redirect" data-to={to} />,
+  useLocation: jest.fn()
+}));
+
+function tree(context: PortalAuthContextResult) {
+  return render(
+    <PortalAuthContext.Provider value={context}>
+      <TokenVerification />
+    </PortalAuthContext.Provider>
+  );
+}
+
+describe('TokenVerification', () => {
+  const useLocationMock = jest.mocked(useLocation);
+
+  beforeEach(() => {
+    useLocationMock.mockReturnValue({ search: '?email=mock-email&token=mock-token' });
+  });
+
+  it('redirects to the contributions list if the user is authenticated', () => {
+    tree({ contributor: { mockContributor: true } as any });
+    expect(screen.getByTestId('mock-redirect').dataset.to).toBe('/portal/my-contributions/');
+  });
+
+  describe("When the user isn't authenticated", () => {
+    it.each([
+      ['email', '?token=mock-token'],
+      ['token', '?email=mock-email']
+    ])("shows an error and doesn't try to verify the token if the %s querystring is missing", (_, search) => {
+      const verifyToken = jest.fn();
+
+      useLocationMock.mockReturnValue({ search });
+      tree({ verifyToken });
+      expect(screen.getByTestId('mock-token-error')).toBeInTheDocument();
+      expect(verifyToken).not.toBeCalled();
+    });
+
+    describe('When email and token querystring params are set', () => {
+      it('verifies the token', () => {
+        const verifyToken = jest.fn();
+
+        tree({ verifyToken });
+        expect(verifyToken.mock.calls).toEqual([['mock-email', 'mock-token']]);
+      });
+
+      it('shows a spinner while verifying', () => {
+        const verifyToken = jest.fn(() => new Promise(() => {}));
+
+        tree({ verifyToken } as any);
+        expect(screen.getByTestId('mock-global-loading')).toBeInTheDocument();
+      });
+
+      it('shows an error if verifying fails', async () => {
+        const verifyToken = jest.fn(() => Promise.reject(new Error()));
+
+        tree({ verifyToken });
+        await waitFor(() => expect(screen.queryByTestId('mock-global-loading')).not.toBeInTheDocument());
+        expect(screen.getByTestId('mock-token-error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // No accessibility test because this component renders no UI of its own.
+});

--- a/spa/src/components/portal/TokenVerification/TokenVerification.tsx
+++ b/spa/src/components/portal/TokenVerification/TokenVerification.tsx
@@ -1,0 +1,45 @@
+import { usePortalAuthContext } from 'hooks/usePortalAuth';
+import { useEffect, useMemo, useState } from 'react';
+import { Redirect, useLocation } from 'react-router-dom';
+import { PORTAL } from 'routes';
+import GlobalLoading from 'elements/GlobalLoading';
+import TokenError from './TokenError';
+
+export function TokenVerification() {
+  const { search } = useLocation();
+  const { email, token } = useMemo(() => {
+    const params = new URLSearchParams(search);
+
+    return { email: params.get('email'), token: params.get('token') };
+  }, [search]);
+  const [error, setError] = useState<Error | undefined>(
+    !email || !token ? new Error('Missing querystring params') : undefined
+  );
+  const { contributor, verifyToken } = usePortalAuthContext();
+
+  useEffect(() => {
+    async function run() {
+      try {
+        await verifyToken!(email!, token!);
+      } catch (error) {
+        setError(error as Error);
+      }
+    }
+
+    if (email && token && verifyToken) {
+      run();
+    }
+  }, [email, token, verifyToken]);
+
+  if (contributor) {
+    return <Redirect to={PORTAL.CONTRIBUTIONS} />;
+  }
+
+  if (error) {
+    return <TokenError />;
+  }
+
+  return <GlobalLoading />;
+}
+
+export default TokenVerification;

--- a/spa/src/components/portal/TokenVerification/__mocks__/TokenError.tsx
+++ b/spa/src/components/portal/TokenVerification/__mocks__/TokenError.tsx
@@ -1,0 +1,2 @@
+export const TokenError = () => <div data-testid="mock-token-error" />;
+export default TokenError;

--- a/spa/src/hooks/useContributorContributionList.ts
+++ b/spa/src/hooks/useContributorContributionList.ts
@@ -113,6 +113,8 @@ export interface UseContributorContributionListResult {
 /**
  * Manages contribution data for the logged-in contributor user. **This returns
  * different data than what what an org or Hub admin would receive.**
+ *
+ * @deprecated
  */
 export function useContributorContributionList(
   queryParams?: UseContributionListQueryParams

--- a/spa/src/hooks/usePortalAuth.test.tsx
+++ b/spa/src/hooks/usePortalAuth.test.tsx
@@ -1,0 +1,177 @@
+import MockAdapter from 'axios-mock-adapter';
+import { useState } from 'react';
+import Axios from 'ajax/axios';
+import { LS_CONTRIBUTOR, LS_CSRF_TOKEN } from 'appSettings';
+import { fireEvent, render, screen, waitFor } from 'test-utils';
+import { PortalAuthContextProvider, usePortalAuthContext } from './usePortalAuth';
+
+function TestConsumer() {
+  const { contributor, verifyToken } = usePortalAuthContext();
+  const [error, setError] = useState<Error>();
+
+  async function handleClick() {
+    try {
+      await verifyToken!('mock-email', 'mock-token');
+    } catch (err) {
+      setError(err as Error);
+    }
+  }
+
+  return (
+    <>
+      {error && <div data-testid="error">{error.message}</div>}
+      {contributor && <div data-testid="contributor">{JSON.stringify(contributor)}</div>}
+      {verifyToken && <button onClick={handleClick}>verifyToken</button>}
+    </>
+  );
+}
+
+function tree() {
+  render(
+    <PortalAuthContextProvider>
+      <TestConsumer />
+    </PortalAuthContextProvider>
+  );
+}
+
+const testContributor = {
+  created: 'test-created',
+  email: 'test-email',
+  id: 123,
+  modified: 'test-modified',
+  uuid: 'test-uuid'
+};
+
+describe('PortalAuthContextProvider', () => {
+  const axiosMock = new MockAdapter(Axios);
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterAll(() => axiosMock.restore());
+
+  it("initially sets the contributor object to undefined if it's not in local storage", () => {
+    tree();
+    expect(screen.queryByTestId('contributor')).not.toBeInTheDocument();
+  });
+
+  it('loads the contributor object from local storage if available', () => {
+    window.localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify(testContributor));
+    tree();
+    expect(screen.getByTestId('contributor')).toHaveTextContent(JSON.stringify(testContributor));
+  });
+
+  it("doesn't provide a verifyToken function if a contributor was loaded from local storage", () => {
+    window.localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify(testContributor));
+    tree();
+    expect(screen.queryByText('verifyToken')).not.toBeInTheDocument();
+  });
+
+  it('ignores a malformed object in local storage', () => {
+    window.localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify({ ...testContributor, email: undefined }));
+    tree();
+    expect(screen.queryByTestId('contributor')).not.toBeInTheDocument();
+  });
+
+  describe('The verifyToken function it provides', () => {
+    beforeEach(() => {
+      axiosMock.onPost('contrib-verify/').reply(200, {
+        contributor: testContributor,
+        csrftoken: 'mock-csrf-token',
+        detail: 'success'
+      });
+    });
+
+    afterEach(() => {
+      axiosMock.reset();
+    });
+
+    it('POSTS email and token to contrib-verify/', async () => {
+      tree();
+      fireEvent.click(screen.getByText('verifyToken'));
+      await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+      expect(axiosMock.history.post[0].url).toBe('contrib-verify/');
+      expect(axiosMock.history.post[0].data).toEqual(JSON.stringify({ email: 'mock-email', token: 'mock-token' }));
+    });
+
+    describe('If the POST succeeds', () => {
+      it('sets the contributor object in context', async () => {
+        tree();
+        expect(screen.queryByTestId('contributor')).not.toBeInTheDocument();
+        fireEvent.click(screen.getByText('verifyToken'));
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+        expect(screen.getByTestId('contributor')).toHaveTextContent(JSON.stringify(testContributor));
+      });
+
+      it('no longer provides a verifyToken function in context', async () => {
+        tree();
+        fireEvent.click(screen.getByText('verifyToken'));
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+        expect(screen.queryByText('verifyToken')).not.toBeInTheDocument();
+      });
+
+      it('saves the contributor to local storage', async () => {
+        tree();
+        expect(window.localStorage.getItem(LS_CONTRIBUTOR)).toBe(null);
+        fireEvent.click(screen.getByText('verifyToken'));
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+        expect(window.localStorage.getItem(LS_CONTRIBUTOR)).toBe(JSON.stringify(testContributor));
+      });
+
+      it('saves the CSRF token to local storage', async () => {
+        tree();
+        expect(window.localStorage.getItem(LS_CSRF_TOKEN)).toBe(null);
+        fireEvent.click(screen.getByText('verifyToken'));
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+        expect(window.localStorage.getItem(LS_CSRF_TOKEN)).toBe('mock-csrf-token');
+      });
+    });
+
+    it('throws an error if the POST itself fails', async () => {
+      axiosMock.reset();
+      axiosMock.onPost().networkError();
+      tree();
+      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('verifyToken'));
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error')).toHaveTextContent('Network Error');
+    });
+
+    it("throws an error if the response code isn't success", async () => {
+      axiosMock.reset();
+      axiosMock.onPost().reply(200, { detail: 'test-error' });
+      tree();
+      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('verifyToken'));
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error')).toHaveTextContent('test-error');
+    });
+
+    it("throws an error if contributor isn't present in the response", async () => {
+      axiosMock.reset();
+      axiosMock.onPost().reply(200, {
+        csrftoken: 'mock-csrf-token',
+        detail: 'success'
+      });
+      tree();
+      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('verifyToken'));
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error')).toHaveTextContent('No contributor in token verification response');
+    });
+
+    it("throws an error if a CSRF token isn't present in the response", async () => {
+      axiosMock.reset();
+      axiosMock.onPost().reply(200, {
+        contributor: testContributor,
+        detail: 'success'
+      });
+      tree();
+      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('verifyToken'));
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error')).toHaveTextContent('No CSRF in token verification response');
+    });
+  });
+});

--- a/spa/src/hooks/usePortalAuth.tsx
+++ b/spa/src/hooks/usePortalAuth.tsx
@@ -1,0 +1,128 @@
+import PropTypes, { InferProps } from 'prop-types';
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import axios from 'ajax/axios';
+import { VERIFY_TOKEN } from 'ajax/endpoints';
+import { LS_CONTRIBUTOR, LS_CSRF_TOKEN } from 'appSettings';
+
+/**
+ * A contributor who has logged into the portal.
+ */
+export interface Contributor {
+  /**
+   * Timestamp when the contributor was created.
+   */
+  created: string;
+  /**
+   * Contributor's email address.
+   */
+  email: string;
+  /**
+   * Internal ID for the contributor.
+   */
+  id: number;
+  /**
+   * Timestamp when the contributor was modified.
+   */
+  modified: string;
+  /**
+   * Unique ID for the contributor
+   */
+  uuid: string;
+}
+
+/**
+ * Properties provided to consumers of usePortalAuthContext.
+ */
+export interface PortalAuthContextResult {
+  /**
+   * The current logged-in contributor. If undefined, the user isn't
+   * authenticated.
+   */
+  contributor?: Contributor;
+  /**
+   * Exchanges a token sent via magic link email for a JWT. If undefined, the
+   * user is already authenticated. If this succeeds, contributor is set in
+   * context and the function resolves. If it fails, it rejects with either an
+   * Axios error (if there were problems with the request itself) or an error
+   * with the response from the server.
+   */
+  verifyToken?: (email: string, token: string) => Promise<void>;
+}
+
+/**
+ * Expected API response when verifying a token.
+ */
+export interface VerifyTokenResponse {
+  contributor?: Contributor;
+  csrftoken?: string;
+  detail: string;
+}
+
+export const PortalAuthContext = createContext<PortalAuthContextResult>({});
+
+export const usePortalAuthContext = () => useContext(PortalAuthContext);
+
+const PortalAuthContextProviderProps = {
+  children: PropTypes.node.isRequired
+};
+
+export function PortalAuthContextProvider({ children }: InferProps<typeof PortalAuthContextProviderProps>) {
+  const [contributor, setContributor] = useState<Contributor>();
+  const verifyToken = useCallback(async (email: string, token: string) => {
+    const { data } = await axios.post<VerifyTokenResponse>(VERIFY_TOKEN, { email, token });
+
+    if (data.detail !== 'success') {
+      throw new Error(data.detail);
+    }
+
+    if (!data.contributor) {
+      throw new Error('No contributor in token verification response');
+    }
+
+    if (!data.csrftoken) {
+      throw new Error('No CSRF in token verification response');
+    }
+
+    // Set values in context and in local storage for later usage. The local
+    // storage key is also needed for backwards compat with isAuthenticated() in
+    // utilities/, used by ProtectedRoute.
+
+    setContributor(data.contributor);
+    localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify(data.contributor));
+    localStorage.setItem(LS_CSRF_TOKEN, data.csrftoken);
+  }, []);
+
+  // Try to initally set the contributor based on local storage.
+
+  useEffect(() => {
+    const lsContributor = localStorage.getItem(LS_CONTRIBUTOR);
+
+    if (!lsContributor) {
+      // The contributor hasn't previously logged in.
+      return;
+    }
+
+    try {
+      const { created, email, id, modified, uuid } = JSON.parse(lsContributor);
+
+      if (
+        typeof created === 'string' &&
+        typeof email === 'string' &&
+        typeof id === 'number' &&
+        typeof modified === 'string' &&
+        typeof uuid === 'string'
+      ) {
+        setContributor({ created, email, id, modified, uuid });
+      }
+    } catch {
+      // Fail silently--their local storage has become malformed, so we want
+      // them to sign in again.
+    }
+  }, []);
+
+  return (
+    <PortalAuthContext.Provider value={contributor ? { contributor } : { verifyToken }}>
+      {children}
+    </PortalAuthContext.Provider>
+  );
+}

--- a/spa/src/hooks/usePortalContributionList.ts
+++ b/spa/src/hooks/usePortalContributionList.ts
@@ -12,7 +12,7 @@ export interface PortalContribution {
    */
   amount: number;
   /**
-   * What payment card was used on the contribution.
+   * The type of card on the contribution's current payment.
    */
   card_brand: CardBrand;
   /**
@@ -20,7 +20,8 @@ export interface PortalContribution {
    */
   created: string;
   /**
-   * When the credit card used for the contribution will expire.
+   * When the credit card used for the contribution's current payment will
+   * expire.
    * @example "4/2024"
    */
   credit_card_expiration_date: string;
@@ -37,17 +38,19 @@ export interface PortalContribution {
    */
   is_modifiable: boolean;
   /**
-   * Last four digits of the payment card used on the contribution.
+   * Last four digits of the payment card used on the current payment method of
+   * the contribution.
    */
   last4: string;
   /**
-   * Timestamp of when the last related payment occurred.
+   * Timestamp of when the last related payment occurred. This may be null in
+   * recurring contributions that have been migrated from legacy subscriptions.
    */
-  last_payment_date: string;
+  last_payment_date: null | string;
   /**
-   * Timestamp of when the next related payment will occur.
+   * Timestamp of when the next related payment will occur, if any.
    */
-  next_payment_date: string;
+  next_payment_date: null | string;
   /**
    * Internal ID of the payment in the payment processor, e.g. Stripe.
    */

--- a/spa/src/hooks/usePortalContributionList.ts
+++ b/spa/src/hooks/usePortalContributionList.ts
@@ -1,0 +1,98 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'ajax/axios';
+import { getContributionsEndpoint } from 'ajax/endpoints';
+import { ContributionInterval } from 'constants/contributionIntervals';
+import { PaymentStatus } from 'constants/paymentStatus';
+
+export type CardBrand = 'amex' | 'diners' | 'discover' | 'jcb' | 'mastercard' | 'unionpay' | 'visa' | 'unknown';
+
+export interface PortalContribution {
+  /**
+   * Amount **in cents** of the contribution.
+   */
+  amount: number;
+  /**
+   * What payment card was used on the contribution.
+   */
+  card_brand: CardBrand;
+  /**
+   * Timestamp of when the contribution was created.
+   */
+  created: string;
+  /**
+   * When the credit card used for the contribution will expire.
+   * @example "4/2024"
+   */
+  credit_card_expiration_date: string;
+  /**
+   * How often the contribution is being made.
+   */
+  interval: ContributionInterval;
+  /**
+   * Can the contribution be cancelled?
+   */
+  is_cancelable: boolean;
+  /**
+   * Can the contribution be modified? (e.g. to change its payment method)
+   */
+  is_modifiable: boolean;
+  /**
+   * Last four digits of the payment card used on the contribution.
+   */
+  last4: string;
+  /**
+   * Timestamp of when the last related payment occurred.
+   */
+  last_payment_date: string;
+  /**
+   * Timestamp of when the next related payment will occur.
+   */
+  next_payment_date: string;
+  /**
+   * Internal ID of the payment in the payment processor, e.g. Stripe.
+   */
+  payment_provider_id: string;
+  /**
+   * How was the payment made?
+   */
+  payment_type: string;
+  /**
+   * Internal ID of the customer in the payment processor, e.g. Stripe.
+   */
+  provider_customer_id: string;
+  /**
+   * ID of the revenue program that was contributed to.
+   */
+  revenue_program: number;
+  /**
+   * Processing status of the payment.
+   */
+  status: PaymentStatus;
+}
+
+export interface ContributionListResponse {
+  count: number;
+  next?: string;
+  previous?: string;
+  results: PortalContribution[];
+}
+
+async function fetchContributions(contributorId: number) {
+  const { data } = await axios.get<ContributionListResponse>(getContributionsEndpoint(contributorId));
+
+  return { count: data.count, results: data.results };
+}
+
+/**
+ * Manages fetching the list of contributions a contributor sees when logging
+ * into the portal.
+ */
+export function usePortalContributionList(contributorId?: number) {
+  const { data, isError, isFetching, isLoading } = useQuery(
+    ['portalContributionList'],
+    () => fetchContributions(contributorId!),
+    { enabled: !!contributorId, keepPreviousData: true }
+  );
+
+  return { contributions: data?.results ?? [], isError, isFetching, isLoading };
+}

--- a/spa/src/hooks/usePortalContributionList.ts
+++ b/spa/src/hooks/usePortalContributionList.ts
@@ -88,11 +88,11 @@ async function fetchContributions(contributorId: number) {
  * into the portal.
  */
 export function usePortalContributionList(contributorId?: number) {
-  const { data, isError, isFetching, isLoading } = useQuery(
+  const { data, isError, isFetching, isLoading, refetch } = useQuery(
     ['portalContributionList'],
     () => fetchContributions(contributorId!),
     { enabled: !!contributorId, keepPreviousData: true }
   );
 
-  return { contributions: data?.results ?? [], isError, isFetching, isLoading };
+  return { contributions: data?.results ?? [], isError, isFetching, isLoading, refetch };
 }

--- a/spa/src/routes.ts
+++ b/spa/src/routes.ts
@@ -29,7 +29,7 @@ export const CONTRIBUTOR_DASHBOARD = join([CONTRIBUTOR_ENTRY, 'contributions/'])
 export const PORTAL = {
   ENTRY: '/portal/',
   VERIFY: '/portal/verification/',
-  DASHBOARD: '/portal/my-contributions/'
+  CONTRIBUTIONS: '/portal/my-contributions/'
 };
 
 // Account

--- a/spa/src/utilities/formatCurrencyAmount.js
+++ b/spa/src/utilities/formatCurrencyAmount.js
@@ -1,5 +1,0 @@
-const formatCurrencyAmount = (rawAmount) => {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(rawAmount / 100);
-};
-
-export default formatCurrencyAmount;

--- a/spa/src/utilities/formatCurrencyAmount.test.ts
+++ b/spa/src/utilities/formatCurrencyAmount.test.ts
@@ -1,0 +1,9 @@
+import formatCurrencyAmount from './formatCurrencyAmount';
+
+describe('formatCurrencyAmount', () => {
+  it('formats a number with cents', () => expect(formatCurrencyAmount(12345)).toBe('$123.45'));
+  it('formats a round number with two decimal places by default', () =>
+    expect(formatCurrencyAmount(12300)).toBe('$123.00'));
+  it('formats a round number without decimal places if requested', () =>
+    expect(formatCurrencyAmount(12300, true)).toBe('$123'));
+});

--- a/spa/src/utilities/formatCurrencyAmount.ts
+++ b/spa/src/utilities/formatCurrencyAmount.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns a formatted currency amount in US cents.
+ * @param rawAmount - amount in cents
+ * @param omitDecimalsInRoundNumbers - if true, leaves out the `.00` in an
+ * amount like 100
+ */
+const formatCurrencyAmount = (rawAmount: number, omitDecimalsInRoundNumbers = false) => {
+  const decimalValue = rawAmount / 100;
+
+  if (omitDecimalsInRoundNumbers && Math.round(decimalValue) === decimalValue) {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    })
+      .format(decimalValue)
+      .replace(/\.00$/, '');
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  }).format(decimalValue);
+};
+
+export default formatCurrencyAmount;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

1. Adds a list of contributions in the new contributor portal. Lots of functionality yet to come; see Jira for out of scope stuff.
2. Adds a new context, PortalAuthContext, and a component to manage it.
3. Uses a new component, TokenVerification, instead of the older ContributorVerify.
4. Adds a new hook, usePortalContributionList, to retrieve contributions from the new API endpoint. Existing hook is marked deprecated.
5. Adds a CircularProgress base component.
6. Migrates `formatCurrencyAmount` to TypeScript and adds parameter to optionally omit the cents in an amount if it's a round number.
7. Changes the name of the `PORTAL.DASHBOARD` route to `PORTAL.CONTRIBUTIONS`.

#### Why are we doing this? How does it help us?

1. Makes progress toward new portal.
2. The existing approach on auth in the contributor portal relied on storing context in local storage. The new context stores it there, but provides a typed interface to consumers who need it (i.e. the contributions list needs to know the contributor ID). This will increase reliability/dev speed since consumers no longer need to use local storage directly and handle possible errors every time they access it.
3. TokenVerification uses the new context in point 2.
4. New hook keeps business logic separate/more testable. I marked the existing one deprecated to avoid confusion since the names are pretty similar.
5. It's a better UI experience to see part of the page show a spinner instead of the entire page graying out. This CircularProgress component allows that.
6. The new contributions list omits cents in round amounts.
7. I thought it was confusing to have a route in the contributor portal named "dashboard" when we are calling the admin area "the dashboard".

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Need updated docs around the new portal, but even merged, users will continue to be directed to the existing portal.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-3884

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

See rest of epic.