### PR TITLE
DEV-4257 | Truncate string fields in Stripe metadata at > 500 characters

### DIFF
--- a/apps/contributions/tests/test_types.py
+++ b/apps/contributions/tests/test_types.py
@@ -1,0 +1,21 @@
+import pytest
+
+from apps.contributions.types import StripeMetadataSchemaBase
+
+
+class TestStripeMetadataSchemaBase:
+    @pytest.fixture
+    def schema(self):
+        class Schema(StripeMetadataSchemaBase):
+            schema_version: str = "1.4"
+            source: str = "rev-engine"
+            foo: str
+            bar: str | None = None
+
+        return Schema
+
+    def test_truncate_strings(self, schema):
+        over_limit = 501 * "a"
+        instance = schema(foo=over_limit)
+        assert len(instance.foo) == 500
+        assert instance.bar is None

--- a/apps/contributions/types.py
+++ b/apps/contributions/types.py
@@ -89,6 +89,8 @@ class StripeMetadataSchemaBase(pydantic.BaseModel):
     schema_version: Literal["1.4"]
     source: Literal["rev-engine"]
 
+    METADATA_TEXT_MAX_LENGTH: ClassVar[int] = 500
+
     @classmethod
     def normalize_boolean(cls, v: Any) -> bool | None:
         """Normalize boolean values
@@ -105,6 +107,17 @@ class StripeMetadataSchemaBase(pydantic.BaseModel):
             if v.lower().strip() in ["true", "yes", "y"]:
                 return True
         raise ValueError("Value must be a boolean, None, or castable string")
+
+    @pydantic.validator("*", pre=True, always=True)
+    def truncate_strings(cls, v: Any) -> str | None:
+        """Truncate strings
+
+        This validator is responsible for ensuring that all string fields are no longer than
+        METADATA_TEXT_MAX_LENGTH characters.
+        """
+        if isinstance(v, str):
+            return v[: cls.METADATA_TEXT_MAX_LENGTH]
+        return v
 
 
 class StripePaymentMetadataSchemaV1_4(StripeMetadataSchemaBase):


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Truncates all string values in Stripe metadata on creation if over 500 characters. Otherwise Stripe complains because that's max length allowed for metadata fields.

This came up as a bug (specifically with the referer field).

#### Why are we doing this? How does it help us?

Solve for bug.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?


Yes

#### How should this change be communicated to end users?

Can let affected orgs know they can accept contributions again.

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No


#### What are the relevant tickets? Add a link to any relevant ones.


[DEV-4257](https://news-revenue-hub.atlassian.net/browse/DEV-4257)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:


N/A


[DEV-4257]: https://news-revenue-hub.atlassian.net/browse/DEV-4257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ