### PR TITLE
DEV-4206: Update wording around Core upgrade

### DIFF
--- a/spa/src/components/dashboard/sidebar/SidebarCoreUpgradePrompt/SidebarCoreUpgradePrompt.styled.ts
+++ b/spa/src/components/dashboard/sidebar/SidebarCoreUpgradePrompt/SidebarCoreUpgradePrompt.styled.ts
@@ -1,6 +1,6 @@
 import { IconButton } from '@material-ui/core';
 import CoreUpgradeIcon from 'assets/icons/upgrade-core.svg?react';
-import { LinkButton } from 'components/base';
+import { RouterLinkButton } from 'components/base';
 import styled from 'styled-components';
 
 export const CloseButton = styled(IconButton)`
@@ -30,7 +30,7 @@ export const Header = styled.h2`
   margin-top: 2px; /* align with icon beside it */
 `;
 
-export const LearnMoreButton = styled(LinkButton)`
+export const UpgradeButton = styled(RouterLinkButton)`
   padding: 10px 30px;
 `;
 

--- a/spa/src/components/dashboard/sidebar/SidebarCoreUpgradePrompt/SidebarCoreUpgradePrompt.test.tsx
+++ b/spa/src/components/dashboard/sidebar/SidebarCoreUpgradePrompt/SidebarCoreUpgradePrompt.test.tsx
@@ -1,5 +1,6 @@
 import { PRICING_URL } from 'constants/helperUrls';
 import { axe } from 'jest-axe';
+import { SETTINGS } from 'routes';
 import { fireEvent, render, screen } from 'test-utils';
 import SidebarCoreUpgradePrompt, { SidebarCoreUpgradePromptProps } from './SidebarCoreUpgradePrompt';
 
@@ -8,14 +9,13 @@ function tree(props?: Partial<SidebarCoreUpgradePromptProps>) {
 }
 
 describe('SidebarCoreUpgradePrompt', () => {
-  it('displays a link to the pricing page', () => {
+  it('displays a link to the subscription apge', () => {
     tree();
 
-    const link = screen.getByRole('link', { name: 'Learn More' });
+    const link = screen.getByRole('button', { name: 'Upgrade' });
 
     expect(link).toBeVisible();
-    expect(link).toHaveAttribute('href', PRICING_URL);
-    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('href', SETTINGS.SUBSCRIPTION);
   });
 
   it('displays a button that calls the onClose prop when clicked', () => {

--- a/spa/src/components/dashboard/sidebar/SidebarCoreUpgradePrompt/SidebarCoreUpgradePrompt.tsx
+++ b/spa/src/components/dashboard/sidebar/SidebarCoreUpgradePrompt/SidebarCoreUpgradePrompt.tsx
@@ -1,7 +1,7 @@
 import { Close } from '@material-ui/icons';
-import { PRICING_URL } from 'constants/helperUrls';
 import PropTypes, { InferProps } from 'prop-types';
-import { CloseButton, Header, LearnMoreButton, Root, Text, UpgradeIcon } from './SidebarCoreUpgradePrompt.styled';
+import { CloseButton, Header, UpgradeButton, Root, Text, UpgradeIcon } from './SidebarCoreUpgradePrompt.styled';
+import { SETTINGS } from 'routes';
 
 const SidebarCoreUpgradePromptPropTypes = {
   onClose: PropTypes.func.isRequired
@@ -18,9 +18,9 @@ export function SidebarCoreUpgradePrompt({ onClose }: SidebarCoreUpgradePromptPr
       </CloseButton>
       <Header>Upgrade to Core</Header>
       <Text>Boost your revenue with segmented email marketing.</Text>
-      <LearnMoreButton href={PRICING_URL} target="_blank" variant="outlined">
-        Learn More
-      </LearnMoreButton>
+      <UpgradeButton to={SETTINGS.SUBSCRIPTION} variant="outlined">
+        Upgrade
+      </UpgradeButton>
     </Root>
   );
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Updates the Core upgrade CTA in the nav bar to point to the subscription settings page instead of the public site pricing page.

#### Why are we doing this? How does it help us?

Makes it easier to upgrade.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Updated existing.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4206

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.