### PR TITLE
DEV-4007: Improve Stripe handling in modal

### DIFF
--- a/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.test.tsx
+++ b/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.test.tsx
@@ -35,7 +35,7 @@ function tree(props?: Partial<FinishPaymentModalProps>) {
 describe('FinishPaymentModal', () => {
   it('shows nothing if not open', () => {
     tree({ open: false });
-    expect(document.body).toHaveTextContent('');
+    expect(screen.getByTestId('mock-stripe-payment-wrapper-children')).toBeEmptyDOMElement();
   });
 
   describe('When open', () => {
@@ -60,7 +60,11 @@ describe('FinishPaymentModal', () => {
       expect(wrapper.dataset.stripeClientSecret).toBe(mockPayment.stripe.clientSecret);
       expect(wrapper.dataset.stripeLocale).toBe('mock-locale');
       expect(onError).not.toBeCalled();
-      fireEvent.click(screen.getByRole('button', { name: 'onError' }));
+
+      // This is hidden by the open modal, but shouldn't matter in practice
+      // since it's a mocked button.
+
+      fireEvent.click(screen.getByRole('button', { name: 'onError', hidden: true }));
       expect(onError).toBeCalledTimes(1);
     });
 

--- a/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.tsx
+++ b/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.tsx
@@ -35,14 +35,14 @@ export function FinishPaymentModal({ onCancel, onError, open, payment, locale }:
   const { t } = useTranslation();
 
   return (
-    <Modal open={open}>
-      <AlertProvider template={Alert} {...alertOptions}>
-        <StripePaymentWrapper
-          onError={onError}
-          stripeClientSecret={payment.stripe.clientSecret}
-          stripeAccountId={payment.stripe.accountId}
-          stripeLocale={locale}
-        >
+    <StripePaymentWrapper
+      onError={onError}
+      stripeClientSecret={payment.stripe.clientSecret}
+      stripeAccountId={payment.stripe.accountId}
+      stripeLocale={locale}
+    >
+      <Modal open={open}>
+        <AlertProvider template={Alert} {...alertOptions}>
           <Root>
             <BackButton onClick={onCancel}>
               <ChevronLeft />
@@ -55,9 +55,9 @@ export function FinishPaymentModal({ onCancel, onError, open, payment, locale }:
               processingDate={new Date()}
             />
           </Root>
-        </StripePaymentWrapper>
-      </AlertProvider>
-    </Modal>
+        </AlertProvider>
+      </Modal>
+    </StripePaymentWrapper>
   );
 }
 

--- a/spa/src/components/paymentProviders/stripe/StripePaymentWrapper.tsx
+++ b/spa/src/components/paymentProviders/stripe/StripePaymentWrapper.tsx
@@ -1,7 +1,7 @@
 import { loadStripe, Stripe, StripeElementLocale } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 import PropTypes, { InferProps } from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { HUB_STRIPE_API_PUB_KEY } from 'appSettings';
 import GlobalLoading from 'elements/GlobalLoading';
 
@@ -68,8 +68,13 @@ export function StripePaymentWrapper({
     }
   }, [inited, onError, stripeAccountId]);
 
+  const options = useMemo(
+    () => ({ clientSecret: stripeClientSecret ?? undefined, locale: stripeLocale }),
+    [stripeClientSecret, stripeLocale]
+  );
+
   return stripe ? (
-    <Elements stripe={stripe} options={{ clientSecret: stripeClientSecret ?? undefined, locale: stripeLocale }}>
+    <Elements stripe={stripe} options={options}>
       {children}
     </Elements>
   ) : (

--- a/spa/src/components/paymentProviders/stripe/__mocks__/StripePaymentWrapper.tsx
+++ b/spa/src/components/paymentProviders/stripe/__mocks__/StripePaymentWrapper.tsx
@@ -15,7 +15,7 @@ export function StripePaymentWrapper({
       data-stripe-locale={stripeLocale}
     >
       {onError && <button onClick={() => onError(new Error())}>onError</button>}
-      {children}
+      <div data-testid="mock-stripe-payment-wrapper-children">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Tries to fix possible issues with Stripe elements in the contribution page payment modal. I wasn't able to repro the bug exactly, but I applied the best practices we used in https://news-revenue-hub.atlassian.net/browse/DEV-2945:

- Move `StripePaymentWrapper` higher in the component hierarchy in `CompletePaymentModal` to avoid it being potentially conditionally rendered
- Memoize the `options` object passed to Stripe's Elements component to avoid re-renders

#### Why are we doing this? How does it help us?

Addresses bug with contribution pages.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4007

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.