### PR TITLE
DEV-4436: Make Stripe client secret optional

### DIFF
--- a/spa/src/components/paymentProviders/stripe/StripePaymentWrapper.test.tsx
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentWrapper.test.tsx
@@ -57,7 +57,7 @@ describe('StripePaymentWrapper', () => {
       expect(screen.queryByTestId('mock-global-loading')).not.toBeInTheDocument();
     });
 
-    it('shows a configured Stripe <Elements> component', async () => {
+    it('shows a configured Stripe <Elements> component with client secret if set', async () => {
       tree();
       await waitFor(() => expect(loadStripeMock).toBeCalled());
 
@@ -66,6 +66,21 @@ describe('StripePaymentWrapper', () => {
       expect(elements).toBeInTheDocument();
       expect(JSON.parse(elements.dataset.options!)).toEqual({
         clientSecret: 'mock-stripe-client-secret',
+        locale: 'mock-stripe-locale'
+      });
+      await waitFor(() => expect(elements.dataset.stripe).not.toEqual('undefined'));
+      expect(elements.dataset.stripe).toEqual('"mock-stripe-loaded"');
+    });
+
+    it('shows a configured Stripe <Elements> component without client secret if not set', async () => {
+      tree({ stripeClientSecret: undefined });
+      await waitFor(() => expect(loadStripeMock).toBeCalled());
+
+      const elements = screen.getByTestId('mock-stripe-elements');
+
+      expect(elements).toBeInTheDocument();
+      expect(JSON.parse(elements.dataset.options!)).toEqual({
+        clientSecret: undefined,
         locale: 'mock-stripe-locale'
       });
       await waitFor(() => expect(elements.dataset.stripe).not.toEqual('undefined'));

--- a/spa/src/components/paymentProviders/stripe/StripePaymentWrapper.tsx
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentWrapper.tsx
@@ -9,7 +9,11 @@ const StripePaymentWrapperPropTypes = {
   children: PropTypes.node,
   onError: PropTypes.func,
   stripeAccountId: PropTypes.string.isRequired,
-  stripeClientSecret: PropTypes.string.isRequired,
+  /**
+   * The client secret used when completing a Stripe payment intent or setup
+   * intent. This can be omitted if Stripe is being used for other purposes.
+   */
+  stripeClientSecret: PropTypes.string,
   stripeLocale: PropTypes.string.isRequired
 };
 
@@ -65,7 +69,7 @@ export function StripePaymentWrapper({
   }, [inited, onError, stripeAccountId]);
 
   return stripe ? (
-    <Elements stripe={stripe} options={{ clientSecret: stripeClientSecret, locale: stripeLocale }}>
+    <Elements stripe={stripe} options={{ clientSecret: stripeClientSecret ?? undefined, locale: stripeLocale }}>
       {children}
     </Elements>
   ) : (


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Makes the client secret optional in `StripePaymentWrapper`.

#### Why are we doing this? How does it help us?

For payment method updates, we are going to use Stripe's Card element which doesn't require a payment or setup intent. The client secret is only used with intents. I've POC'd the approach and want to split this change out because 4408 is going to be a large PR.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4436

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

https://news-revenue-hub.atlassian.net/browse/DEV-4408