### PR TITLE
DEV-2945: Fix IntegrationError: Invalid value for `(): elements should have a mounted Payment Element or Pay 

### DIFF
--- a/spa/src/components/donationPage/FinishPaymentModal/StripePaymentForm.tsx
+++ b/spa/src/components/donationPage/FinishPaymentModal/StripePaymentForm.tsx
@@ -132,18 +132,21 @@ export function StripePaymentForm({ payment, locale }: StripePaymentFormProps) {
 
   // for full options, see: https://stripe.com/docs/js/elements_object/create_payment_element
   // notably, can control fonts
-  const paymentElementOptions: StripePaymentElementOptions = {
-    fields: {
-      // we collected name, email, etc. in previous form, so we don't need to display these
-      // inputs in Stripe's payment element which defaults to including them. This means
-      // we need to add that data when we call stripe.confirmPayment.
-      billingDetails: 'never'
-    },
-    // This removes legal agreements that Stripe may display
-    terms: {
-      card: 'never'
-    }
-  };
+  const paymentElementOptions: StripePaymentElementOptions = useMemo(
+    () => ({
+      fields: {
+        // we collected name, email, etc. in previous form, so we don't need to display these
+        // inputs in Stripe's payment element which defaults to including them. This means
+        // we need to add that data when we call stripe.confirmPayment.
+        billingDetails: 'never'
+      },
+      // This removes legal agreements that Stripe may display
+      terms: {
+        card: 'never'
+      }
+    }),
+    []
+  );
 
   return (
     <Form onSubmit={handleSubmit}>

--- a/spa/src/components/donationPage/FinishPaymentModal/StripePaymentForm.tsx
+++ b/spa/src/components/donationPage/FinishPaymentModal/StripePaymentForm.tsx
@@ -14,6 +14,21 @@ const StripePaymentFormPropTypes = {
   payment: PropTypes.object.isRequired
 };
 
+// for full options, see: https://stripe.com/docs/js/elements_object/create_payment_element
+// notably, can control fonts
+export const paymentElementOptions: StripePaymentElementOptions = {
+  fields: {
+    // we collected name, email, etc. in previous form, so we don't need to display these
+    // inputs in Stripe's payment element which defaults to including them. This means
+    // we need to add that data when we call stripe.confirmPayment.
+    billingDetails: 'never'
+  },
+  // This removes legal agreements that Stripe may display
+  terms: {
+    card: 'never'
+  }
+};
+
 export interface StripePaymentFormProps extends InferProps<typeof StripePaymentFormPropTypes> {
   payment: Payment;
   locale: string;
@@ -129,24 +144,6 @@ export function StripePaymentForm({ payment, locale }: StripePaymentFormProps) {
       setIsLoading(false);
     }
   };
-
-  // for full options, see: https://stripe.com/docs/js/elements_object/create_payment_element
-  // notably, can control fonts
-  const paymentElementOptions: StripePaymentElementOptions = useMemo(
-    () => ({
-      fields: {
-        // we collected name, email, etc. in previous form, so we don't need to display these
-        // inputs in Stripe's payment element which defaults to including them. This means
-        // we need to add that data when we call stripe.confirmPayment.
-        billingDetails: 'never'
-      },
-      // This removes legal agreements that Stripe may display
-      terms: {
-        card: 'never'
-      }
-    }),
-    []
-  );
 
   return (
     <Form onSubmit={handleSubmit}>


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
Memoize stripe's PaymentElement `options` so that it doesn't trigger re-renders that might break stripe create payment function.

#### Why are we doing this? How does it help us?
Fix issue that avoids users from donating

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
n/a
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no
#### Have automated unit tests been added? If not, why?
No, no changes in functionality were made. 

#### How should this change be communicated to end users?
n/a
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
n/a
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-2945
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no