### PR TITLE
DEV-4443: Create sentry alert for manage my plan

### DIFF
--- a/spa/src/components/settings/Subscription/ManageSubscription.test.tsx
+++ b/spa/src/components/settings/Subscription/ManageSubscription.test.tsx
@@ -61,20 +61,18 @@ describe('ManageSubscription', () => {
     });
   });
 
-  it('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is non-empty string', () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  it('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is non-empty string, no errors are triggered', () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     tree();
 
     expect(addBreadcrumbMock).not.toHaveBeenCalled();
-    expect(consoleWarnSpy).not.toHaveBeenCalled();
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   describe('Error handling', () => {
-    describe('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not a string', () => {
-      describe.each([null, undefined, 123, true, false, {}])('url is: %p', (url) => {
+    describe('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not valid', () => {
+      describe.each([null, undefined, 123, true, false, {}, ''])('url is: %p', (url) => {
         let consoleErrorSpy: jest.SpyInstance;
         beforeEach(() => {
           mockURL.mockReturnValue(url);
@@ -100,24 +98,8 @@ describe('ManageSubscription', () => {
           const error = jest.fn();
           consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(error);
           tree();
-          expect(error).toHaveBeenCalledWith('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not a string');
+          expect(error).toHaveBeenCalledWith('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not valid.');
         });
-      });
-    });
-    describe('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is an empty string', () => {
-      let consoleWarnSpy: jest.SpyInstance;
-      beforeEach(() => {
-        mockURL.mockReturnValue('');
-        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      });
-
-      afterEach(() => {
-        consoleWarnSpy.mockRestore();
-      });
-
-      it('logs a console warning', () => {
-        tree();
-        expect(consoleWarnSpy).toHaveBeenCalledWith('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is an empty string');
       });
     });
   });

--- a/spa/src/components/settings/Subscription/ManageSubscription.test.tsx
+++ b/spa/src/components/settings/Subscription/ManageSubscription.test.tsx
@@ -1,11 +1,17 @@
+import { addBreadcrumb } from '@sentry/react';
+import { SELF_UPGRADE_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
+import { Organization, User } from 'hooks/useUser.types';
 import { axe } from 'jest-axe';
 import { render, screen } from 'test-utils';
 import ManageSubscription, { ManageSubscriptionProps } from './ManageSubscription';
-import { Organization, User } from 'hooks/useUser.types';
-import { SELF_UPGRADE_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
 
+const mockURL = jest.fn();
+
+jest.mock('@sentry/react');
 jest.mock('appSettings', () => ({
-  STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL: 'mock-customer-portal-url'
+  get STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL() {
+    return mockURL();
+  }
 }));
 
 const mockOrg = { plan: { name: 'CORE' } } as Organization;
@@ -16,6 +22,12 @@ function tree(props?: Partial<ManageSubscriptionProps>) {
 }
 
 describe('ManageSubscription', () => {
+  const addBreadcrumbMock = addBreadcrumb as jest.Mock;
+
+  beforeEach(() => {
+    mockURL.mockReturnValue('mock-customer-portal-url');
+  });
+
   it('shows nothing if the user is on the Free plan, even if they have the self-upgrade feature flag', () => {
     tree({ organization: { plan: { name: 'FREE' } } as Organization });
     expect(document.body).toHaveTextContent('');
@@ -46,6 +58,67 @@ describe('ManageSubscription', () => {
       const { container } = tree();
 
       expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  it('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is non-empty string', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    tree();
+
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  describe('Error handling', () => {
+    describe('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not a string', () => {
+      describe.each([null, undefined, 123, true, false, {}])('url is: %p', (url) => {
+        let consoleErrorSpy: jest.SpyInstance;
+        beforeEach(() => {
+          mockURL.mockReturnValue(url);
+          consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+          consoleErrorSpy.mockRestore();
+        });
+
+        it('logs a breadcrumb', () => {
+          expect(addBreadcrumbMock).not.toHaveBeenCalled();
+          tree();
+
+          expect(addBreadcrumbMock).toHaveBeenCalledWith({
+            category: 'rev-engine',
+            level: 'debug',
+            message: `Manage my plan URL: "${url}"`
+          });
+        });
+
+        it('logs a console error', () => {
+          const error = jest.fn();
+          consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(error);
+          tree();
+          expect(error).toHaveBeenCalledWith('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not a string');
+        });
+      });
+    });
+    describe('when STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is an empty string', () => {
+      let consoleWarnSpy: jest.SpyInstance;
+      beforeEach(() => {
+        mockURL.mockReturnValue('');
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        consoleWarnSpy.mockRestore();
+      });
+
+      it('logs a console warning', () => {
+        tree();
+        expect(consoleWarnSpy).toHaveBeenCalledWith('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is an empty string');
+      });
     });
   });
 });

--- a/spa/src/components/settings/Subscription/ManageSubscription.tsx
+++ b/spa/src/components/settings/Subscription/ManageSubscription.tsx
@@ -24,19 +24,20 @@ export function ManageSubscription({ organization, user }: ManageSubscriptionPro
     organization.plan.name === PLAN_NAMES.FREE || !flagIsActiveForUser(SELF_UPGRADE_ACCESS_FLAG_NAME, user);
 
   useEffect(() => {
-    if (!hideManageSubscription) {
-      if (typeof STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL !== 'string') {
-        Sentry.addBreadcrumb({
-          category: 'rev-engine',
-          level: 'debug',
-          message: `Manage my plan URL: "${STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL}"`
-        });
-        console.error('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not a string');
-      } else {
-        if (STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL === '') {
-          console.warn('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is an empty string');
-        }
-      }
+    if (hideManageSubscription) {
+      return;
+    }
+
+    if (
+      typeof STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL !== 'string' ||
+      STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL?.length === 0
+    ) {
+      Sentry.addBreadcrumb({
+        category: 'rev-engine',
+        level: 'debug',
+        message: `Manage my plan URL: "${STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL}"`
+      });
+      console.error('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not valid.');
     }
   }, [hideManageSubscription]);
 

--- a/spa/src/components/settings/Subscription/ManageSubscription.tsx
+++ b/spa/src/components/settings/Subscription/ManageSubscription.tsx
@@ -1,10 +1,12 @@
-import PropTypes, { InferProps } from 'prop-types';
+import * as Sentry from '@sentry/react';
 import { STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL } from 'appSettings';
 import { Link } from 'components/base';
 import SettingsSection from 'components/common/SettingsSection';
 import { SELF_UPGRADE_ACCESS_FLAG_NAME } from 'constants/featureFlagConstants';
 import { PLAN_NAMES } from 'constants/orgPlanConstants';
 import { Organization, User } from 'hooks/useUser.types';
+import PropTypes, { InferProps } from 'prop-types';
+import { useEffect } from 'react';
 import flagIsActiveForUser from 'utilities/flagIsActiveForUser';
 
 const ManageSubscriptionPropTypes = {
@@ -18,7 +20,27 @@ export interface ManageSubscriptionProps extends InferProps<typeof ManageSubscri
 }
 
 export function ManageSubscription({ organization, user }: ManageSubscriptionProps) {
-  if (organization.plan.name === PLAN_NAMES.FREE || !flagIsActiveForUser(SELF_UPGRADE_ACCESS_FLAG_NAME, user)) {
+  const hideManageSubscription =
+    organization.plan.name === PLAN_NAMES.FREE || !flagIsActiveForUser(SELF_UPGRADE_ACCESS_FLAG_NAME, user);
+
+  useEffect(() => {
+    if (!hideManageSubscription) {
+      if (typeof STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL !== 'string') {
+        Sentry.addBreadcrumb({
+          category: 'rev-engine',
+          level: 'debug',
+          message: `Manage my plan URL: "${STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL}"`
+        });
+        console.error('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is not a string');
+      } else {
+        if (STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL === '') {
+          console.warn('STRIPE_SELF_UPGRADE_CUSTOMER_PORTAL_URL is an empty string');
+        }
+      }
+    }
+  }, [hideManageSubscription]);
+
+  if (hideManageSubscription) {
     return null;
   }
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a

#### What's this PR do?
- Add sentry breadcrumbs with the "self upgrade stripe url"
- Consoles an error or warning depending on the url

#### Why are we doing this? How does it help us?
- Helps understand issues that come from "manage my plan" feature

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
- yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no
#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
n/a
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
no
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-4443
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no