### PR TITLE
DEV-4347: Show placeholders for contribution detail instead of spinner in new portal

### DIFF
--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.styled.ts
@@ -30,9 +30,10 @@ export const Root = styled.div`
   }
 `;
 
-export const Loading = styled.div`
-  align-items: center;
-  display: grid;
-  height: 500px; /* Roughly match height once loaded */
-  justify-content: center;
+export const Desktop = styled.div`
+  display: block;
+
+  @media (${(props) => props.theme.breakpoints.tabletLandscapeDown}) {
+    display: none;
+  }
 `;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.styled.ts
@@ -29,11 +29,3 @@ export const Root = styled.div`
     transform: none;
   }
 `;
-
-export const Desktop = styled.div`
-  display: block;
-
-  @media (${(props) => props.theme.breakpoints.tabletLandscapeDown}) {
-    display: none;
-  }
-`;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
@@ -58,9 +58,14 @@ describe('ContributionDetail', () => {
       });
     });
 
-    it('shows a spinner', () => {
+    it('shows the loading skeleton', () => {
       tree();
-      expect(screen.getByTestId('loading')).toBeInTheDocument();
+      expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument();
+    });
+
+    it('shows a mobile back button', () => {
+      tree();
+      expect(screen.getByTestId('mock-mobile-back-button')).toBeInTheDocument();
     });
 
     it('is accessible', async () => {

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
@@ -1,7 +1,6 @@
 import { PaymentMethod as StripePaymentMethod } from '@stripe/stripe-js';
 import PropTypes, { InferProps } from 'prop-types';
 import { useState } from 'react';
-import { CircularProgress } from 'components/base';
 import { StripePaymentWrapper } from 'components/paymentProviders/stripe';
 import { usePortalContribution } from 'hooks/usePortalContribution';
 import ContributionFetchError from '../ContributionFetchError';
@@ -13,7 +12,8 @@ import { BillingHistory } from './BillingHistory';
 import { PaymentMethod } from './PaymentMethod';
 import { MobileBackButton } from './MobileBackButton';
 import { MobileHeader } from './MobileHeader';
-import { Root, Loading, TopMatter, Content } from './ContributionDetail.styled';
+import { Root, TopMatter, Content } from './ContributionDetail.styled';
+import { LoadingSkeleton } from './LoadingSkeleton';
 
 const ContributionDetailPropTypes = {
   contributionId: PropTypes.number.isRequired,
@@ -51,12 +51,13 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
     );
   }
 
-  if (isLoading || !contribution) {
+  if (isLoading || contribution?.id !== contributionId) {
     return (
       <Root key="loading" ref={setRootEl}>
-        <Loading data-testid="loading">
-          <CircularProgress aria-label="Loading contribution" size={48} variant="indeterminate" />
-        </Loading>
+        <TopMatter>
+          <MobileBackButton />
+          <LoadingSkeleton />
+        </TopMatter>
       </Root>
     );
   }

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
@@ -51,7 +51,7 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
     );
   }
 
-  if (isLoading || contribution?.id !== contributionId) {
+  if (isLoading || !contribution) {
     return (
       <Root key="loading" ref={setRootEl}>
         <TopMatter>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/DetailSection/DetailSection.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/DetailSection/DetailSection.tsx
@@ -6,7 +6,7 @@ const DetailSectionPropTypes = {
   controls: PropTypes.node,
   disabled: PropTypes.bool,
   highlighted: PropTypes.bool,
-  title: PropTypes.string.isRequired
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired
 };
 
 export type DetailSectionProps = InferProps<typeof DetailSectionPropTypes>;
@@ -15,7 +15,7 @@ export function DetailSection({ children, controls, disabled, highlighted, title
   return (
     <Root $disabled={!!disabled} $highlighted={!!highlighted}>
       <Header>
-        <Title>{title}</Title>
+        {typeof title === 'string' ? <Title>{title}</Title> : title}
         <Controls>{controls}</Controls>
       </Header>
       {children}

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.stories.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react';
+import LoadingSkeleton from './LoadingSkeleton';
+
+const LoadingSkeletonDemo = () => <LoadingSkeleton />;
+
+const meta: Meta<typeof LoadingSkeletonDemo> = {
+  component: LoadingSkeletonDemo,
+  title: 'Contributor/LoadingSkeleton'
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LoadingSkeletonDemo>;
+
+export const Default: Story = {};

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.stories.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.stories.tsx
@@ -1,15 +1,13 @@
 import { Meta, StoryObj } from '@storybook/react';
 import LoadingSkeleton from './LoadingSkeleton';
 
-const LoadingSkeletonDemo = () => <LoadingSkeleton />;
-
-const meta: Meta<typeof LoadingSkeletonDemo> = {
-  component: LoadingSkeletonDemo,
+const meta: Meta<typeof LoadingSkeleton> = {
+  component: LoadingSkeleton,
   title: 'Contributor/LoadingSkeleton'
 };
 
 export default meta;
 
-type Story = StoryObj<typeof LoadingSkeletonDemo>;
+type Story = StoryObj<typeof LoadingSkeleton>;
 
 export const Default: Story = {};

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.test.tsx
@@ -1,0 +1,25 @@
+import { axe } from 'jest-axe';
+import { render, screen } from 'test-utils';
+import LoadingSkeleton from './LoadingSkeleton';
+
+jest.mock('@material-ui/lab', () => ({
+  ...jest.requireActual('@material-ui/lab'),
+  Skeleton: () => <div data-testid="mock-skeleton" />
+}));
+
+function tree() {
+  return render(<LoadingSkeleton />);
+}
+
+describe('LoadingSkeleton', () => {
+  it('should render skeletons for each section', () => {
+    tree();
+    expect(screen.getAllByTestId('mock-skeleton')).toHaveLength(4);
+  });
+
+  it('is accessible', async () => {
+    const { container } = tree();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/LoadingSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@material-ui/lab';
+import { DetailSection } from '../DetailSection';
+import { Content } from '../ContributionDetail.styled';
+
+export function LoadingSkeleton() {
+  return (
+    <Content data-testid="loading-skeleton">
+      <DetailSection title={<Skeleton variant="text" width={100} />}>
+        <Skeleton variant="rect" height={140} />
+      </DetailSection>
+      <DetailSection title={<Skeleton variant="text" width={100} />}>
+        <Skeleton variant="rect" height={140} />
+      </DetailSection>
+    </Content>
+  );
+}
+
+export default LoadingSkeleton;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/index.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/LoadingSkeleton/index.ts
@@ -1,0 +1,1 @@
+export * from './LoadingSkeleton';

--- a/spa/src/hooks/usePortalContribution.tsx
+++ b/spa/src/hooks/usePortalContribution.tsx
@@ -80,8 +80,7 @@ export function usePortalContribution(contributorId: number, contributionId: num
 
   const { data, isError, isFetching, isLoading, refetch } = useQuery(
     ['portalContribution', contributorId, contributionId],
-    () => fetchContribution(contributorId, contributionId),
-    { keepPreviousData: true }
+    () => fetchContribution(contributorId, contributionId)
   );
 
   // Refresh the contribution details and list after 15 seconds to allow the backend / stripe to process the cancellation.


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
- Improves loading indicator for contribution detail
#### Why are we doing this? How does it help us?
- Improve UX
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
- yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
- yes
#### Have automated unit tests been added? If not, why?
- yes
#### How should this change be communicated to end users?
- n/a
#### Are there any smells or added technical debt to note?
- no 
#### Has this been documented? If so, where?
- no
#### What are the relevant tickets? Add a link to any relevant ones.
- https://news-revenue-hub.atlassian.net/browse/DEV-4347
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
- no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
- Parent ticket: https://news-revenue-hub.atlassian.net/browse/DEV-3780