### PR TITLE
DEV-4467: Portal pre-release refinements

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -1090,11 +1090,14 @@ class Contribution(IndexedTimeStampedModel):
             stripe.Subscription.modify(
                 sub_id, default_payment_method=provider_payment_method_id, stripe_account=self.stripe_account_id
             )
-        except StripeError:
-            logger.exception(
-                "Encountered a Stripe error while trying to update payment method for subscription on contribution %s",
-                self.id,
-            )
+        except StripeError as stripe_error:
+            # Don't log/send Sentry alert if stripe error is "declined card"
+            if stripe_error.code != "card_declined":
+                logger.exception(
+                    "Encountered a Stripe error while trying to update payment method for subscription on contribution %s",
+                    self.id,
+                )
+
             raise
 
 

--- a/spa/src/ajax/portal-axios.test.ts
+++ b/spa/src/ajax/portal-axios.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react-hooks';
+import Axios from 'ajax/portal-axios';
+import MockAdapter from 'axios-mock-adapter';
+import { TestQueryClientProvider } from 'test-utils';
+
+const mockPortalAxios = () => {
+  const get = async () => {
+    return await Axios.get('/mock');
+  };
+
+  return { get };
+};
+
+function hook() {
+  return renderHook(() => mockPortalAxios(), {
+    wrapper: TestQueryClientProvider
+  });
+}
+
+describe('portal-axios', () => {
+  const axiosMock = new MockAdapter(Axios);
+
+  beforeEach(() => {
+    axiosMock.onGet('/mock').reply(200);
+  });
+
+  afterEach(() => axiosMock.reset());
+  afterAll(() => axiosMock.restore());
+
+  it('does not redirect if axios succeeds', async () => {
+    const assign = jest.fn();
+    jest.spyOn(window.location, 'assign').mockImplementation(assign);
+
+    const { waitFor, result } = hook();
+
+    result.current.get();
+
+    await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect if axios error is not Authentication Error (not 401)', async () => {
+    const assign = jest.fn();
+    jest.spyOn(window.location, 'assign').mockImplementation(assign);
+
+    axiosMock.onGet('/mock').networkError();
+
+    const { waitFor, result } = hook();
+
+    try {
+      await result.current.get();
+    } catch {}
+
+    await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('redirects user to magic link (login) page if axios error is Authentication Error (401)', async () => {
+    const assign = jest.fn();
+    jest.spyOn(window.location, 'assign').mockImplementation(assign);
+
+    axiosMock.onGet('/mock').reply(401);
+
+    expect(assign).not.toHaveBeenCalled();
+
+    const { waitFor, result } = hook();
+
+    try {
+      await result.current.get();
+    } catch {}
+
+    await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
+    expect(assign).toHaveBeenCalledWith('/portal/');
+  });
+});

--- a/spa/src/ajax/portal-axios.ts
+++ b/spa/src/ajax/portal-axios.ts
@@ -1,0 +1,15 @@
+import { PORTAL } from 'routes';
+import Axios from './axios';
+import { AxiosError } from 'axios';
+
+export default Axios;
+
+/**
+ * Overrides response interceptor from base Axios instance
+ */
+Axios.interceptors.response.use((success) => success, handleResponseError);
+
+function handleResponseError(error: AxiosError) {
+  if (error?.name === 'AuthenticationError') return window.location.assign(PORTAL.ENTRY);
+  return Promise.reject(error);
+}

--- a/spa/src/ajax/portal-axios.ts
+++ b/spa/src/ajax/portal-axios.ts
@@ -1,15 +1,47 @@
+import { CSRF_HEADER, LS_CSRF_TOKEN, REVENGINE_API_VERSION } from 'appSettings';
+import axios, { AxiosError } from 'axios';
 import { PORTAL } from 'routes';
-import Axios from './axios';
-import { AxiosError } from 'axios';
+
+export const apiBaseUrl = `/api/${REVENGINE_API_VERSION}/`;
+
+const Axios = axios.create({
+  baseURL: apiBaseUrl,
+  timeout: 15000,
+  withCredentials: true // allow setting/passing cookies
+});
 
 export default Axios;
+
+/**
+ * A Request interceptor.
+ * first callback intercepts successfully formed requests
+ * second callback handles errors, so pass through
+ */
+Axios.interceptors.request.use(
+  (request) => {
+    const csrfToken = localStorage.getItem(LS_CSRF_TOKEN);
+    if (csrfToken) request.headers[CSRF_HEADER] = csrfToken;
+    return request;
+  },
+  (error) => Promise.reject(error)
+);
+
+/**
+ * A Response interceptor.
+ * first callback handles success, so pass through
+ * second callback handles errors
+ */
+Axios.interceptors.response.use((success) => success, handleResponseError);
+
+function handleResponseError(error: AxiosError) {
+  if (error?.response?.status === 401) {
+    window.location.assign(PORTAL.ENTRY);
+  }
+
+  return Promise.reject(error);
+}
 
 /**
  * Overrides response interceptor from base Axios instance
  */
 Axios.interceptors.response.use((success) => success, handleResponseError);
-
-function handleResponseError(error: AxiosError) {
-  if (error?.name === 'AuthenticationError') return window.location.assign(PORTAL.ENTRY);
-  return Promise.reject(error);
-}

--- a/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.styled.ts
@@ -12,6 +12,10 @@ export const List = styled.div<{ $detailVisible: boolean }>`
   }
 `;
 
+export const AlignPositionWrapper = styled.div`
+  grid-area: list;
+`;
+
 export const StyledPortalPage = styled(PortalPage)`
   @media (${(props) => props.theme.breakpoints.tabletLandscapeDown}) {
     background-color: ${({ theme }) => theme.basePalette.greyscale.white};
@@ -61,6 +65,7 @@ export const Loading = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
+  grid-area: list;
 `;
 
 export const Subhead = styled.h2`

--- a/spa/src/components/portal/ContributionsList/ContributionsList.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.tsx
@@ -7,7 +7,17 @@ import ContributionItem from './ContributionItem/ContributionItem';
 import NoContributions from './NoContributions';
 import ContributionFetchError from './ContributionFetchError';
 import ContributionDetail from './ContributionDetail/ContributionDetail';
-import { List, Root, Subhead, Columns, Loading, Legend, Detail, StyledPortalPage } from './ContributionsList.styled';
+import {
+  List,
+  Root,
+  Subhead,
+  Columns,
+  Loading,
+  Legend,
+  Detail,
+  StyledPortalPage,
+  AlignPositionWrapper
+} from './ContributionsList.styled';
 import Sort from 'components/common/Sort';
 
 const CONTRIBUTION_SORT_OPTIONS = [
@@ -53,7 +63,11 @@ export function ContributionsList() {
       </Loading>
     );
   } else if (isError) {
-    content = <ContributionFetchError message="Error loading contributions." onRetry={() => refetch()} />;
+    content = (
+      <AlignPositionWrapper>
+        <ContributionFetchError message="Error loading contributions." onRetry={refetch} />
+      </AlignPositionWrapper>
+    );
   } else if (contributor && contributions?.length > 0) {
     content = (
       <List $detailVisible={!!selectedContribution}>
@@ -72,7 +86,11 @@ export function ContributionsList() {
       </List>
     );
   } else {
-    content = <NoContributions />;
+    content = (
+      <AlignPositionWrapper>
+        <NoContributions />
+      </AlignPositionWrapper>
+    );
   }
 
   return (

--- a/spa/src/hooks/usePortalContribution.test.tsx
+++ b/spa/src/hooks/usePortalContribution.test.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react-hooks';
-import Axios from 'ajax/axios';
+import Axios from 'ajax/portal-axios';
 import MockAdapter from 'axios-mock-adapter';
 import { useSnackbar } from 'notistack';
 import { TestQueryClientProvider } from 'test-utils';
@@ -115,20 +115,6 @@ describe('usePortalContribution', () => {
       await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
       expect(result.current.contribution).toBeUndefined();
     });
-
-    it('redirects user to magic link (login) page if GET error = Authentication Error', async () => {
-      const assign = jest.fn();
-      jest.spyOn(window.location, 'assign').mockImplementation(assign);
-
-      axiosMock.onGet('contributors/123/contributions/1/').reply(401);
-
-      expect(assign).not.toHaveBeenCalled();
-
-      const { waitFor } = hook(123, 1);
-
-      await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-      expect(assign).toHaveBeenCalledWith('/portal/');
-    });
   });
 
   describe('The cancelContribution function', () => {
@@ -212,27 +198,6 @@ describe('usePortalContribution', () => {
       await waitFor(() =>
         expect(enqueueSnackbar).toHaveBeenCalledWith('custom error message', expect.objectContaining({ persist: true }))
       );
-    });
-
-    it('redirects user to magic link (login) page if DELETE error = Authentication Error', async () => {
-      const assign = jest.fn();
-      jest.spyOn(window.location, 'assign').mockImplementation(assign);
-
-      axiosMock.onDelete('contributors/123/contributions/1/').reply(401);
-
-      expect(assign).not.toHaveBeenCalled();
-
-      const { result, waitFor } = hook(123, 1);
-
-      await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-
-      try {
-        await result.current.cancelContribution();
-      } catch {}
-
-      await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
-
-      expect(assign).toHaveBeenCalledWith('/portal/');
     });
 
     it('invalidates the contribution list and detail query', async () => {
@@ -332,27 +297,6 @@ describe('usePortalContribution', () => {
         ]
       ]);
       errorSpy.mockRestore();
-    });
-
-    it('redirects user to magic link (login) page if PATCH error = Authentication Error', async () => {
-      const assign = jest.fn();
-      jest.spyOn(window.location, 'assign').mockImplementation(assign);
-
-      axiosMock.onPatch('contributors/123/contributions/1/').reply(401);
-
-      expect(assign).not.toHaveBeenCalled();
-
-      const { result, waitFor } = hook(123, 1);
-
-      await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-
-      try {
-        await result.current.updateContribution({ provider_payment_method_id: 'new-id' }, 'paymentMethod');
-      } catch {}
-
-      await waitFor(() => expect(axiosMock.history.patch.length).toBe(1));
-
-      expect(assign).toHaveBeenCalledWith('/portal/');
     });
   });
 });

--- a/spa/src/hooks/usePortalContribution.test.tsx
+++ b/spa/src/hooks/usePortalContribution.test.tsx
@@ -117,14 +117,17 @@ describe('usePortalContribution', () => {
     });
 
     it('redirects user to magic link (login) page if GET error = Authentication Error', async () => {
+      const assign = jest.fn();
+      jest.spyOn(window.location, 'assign').mockImplementation(assign);
+
       axiosMock.onGet('contributors/123/contributions/1/').reply(401);
 
-      expect(push).not.toHaveBeenCalled();
+      expect(assign).not.toHaveBeenCalled();
 
       const { waitFor } = hook(123, 1);
 
       await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-      expect(push).toHaveBeenCalledWith('/portal/');
+      expect(assign).toHaveBeenCalledWith('/portal/');
     });
   });
 
@@ -212,9 +215,12 @@ describe('usePortalContribution', () => {
     });
 
     it('redirects user to magic link (login) page if DELETE error = Authentication Error', async () => {
+      const assign = jest.fn();
+      jest.spyOn(window.location, 'assign').mockImplementation(assign);
+
       axiosMock.onDelete('contributors/123/contributions/1/').reply(401);
 
-      expect(push).not.toHaveBeenCalled();
+      expect(assign).not.toHaveBeenCalled();
 
       const { result, waitFor } = hook(123, 1);
 
@@ -226,7 +232,7 @@ describe('usePortalContribution', () => {
 
       await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
 
-      expect(push).toHaveBeenCalledWith('/portal/');
+      expect(assign).toHaveBeenCalledWith('/portal/');
     });
 
     it('invalidates the contribution list and detail query', async () => {
@@ -329,9 +335,12 @@ describe('usePortalContribution', () => {
     });
 
     it('redirects user to magic link (login) page if PATCH error = Authentication Error', async () => {
+      const assign = jest.fn();
+      jest.spyOn(window.location, 'assign').mockImplementation(assign);
+
       axiosMock.onPatch('contributors/123/contributions/1/').reply(401);
 
-      expect(push).not.toHaveBeenCalled();
+      expect(assign).not.toHaveBeenCalled();
 
       const { result, waitFor } = hook(123, 1);
 
@@ -343,7 +352,7 @@ describe('usePortalContribution', () => {
 
       await waitFor(() => expect(axiosMock.history.patch.length).toBe(1));
 
-      expect(push).toHaveBeenCalledWith('/portal/');
+      expect(assign).toHaveBeenCalledWith('/portal/');
     });
   });
 });

--- a/spa/src/hooks/usePortalContribution.tsx
+++ b/spa/src/hooks/usePortalContribution.tsx
@@ -114,6 +114,7 @@ export function usePortalContribution(contributorId: number, contributionId: num
         });
       },
       onError: (error: AxiosError) => {
+        console.error('[usePortalContribution:cancelContribution] ', error);
         enqueueSnackbar(error?.response?.data?.detail ?? 'Something went wrong. Please, try again later.', {
           persist: true,
           content: (key: string, message: string) => (

--- a/spa/src/hooks/usePortalContributionList.test.ts
+++ b/spa/src/hooks/usePortalContributionList.test.ts
@@ -143,6 +143,9 @@ describe('usePortalContributionList', () => {
       });
 
       it('redirects user to magic link (login) page if error = Authentication Error', async () => {
+        const assign = jest.fn();
+        jest.spyOn(window.location, 'assign').mockImplementation(assign);
+
         axiosMock.onGet('contributors/123/contributions/').reply(401);
 
         expect(push).not.toHaveBeenCalled();
@@ -150,7 +153,7 @@ describe('usePortalContributionList', () => {
         const { result, waitFor } = hook(123);
 
         await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-        expect(push).toHaveBeenCalledWith('/portal/');
+        expect(assign).toHaveBeenCalledWith('/portal/');
         expect(result.current.isError).toBe(true);
         expect(result.current.contributions).toEqual([]);
       });

--- a/spa/src/hooks/usePortalContributionList.test.ts
+++ b/spa/src/hooks/usePortalContributionList.test.ts
@@ -1,5 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
-import Axios from 'ajax/axios';
+import Axios from 'ajax/portal-axios';
 import { TestQueryClientProvider } from 'test-utils';
 import { ContributionListResponse, usePortalContributionList } from './usePortalContributionList';
 import { renderHook } from '@testing-library/react-hooks';
@@ -132,29 +132,6 @@ describe('usePortalContributionList', () => {
         const { result, waitFor } = hook(123);
 
         await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-        expect(result.current.contributions).toEqual([]);
-      });
-
-      it('does not redirect if error is not an Authentication Error', async () => {
-        const { waitFor } = hook(123);
-
-        await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-        expect(push).not.toHaveBeenCalled();
-      });
-
-      it('redirects user to magic link (login) page if error = Authentication Error', async () => {
-        const assign = jest.fn();
-        jest.spyOn(window.location, 'assign').mockImplementation(assign);
-
-        axiosMock.onGet('contributors/123/contributions/').reply(401);
-
-        expect(push).not.toHaveBeenCalled();
-
-        const { result, waitFor } = hook(123);
-
-        await waitFor(() => expect(axiosMock.history.get.length).toBe(1));
-        expect(assign).toHaveBeenCalledWith('/portal/');
-        expect(result.current.isError).toBe(true);
         expect(result.current.contributions).toEqual([]);
       });
     });

--- a/spa/src/hooks/usePortalContributionList.ts
+++ b/spa/src/hooks/usePortalContributionList.ts
@@ -1,13 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { useHistory } from 'react-router-dom';
-import queryString from 'query-string';
-import axios from 'ajax/axios';
 import { getContributionsEndpoint } from 'ajax/endpoints';
+import axios from 'ajax/portal-axios';
 import { ContributionInterval } from 'constants/contributionIntervals';
 import { PaymentStatus } from 'constants/paymentStatus';
-import { PORTAL } from 'routes';
-import { AxiosError } from 'axios';
-import { useEffect } from 'react';
+import queryString from 'query-string';
 
 export type CardBrand = 'amex' | 'diners' | 'discover' | 'jcb' | 'mastercard' | 'unionpay' | 'visa' | 'unknown';
 
@@ -94,28 +90,11 @@ async function fetchContributions(contributorId: number, queryParams?: string) {
  * into the portal.
  */
 export function usePortalContributionList(contributorId?: number, queryParams?: { ordering: string }) {
-  const history = useHistory();
-
-  const { data, isError, isFetching, isLoading, refetch, error } = useQuery(
+  const { data, isError, isFetching, isLoading, refetch } = useQuery(
     ['portalContributionList', queryParams?.ordering],
     () => fetchContributions(contributorId!, queryString.stringify(queryParams || {})),
     { enabled: !!contributorId, keepPreviousData: true }
   );
-
-  useEffect(() => {
-    if ((error as AxiosError)?.name === 'AuthenticationError') {
-      // Redirect to portal login page
-      history.push(PORTAL.ENTRY);
-
-      // TODO: waiting on Rachel's approval
-      // enqueueSnackbar('Please request another magic link to see your contributions.', {
-      //   persist: true,
-      //   content: (key: string, message: string) => (
-      //     <SystemNotification id={key} message={message} header="Authentication failed" type="error" />
-      //   )
-      // });
-    }
-  }, [error, history]);
 
   return { contributions: data?.results ?? [], isError, isFetching, isLoading, refetch };
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
- Align the loading, error, empty contribution components in the correct place on screen
- Refetches data 15 seconds after update or cancel contribution
- Redirects to magic link page if not logged in
- Remove sentry alert from being triggered if stripe returns "card declined" error
#### Why are we doing this? How does it help us?
- Refining new portal for launch
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
- yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
- no
#### Have automated unit tests been added? If not, why?
- yes
#### How should this change be communicated to end users?
- n/a
#### Are there any smells or added technical debt to note?
- no
#### Has this been documented? If so, where?
- no
#### What are the relevant tickets? Add a link to any relevant ones.
- https://news-revenue-hub.atlassian.net/browse/DEV-4467
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
- no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
- New Portal UI Updates Epic: https://news-revenue-hub.atlassian.net/browse/DEV-3780