### PR TITLE
DEV-4482: Don't let contributors see rejected or processing contributions

### DIFF
--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -412,7 +412,13 @@ class TestContributionsViewSet:
         "user", (pytest_cases.fixture_ref("superuser"), pytest_cases.fixture_ref("hub_admin_user"))
     )
     @pytest.mark.parametrize(
-        "contribution_status", (ContributionStatus.FLAGGED, ContributionStatus.REJECTED, ContributionStatus.PROCESSING)
+        "contribution_status",
+        (
+            ContributionStatus.FAILED,
+            ContributionStatus.FLAGGED,
+            ContributionStatus.PROCESSING,
+            ContributionStatus.REJECTED,
+        ),
     )
     def test_filter_contributions_based_on_status(
         self,
@@ -1744,7 +1750,15 @@ class TestPortalContributorsViewSet:
         response = api_client.get(reverse("portal-contributor-contributions-list", args=(contributor.id,)))
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @pytest.mark.parametrize("status", (ContributionStatus.FAILED, ContributionStatus.PROCESSING))
+    @pytest.mark.parametrize(
+        "status",
+        (
+            ContributionStatus.FAILED,
+            ContributionStatus.FLAGGED,
+            ContributionStatus.PROCESSING,
+            ContributionStatus.REJECTED,
+        ),
+    )
     def test_contributions_list_hides_statuses(
         self,
         status,
@@ -1869,7 +1883,15 @@ class TestPortalContributorsViewSet:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Contribution not found"}
 
-    @pytest.mark.parametrize("contribution_status", (ContributionStatus.FAILED, ContributionStatus.PROCESSING))
+    @pytest.mark.parametrize(
+        "contribution_status",
+        (
+            ContributionStatus.FAILED,
+            ContributionStatus.FLAGGED,
+            ContributionStatus.PROCESSING,
+            ContributionStatus.REJECTED,
+        ),
+    )
     def test_contributions_detail_when_hidden_status(
         self, contribution_status, api_client, one_time_contribution, portal_contributor_with_multiple_contributions
     ):
@@ -1986,7 +2008,15 @@ class TestPortalContributorsViewSet:
         assert response.json() == {"detail": "Problem updating contribution"}
         mock_pm_attach.assert_called_once()
 
-    @pytest.mark.parametrize("contribution_status", (ContributionStatus.FAILED, ContributionStatus.PROCESSING))
+    @pytest.mark.parametrize(
+        "contribution_status",
+        (
+            ContributionStatus.FAILED,
+            ContributionStatus.FLAGGED,
+            ContributionStatus.PROCESSING,
+            ContributionStatus.REJECTED,
+        ),
+    )
     def test_contributions_detail_patch_when_hidden_status(
         self, contribution_status, api_client, one_time_contribution, portal_contributor_with_multiple_contributions
     ):
@@ -2085,7 +2115,15 @@ class TestPortalContributorsViewSet:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {"detail": "Cannot cancel contribution"}
 
-    @pytest.mark.parametrize("contribution_status", (ContributionStatus.FAILED, ContributionStatus.PROCESSING))
+    @pytest.mark.parametrize(
+        "contribution_status",
+        (
+            ContributionStatus.FAILED,
+            ContributionStatus.FLAGGED,
+            ContributionStatus.PROCESSING,
+            ContributionStatus.REJECTED,
+        ),
+    )
     def test_contributions_detail_delete_when_hidden_status(
         self, contribution_status, api_client, one_time_contribution, portal_contributor_with_multiple_contributions
     ):

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -1882,6 +1882,7 @@ class TestPortalContributorsViewSet:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Contribution not found"}
 
+    @pytest.mark.parametrize("http_method", ("delete", "get", "patch"))
     @pytest.mark.parametrize(
         "contribution_status",
         (
@@ -1891,13 +1892,18 @@ class TestPortalContributorsViewSet:
         ),
     )
     def test_contributions_detail_when_hidden_status(
-        self, contribution_status, api_client, one_time_contribution, portal_contributor_with_multiple_contributions
+        self,
+        http_method,
+        contribution_status,
+        api_client,
+        one_time_contribution,
+        portal_contributor_with_multiple_contributions,
     ):
         contributor = portal_contributor_with_multiple_contributions[0]
         one_time_contribution.status = contribution_status
         one_time_contribution.save()
         api_client.force_authenticate(contributor)
-        response = api_client.get(
+        response = getattr(api_client, http_method)(
             reverse("portal-contributor-contribution-detail", args=(contributor.id, one_time_contribution.id))
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -2006,33 +2012,6 @@ class TestPortalContributorsViewSet:
         assert response.json() == {"detail": "Problem updating contribution"}
         mock_pm_attach.assert_called_once()
 
-    @pytest.mark.parametrize(
-        "contribution_status",
-        (
-            ContributionStatus.FLAGGED,
-            ContributionStatus.PROCESSING,
-            ContributionStatus.REJECTED,
-        ),
-    )
-    def test_contributions_detail_patch_when_hidden_status(
-        self, contribution_status, api_client, one_time_contribution, portal_contributor_with_multiple_contributions
-    ):
-        contributor = portal_contributor_with_multiple_contributions[0]
-        one_time_contribution.status = contribution_status
-        one_time_contribution.save()
-        api_client.force_authenticate(contributor)
-        response = api_client.patch(
-            reverse(
-                "portal-contributor-contribution-detail",
-                args=(
-                    contributor.id,
-                    one_time_contribution.id,
-                ),
-            )
-        )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {"detail": "Contribution not found"}
-
     def test_contribution_detail_delete_happy_path(
         self, api_client, portal_contributor_with_multiple_contributions, mocker
     ):
@@ -2111,33 +2090,6 @@ class TestPortalContributorsViewSet:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {"detail": "Cannot cancel contribution"}
-
-    @pytest.mark.parametrize(
-        "contribution_status",
-        (
-            ContributionStatus.FLAGGED,
-            ContributionStatus.PROCESSING,
-            ContributionStatus.REJECTED,
-        ),
-    )
-    def test_contributions_detail_delete_when_hidden_status(
-        self, contribution_status, api_client, one_time_contribution, portal_contributor_with_multiple_contributions
-    ):
-        contributor = portal_contributor_with_multiple_contributions[0]
-        one_time_contribution.status = contribution_status
-        one_time_contribution.save()
-        api_client.force_authenticate(contributor)
-        response = api_client.delete(
-            reverse(
-                "portal-contributor-contribution-detail",
-                args=(
-                    contributor.id,
-                    one_time_contribution.id,
-                ),
-            )
-        )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {"detail": "Contribution not found"}
 
     @pytest.mark.parametrize(
         "method, kwargs",

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -1753,7 +1753,6 @@ class TestPortalContributorsViewSet:
     @pytest.mark.parametrize(
         "status",
         (
-            ContributionStatus.FAILED,
             ContributionStatus.FLAGGED,
             ContributionStatus.PROCESSING,
             ContributionStatus.REJECTED,
@@ -1886,7 +1885,6 @@ class TestPortalContributorsViewSet:
     @pytest.mark.parametrize(
         "contribution_status",
         (
-            ContributionStatus.FAILED,
             ContributionStatus.FLAGGED,
             ContributionStatus.PROCESSING,
             ContributionStatus.REJECTED,
@@ -2011,7 +2009,6 @@ class TestPortalContributorsViewSet:
     @pytest.mark.parametrize(
         "contribution_status",
         (
-            ContributionStatus.FAILED,
             ContributionStatus.FLAGGED,
             ContributionStatus.PROCESSING,
             ContributionStatus.REJECTED,
@@ -2118,7 +2115,6 @@ class TestPortalContributorsViewSet:
     @pytest.mark.parametrize(
         "contribution_status",
         (
-            ContributionStatus.FAILED,
             ContributionStatus.FLAGGED,
             ContributionStatus.PROCESSING,
             ContributionStatus.REJECTED,

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -581,7 +581,6 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
     # Contributors should never see contributions with these statuses, or
     # interact with them (e.g. delete or patch them).
     HIDDEN_STATUSES = [
-        ContributionStatus.FAILED,
         ContributionStatus.FLAGGED,
         ContributionStatus.PROCESSING,
         ContributionStatus.REJECTED,

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -580,7 +580,12 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
 
     # Contributors should never see contributions with these statuses, or
     # interact with them (e.g. delete or patch them).
-    HIDDEN_STATUSES = [ContributionStatus.FAILED, ContributionStatus.PROCESSING]
+    HIDDEN_STATUSES = [
+        ContributionStatus.FAILED,
+        ContributionStatus.FLAGGED,
+        ContributionStatus.PROCESSING,
+        ContributionStatus.REJECTED,
+    ]
 
     queryset = Contributor.objects.all()
 

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -36,6 +36,7 @@ from apps.contributions.models import (
     Contribution,
     ContributionInterval,
     ContributionIntervalError,
+    ContributionQuerySet,
     ContributionStatus,
     ContributionStatusError,
     Contributor,
@@ -577,6 +578,10 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         "status",
     ]
 
+    # Contributors should never see contributions with these statuses, or
+    # interact with them (e.g. delete or patch them).
+    HIDDEN_STATUSES = [ContributionStatus.FAILED, ContributionStatus.PROCESSING]
+
     queryset = Contributor.objects.all()
 
     def _get_contributor_and_check_permissions(self, request, contributor_id):
@@ -586,6 +591,12 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
             raise NotFound(detail="Contributor not found", code=status.HTTP_404_NOT_FOUND)
         self.check_object_permissions(request, contributor)
         return contributor
+
+    def _prune_contributions_queryset(self, queryset: ContributionQuerySet) -> ContributionQuerySet:
+        """Removes contributions from a contribution queryset that should never be visible to a contributor."""
+        # This is needed bcecause the queryset property of this class is tied to
+        # contributors, not contributions.
+        return queryset.exclude(status__in=self.HIDDEN_STATUSES)
 
     def get_serializer_class(self):
         return (
@@ -609,7 +620,7 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         for k in self.ALLOWED_FILTER_FIELDS:
             if (v := self.request.query_params.get(k)) is not None:
                 filters[k] = v
-        queryset = contributor.contribution_set.filter(**filters).order_by(ordering)
+        queryset = self._prune_contributions_queryset(contributor.contribution_set).filter(**filters).order_by(ordering)
         paginator = self.pagination_class()
         page = paginator.paginate_queryset(queryset, request)
         serializer = self.get_serializer(page, many=True)
@@ -626,7 +637,7 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         """Endpoint to get or update a contribution for a given contributor"""
         contributor = self._get_contributor_and_check_permissions(request, pk)
         try:
-            contribution = contributor.contribution_set.get(pk=contribution_id)
+            contribution = self._prune_contributions_queryset(contributor.contribution_set).get(pk=contribution_id)
         except Contribution.DoesNotExist:
             return Response({"detail": "Contribution not found"}, status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Filters out rejected and processing contributions from new endpoints. They don't appear in contribution lists and trying interact with detail (GET, PATCH, DELETE) returns a 404.

#### Why are we doing this? How does it help us?

These shouldn't be visible to contributors.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No..?

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4482

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.