### PR TITLE
DEV-3207: Add support for request id logs in GKE envs

### DIFF
--- a/revengine/settings/base.py
+++ b/revengine/settings/base.py
@@ -307,6 +307,10 @@ LOGGING = {
     },
 }
 
+### Request ID Settings
+# Ref: https://django-request-id.readthedocs.io/en/latest/
+# For Heroku environments, REQUEST_ID_HEADER will have to be set to "X-Request-ID"
+REQUEST_ID_HEADER = os.getenv("REQUEST_ID_HEADER", None)
 
 ### Sentry Settings
 SENTRY_ENABLE_FRONTEND = os.getenv("SENTRY_ENABLE_FRONTEND", "false").lower() == "true"


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
- Adds configuration to make request_id enabled for services that can’t generate the X-Request-Id header at the web server level (GKE/Google)

#### Why are we doing this? How does it help us?
- Enables request ID to be logged in GKE envs

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no

#### Have automated unit tests been added? If not, why?
n/a

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-3207

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
Yes, https://news-revenue-hub.atlassian.net/browse/ITS-2125

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no