### PR TITLE
DEV-4305: Identify user in Sentry upon payment creation

### DIFF
--- a/spa/cypress/e2e/01-donationPage.cy.js
+++ b/spa/cypress/e2e/01-donationPage.cy.js
@@ -830,7 +830,7 @@ describe('User flow: unhappy paths', () => {
       .findByRole('button', { name: /Continue to Payment/ })
       .click();
     cy.wait('@create-one-time-payment__unauthorized');
-    cy.get('[data-testid="500-something-wrong"]');
+    cy.get('[data-testid="live-error-fallback"]');
   });
 
   specify("Users indicates they want to specify an amount, but doesn't specify an actual number", () => {
@@ -875,7 +875,7 @@ describe('User flow: unhappy paths', () => {
     cy.get('[data-testid*="mailing_state"]').type('NY');
     cy.get('[data-testid*="mailing_postal_code"]').type('100738');
     cy.get('#country').type('a{enter}');
-    cy.get('[data-testid="500-something-wrong"]').should('not.exist');
+    cy.get('[data-testid="live-error-fallback"]').should('not.exist');
   });
 });
 

--- a/spa/public/static/locales/en/translation.json
+++ b/spa/public/static/locales/en/translation.json
@@ -5,7 +5,10 @@
     "no": "No",
     "error": {
       "generic": "We encountered an issue and have been notified. Please try again.",
-      "internalError": "We've encountered an error. Please refresh and try again."
+      "internalError": {
+        "heading": "We've encountered an error.",
+        "message": "Please refresh and try again."
+      }
     },
     "actions": {
       "back": "Back"

--- a/spa/public/static/locales/es/translation.json
+++ b/spa/public/static/locales/es/translation.json
@@ -5,7 +5,10 @@
     "no": "No",
     "error": {
       "generic": "Encontramos un problema y se nos ha notificado. Por favor, intente nuevamente.",
-      "internalError": "Hemos encontrado un error. Por favor, actualice la página e intente nuevamente."
+      "internalError": {
+        "heading": "Hemos encontrado un error.",
+        "message": "Por favor, actualice la página e intente nuevamente."
+      }
     },
     "actions": {
       "back": "Regrese"

--- a/spa/src/components/donationPage/live/LiveErrorFallback.stories.tsx
+++ b/spa/src/components/donationPage/live/LiveErrorFallback.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import LiveErrorFallback from './LiveErrorFallback';
+
+const meta: Meta<typeof LiveErrorFallback> = {
+  title: 'Errors/LiveErrorFallback',
+  component: LiveErrorFallback
+};
+
+export default meta;
+type Story = StoryObj<typeof LiveErrorFallback>;
+
+export const Default: Story = {};

--- a/spa/src/components/donationPage/live/LiveErrorFallback.styled.ts
+++ b/spa/src/components/donationPage/live/LiveErrorFallback.styled.ts
@@ -1,30 +1,20 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.div`
+export const Root = styled.div`
+  align-items: center;
   flex: 1;
   display: flex;
+  flex-direction: column;
+  gap: 12px;
   justify-content: center;
-  background: ${(props) => props.theme.colors.fieldBackground};
+  padding: 24px;
+  background-color: #fee6eb;
 `;
 
-export const Content = styled.div`
-  margin-top: 10%;
+export const Heading = styled.p`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.lg};
 `;
 
-export const FiveHundred = styled.h2`
-  display: block;
-  font-size: ${(props) => props.theme.fontSizes[6]};
-  font-weight: 900;
-  text-transform: uppercase;
-  text-align: center;
-  color: ${(props) => props.theme.colors.grey[4]};
-  margin: 0;
-  padding: 0;
-  margin-bottom: 1rem;
-
-  @media (${(props) => props.theme.breakpoints.tabletLandscapeDown}) {
-    font-size: ${(props) => props.theme.fontSizes[5]};
-  }
+export const Message = styled.p`
+  font-size: ${({ theme }) => theme.fontSizesUpdated.md};
 `;
-
-export const Description = styled.p``;

--- a/spa/src/components/donationPage/live/LiveErrorFallback.test.tsx
+++ b/spa/src/components/donationPage/live/LiveErrorFallback.test.tsx
@@ -5,14 +5,8 @@ import LiveErrorFallback from './LiveErrorFallback';
 describe('LiveErrorFallback', () => {
   it('should display the correct error message', () => {
     render(<LiveErrorFallback />);
-
-    expect(screen.getByText('common.error.internalError')).toBeInTheDocument();
-  });
-
-  it('should display the correct error code', () => {
-    render(<LiveErrorFallback />);
-
-    expect(screen.getByText('500')).toBeInTheDocument();
+    expect(screen.getByText('common.error.internalError.heading')).toBeInTheDocument();
+    expect(screen.getByText('common.error.internalError.message')).toBeInTheDocument();
   });
 
   it('is accessible', async () => {

--- a/spa/src/components/donationPage/live/LiveErrorFallback.tsx
+++ b/spa/src/components/donationPage/live/LiveErrorFallback.tsx
@@ -1,16 +1,14 @@
 import { useTranslation } from 'react-i18next';
-import { Wrapper, FiveHundred, Description, Content } from './LiveErrorFallback.styled';
+import { Heading, Message, Root } from './LiveErrorFallback.styled';
 
 function LiveErrorFallback() {
   const { t } = useTranslation();
 
   return (
-    <Wrapper data-testid="500-something-wrong">
-      <Content>
-        <FiveHundred>500</FiveHundred>
-        <Description>{t('common.error.internalError')}</Description>
-      </Content>
-    </Wrapper>
+    <Root data-testid="live-error-fallback">
+      <Heading>{t('common.error.internalError.heading')}</Heading>
+      <Message>{t('common.error.internalError.message')}</Message>
+    </Root>
   );
 }
 

--- a/spa/src/hooks/usePayment.test.ts
+++ b/spa/src/hooks/usePayment.test.ts
@@ -219,6 +219,17 @@ describe('usePayment', () => {
         await expect(result.current.createPayment!(mockFormData, mockPage)).rejects.toThrow();
         errorSpy.mockRestore();
       });
+
+      it('logs the error response if the POST fails', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const { result } = hook();
+
+        axiosMock.reset();
+        axiosMock.onPost().reply(500, { detail: 'mock-detail' });
+        await expect(result.current.createPayment!(mockFormData, mockPage)).rejects.toThrow();
+        expect(errorSpy).toBeCalledWith('Error creating payment: {"detail":"mock-detail"}');
+        errorSpy.mockRestore();
+      });
     });
 
     it("doesn't return a payment", async () => {

--- a/spa/src/hooks/usePayment.ts
+++ b/spa/src/hooks/usePayment.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import { PaymentMethodCreateParams } from '@stripe/stripe-js';
 import { useMutation } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
@@ -104,6 +105,16 @@ export function usePayment() {
   );
   const createPayment = useCallback(
     async (paymentData: PaymentData, page: ContributionPage) => {
+      // Set the user in Sentry so if there are any problems, we have work
+      // backwards to find them in Sentry. This needs to happen immediately so
+      // that if anything goes wrong here, the user is identified.
+
+      Sentry.setUser({
+        email: (paymentData.email as string | null) ?? '<unset>',
+        firstName: paymentData.first_name,
+        lastName: paymentData.last_name
+      });
+
       // A published page should always have a slug, so this shouldn't happen in
       // practice.
 

--- a/spa/src/hooks/usePayment.ts
+++ b/spa/src/hooks/usePayment.ts
@@ -9,6 +9,7 @@ import { CSRF_HEADER } from 'appSettings';
 import { serializeData } from 'components/paymentProviders/stripe/stripeFns';
 import { CONTRIBUTION_INTERVALS, ContributionInterval } from 'constants/contributionIntervals';
 import { ContributionPage } from './useContributionPage';
+import { AxiosError } from 'axios';
 
 export type PaymentData = ReturnType<typeof serializeData>;
 
@@ -139,6 +140,13 @@ export function usePayment() {
       }
 
       return createPaymentMutation.mutateAsync(paymentData, {
+        onError(error) {
+          // Log the response (if any) in Sentry.
+
+          if ((error as AxiosError).response?.data) {
+            console.error(`Error creating payment: ${JSON.stringify((error as AxiosError).response!.data)}`);
+          }
+        },
         onSuccess({ data }) {
           setPayment({
             amount: paymentData.amount,

--- a/spa/vite.config.js
+++ b/spa/vite.config.js
@@ -18,6 +18,11 @@ const config = defineConfig({
     // problems in Jest.
     'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`
   },
+  optimizeDeps: {
+    // Needed because Storybook was showing a "504 Outdated Optimize Dep" error.
+    // See https://github.com/vitejs/vite/issues/12434
+    exclude: ['sb-vite']
+  },
   plugins: [
     checker({
       eslint: { lintCommand: 'eslint src' },


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Sets user data in Sentry right before a payment is created on a donation page.
- Updates appearance of error message.

#### Why are we doing this? How does it help us?

- Gives us additional info in Sentry to track down issues.
- Removes spurious/confusing "500" heading.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4305

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.