### PR TITLE
DEV-4355: Add className to PortalPage for styling

### DIFF
--- a/spa/src/components/PortalRouter.test.tsx
+++ b/spa/src/components/PortalRouter.test.tsx
@@ -16,10 +16,7 @@ jest.mock('react-router-dom', () => ({
 
 // Mock TrackPageView as a passthrough.
 
-jest.mock('components/portal/PortalPage', () => ({ children }: { children: React.ReactNode }) => (
-  <div data-testid="mock-portal-page">{children}</div>
-));
-
+jest.mock('components/portal/PortalPage');
 jest.mock('components/authentication/ProtectedRoute', () => ({ render }: { render: () => React.ReactNode }) => (
   <div data-testid="mock-protected-router">{render()}</div>
 ));
@@ -59,13 +56,12 @@ describe('PortalRouter', () => {
     expect(within(screen.getByTestId('mock-portal-page')).getByTestId('mock-portal-entry')).toBeInTheDocument();
   });
 
-  it('displays a PortalPage with ContributionsList at /portal/my-contributions/', async () => {
+  it('displays ContributionsList at /portal/my-contributions/', async () => {
     tree('/portal/my-contributions/');
     await screen.findByTestId('mock-contributions-list');
     expect(
       within(screen.getByTestId('mock-protected-router')).getByTestId('mock-contributions-list')
     ).toBeInTheDocument();
-    expect(within(screen.getByTestId('mock-portal-page')).getByTestId('mock-contributions-list')).toBeInTheDocument();
   });
 
   it('displays a PortalPage with ContributionsList at /portal/my-contributions/:contributionId/', async () => {

--- a/spa/src/components/PortalRouter.test.tsx
+++ b/spa/src/components/PortalRouter.test.tsx
@@ -64,13 +64,12 @@ describe('PortalRouter', () => {
     ).toBeInTheDocument();
   });
 
-  it('displays a PortalPage with ContributionsList at /portal/my-contributions/:contributionId/', async () => {
+  it('displays ContributionsList at /portal/my-contributions/:contributionId/', async () => {
     tree('/portal/my-contributions/contribution-id/');
     await screen.findByTestId('mock-contributions-list');
     expect(
       within(screen.getByTestId('mock-protected-router')).getByTestId('mock-contributions-list')
     ).toBeInTheDocument();
-    expect(within(screen.getByTestId('mock-portal-page')).getByTestId('mock-contributions-list')).toBeInTheDocument();
   });
 
   it('displays a PortalPage with TokenVerification at /portal/verification/', async () => {

--- a/spa/src/components/PortalRouter.tsx
+++ b/spa/src/components/PortalRouter.tsx
@@ -19,17 +19,9 @@ function PortalRouter() {
   return (
     <PortalAuthContextProvider>
       <RouterSetup>
-        {/* This doesn't get wrapped in <PortalPage> because the component styles it. */}
+        {/* These don't get wrapped in <PortalPage> because the component styles it. */}
         <ProtectedRoute path={ROUTES.PORTAL.CONTRIBUTIONS} render={() => <TransactionsList />} contributor exact />
-        <ProtectedRoute
-          path={ROUTES.PORTAL.CONTRIBUTION_DETAIL}
-          render={() => (
-            <PortalPage>
-              <TransactionsList />
-            </PortalPage>
-          )}
-          contributor
-        />
+        <ProtectedRoute path={ROUTES.PORTAL.CONTRIBUTION_DETAIL} render={() => <TransactionsList />} contributor />
         <SentryRoute
           exact
           path={ROUTES.PORTAL.ENTRY}

--- a/spa/src/components/PortalRouter.tsx
+++ b/spa/src/components/PortalRouter.tsx
@@ -19,16 +19,8 @@ function PortalRouter() {
   return (
     <PortalAuthContextProvider>
       <RouterSetup>
-        <ProtectedRoute
-          path={ROUTES.PORTAL.CONTRIBUTIONS}
-          render={() => (
-            <PortalPage>
-              <TransactionsList />
-            </PortalPage>
-          )}
-          contributor
-          exact
-        />
+        {/* This doesn't get wrapped in <PortalPage> because the component styles it. */}
+        <ProtectedRoute path={ROUTES.PORTAL.CONTRIBUTIONS} render={() => <TransactionsList />} contributor exact />
         <ProtectedRoute
           path={ROUTES.PORTAL.CONTRIBUTION_DETAIL}
           render={() => (

--- a/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import PortalPage from '../PortalPage';
 
 export const List = styled.div<{ $detailVisible: boolean }>`
   align-self: self-start;
@@ -8,6 +9,12 @@ export const List = styled.div<{ $detailVisible: boolean }>`
 
   @media (${(props) => props.theme.breakpoints.tabletLandscapeDown}) {
     ${(props) => props.$detailVisible && 'display: none;'}
+  }
+`;
+
+export const StyledPortalPage = styled(PortalPage)`
+  @media (${(props) => props.theme.breakpoints.tabletLandscapeDown}) {
+    background-color: ${({ theme }) => theme.basePalette.greyscale.white};
   }
 `;
 

--- a/spa/src/components/portal/ContributionsList/ContributionsList.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.test.tsx
@@ -13,6 +13,7 @@ jest.mock('hooks/usePortalContributionList');
 jest.mock('./ContributionDetail/ContributionDetail');
 jest.mock('./ContributionItem/ContributionItem');
 jest.mock('./ContributionFetchError');
+jest.mock('../PortalPage');
 
 function tree(context?: Partial<PortalAuthContextResult>) {
   return render(

--- a/spa/src/components/portal/ContributionsList/ContributionsList.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.tsx
@@ -7,7 +7,7 @@ import ContributionItem from './ContributionItem/ContributionItem';
 import NoContributions from './NoContributions';
 import ContributionFetchError from './ContributionFetchError';
 import ContributionDetail from './ContributionDetail/ContributionDetail';
-import { List, Root, Subhead, Columns, Loading, Legend, Detail } from './ContributionsList.styled';
+import { List, Root, Subhead, Columns, Loading, Legend, Detail, StyledPortalPage } from './ContributionsList.styled';
 
 export function ContributionsList() {
   const { contributionId } = useParams<{ contributionId?: string }>();
@@ -51,24 +51,26 @@ export function ContributionsList() {
   }
 
   return (
-    <Root>
-      <Columns>
-        <Legend $detailVisible={!!selectedContribution}>
-          <Subhead>Transactions</Subhead>
-          <p>View billing history, update payment details, and resend receipts.</p>
-        </Legend>
-        {content}
-        {contributor && selectedContribution && (
-          <Detail>
-            <ContributionDetail
-              domAnchor={selectedContributionEl}
-              contributionId={selectedContribution.payment_provider_id}
-              contributorId={contributor.id}
-            />
-          </Detail>
-        )}
-      </Columns>
-    </Root>
+    <StyledPortalPage>
+      <Root>
+        <Columns>
+          <Legend $detailVisible={!!selectedContribution}>
+            <Subhead>Transactions</Subhead>
+            <p>View billing history, update payment details, and resend receipts.</p>
+          </Legend>
+          {content}
+          {contributor && selectedContribution && (
+            <Detail>
+              <ContributionDetail
+                domAnchor={selectedContributionEl}
+                contributionId={selectedContribution.payment_provider_id}
+                contributorId={contributor.id}
+              />
+            </Detail>
+          )}
+        </Columns>
+      </Root>
+    </StyledPortalPage>
   );
 }
 

--- a/spa/src/components/portal/PortalPage.styled.ts
+++ b/spa/src/components/portal/PortalPage.styled.ts
@@ -10,7 +10,6 @@ export const PoweredBy = styled.div`
   font-weight: 400;
   font-size: ${(props) => props.theme.fontSizesUpdated.sm};
   color: ${(props) => props.theme.basePalette.greyscale.black};
-  background: ${(props) => props.theme.basePalette.greyscale.grey4};
   padding: 45px 0;
 
   & > span {
@@ -38,6 +37,7 @@ export const Logo = styled.img`
 `;
 
 export const Root = styled.div`
+  background: ${(props) => props.theme.basePalette.greyscale.grey4};
   display: grid;
   grid-template-rows: 60px 1fr 145px;
   min-height: 100vh;

--- a/spa/src/components/portal/PortalPage.test.tsx
+++ b/spa/src/components/portal/PortalPage.test.tsx
@@ -3,7 +3,7 @@ import { LIVE_PAGE_DETAIL } from 'ajax/endpoints';
 import MockAdapter from 'axios-mock-adapter';
 import useWebFonts from 'hooks/useWebFonts';
 import { render, screen, waitFor } from 'test-utils';
-import PortalPage from './PortalPage';
+import PortalPage, { PortalPageProps } from './PortalPage';
 
 jest.mock('components/analytics/TrackPageView', () => ({ children }: { children: React.ReactNode }) => (
   <div data-testid="mock-track-page-view">{children}</div>
@@ -44,13 +44,19 @@ describe('PortalPage', () => {
 
   afterAll(() => axiosMock.restore());
 
-  function tree() {
+  function tree(props?: PortalPageProps) {
     return render(
-      <PortalPage>
+      <PortalPage {...props}>
         <div data-testid="mock-content-component" />
       </PortalPage>
     );
   }
+
+  it('puts the className prop on its container', async () => {
+    tree({ className: 'test-class-name' });
+    await screen.findByTestId('mock-track-page-view');
+    expect(document.body.querySelector('.test-class-name')).toBeInTheDocument();
+  });
 
   const assertContentIsRendered = async () => {
     await screen.findByTestId('mock-track-page-view');

--- a/spa/src/components/portal/PortalPage.tsx
+++ b/spa/src/components/portal/PortalPage.tsx
@@ -1,16 +1,27 @@
+import PropTypes, { InferProps } from 'prop-types';
+import { ReactNode } from 'react';
+import NRELogo from 'assets/images/nre-logo-blue.svg';
 import PoweredByNRELogo from 'assets/images/nre-logo-yellow.svg?react';
 import TrackPageView from 'components/analytics/TrackPageView';
 import DonationPageHeader from 'components/donationPage/DonationPageHeader';
 import SegregatedStyles from 'components/donationPage/SegregatedStyles';
+import { HOME_PAGE_URL } from 'constants/helperUrls';
 import { PLAN_NAMES } from 'constants/orgPlanConstants';
 import usePortal from 'hooks/usePortal';
 import useWebFonts from 'hooks/useWebFonts';
-import React from 'react';
-import NRELogo from 'assets/images/nre-logo-blue.svg';
 import { PoweredBy, Header, Logo, Root } from './PortalPage.styled';
-import { HOME_PAGE_URL } from 'constants/helperUrls';
 
-function PortalPage({ children }: { children: React.ReactNode }) {
+const PortalPagePropTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string
+};
+
+export interface PortalPageProps extends InferProps<typeof PortalPagePropTypes> {
+  children?: ReactNode;
+  className?: string;
+}
+
+function PortalPage({ children, className }: PortalPageProps) {
   const { page, pageIsFetched, enablePageFetch } = usePortal();
 
   const isFreeOrg = page?.revenue_program?.organization?.plan?.name === PLAN_NAMES.FREE;
@@ -26,7 +37,7 @@ function PortalPage({ children }: { children: React.ReactNode }) {
   return (
     <TrackPageView>
       <SegregatedStyles page={renderCustomStyles && page}>
-        <Root>
+        <Root className={className}>
           {renderCustomStyles ? (
             <DonationPageHeader page={page} />
           ) : (
@@ -46,5 +57,7 @@ function PortalPage({ children }: { children: React.ReactNode }) {
     </TrackPageView>
   );
 }
+
+PortalPage.propTypes = PortalPagePropTypes;
 
 export default PortalPage;

--- a/spa/src/components/portal/__mocks__/PortalPage.tsx
+++ b/spa/src/components/portal/__mocks__/PortalPage.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+
+export const PortalPage = ({ children }: { children: ReactNode }) => (
+  <div data-testid="mock-portal-page">{children}</div>
+);
+
+export default PortalPage;

--- a/spa/src/utilities/isPortalAppPath.test.ts
+++ b/spa/src/utilities/isPortalAppPath.test.ts
@@ -15,7 +15,7 @@ describe('isPortalAppPath', () => {
     window.location = realLocation;
   });
 
-  it.each(['/portal/', '/portal/verification/', '/portal/my-contributions'])(
+  it.each(['/portal/', '/portal/verification/', '/portal/my-contributions/', '/portal/my-contributions/abcd/'])(
     'should return true if path is: %s',
     (route) => {
       delete (window as any).location;

--- a/spa/src/utilities/isPortalAppPath.ts
+++ b/spa/src/utilities/isPortalAppPath.ts
@@ -1,11 +1,7 @@
-import * as ROUTES from 'routes';
+import { PORTAL } from 'routes';
 
 function isPortalAppPath() {
-  const pathname = window.location.pathname;
-  const routes = Object.values(ROUTES.PORTAL);
-
-  // Be lenient about trailing slashes in the actual pathname.
-  return routes.includes(pathname) || routes.includes(pathname + '/');
+  return window.location.pathname.indexOf(PORTAL.ENTRY) === 0;
 }
 
 export default isPortalAppPath;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Makes `<PortalPage>` stylable by adding a `className` prop.
- Styles `<ContributionList>` so that the background is white on mobile viewports.

#### Why are we doing this? How does it help us?

Improves visual appearance.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4355

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.