### PR TITLE
DEV-4191: Send Pendo event on page publish

### DIFF
--- a/spa/src/components/common/Button/PublishButton/PublishButton.tsx
+++ b/spa/src/components/common/Button/PublishButton/PublishButton.tsx
@@ -72,7 +72,6 @@ function PublishButton({ className }: PublishButtonProps) {
   } = useModal();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [slugError, setSlugError] = useState<string[]>();
-
   const showPopover = Boolean(anchorEl);
   const disabled = !page?.payment_provider?.stripe_verified;
   const isPublished = page && pageIsPublished(page);
@@ -151,6 +150,21 @@ function PublishButton({ className }: PublishButtonProps) {
       // Notify the user of success.
 
       handleOpenSuccessfulPublishModal();
+
+      // Track an event in Pendo if available. It will only be available when
+      // the user is an org admin. If it fails, log the problem but don't show
+      // an error to the user.
+
+      if ((window as any).pendo) {
+        try {
+          (window as any).pendo.track('contribution-page-publish', {
+            id: page.id,
+            name: page.name
+          });
+        } catch (error) {
+          console.error(`Couldn't track a page publish event in Pendo: ${(error as Error).message}`);
+        }
+      }
     } catch (error) {
       const { isHubAdmin, isSuperUser } = getUserRole(user);
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

If Pendo is previously initialized, sends an event when a user publishes a page.

#### Why are we doing this? How does it help us?

Provides better app analytics.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4191

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

https://news-revenue-hub.atlassian.net/browse/DEV-4192