### PR TITLE
DEV-4500-convert-local-storage-based-auth-to-session-storage-instead

### DIFF
--- a/spa/src/appSettings.ts
+++ b/spa/src/appSettings.ts
@@ -28,6 +28,7 @@ export const ORG_GA_V3_PLUGIN_NAME = 'ga-v3-org';
 // Auth
 export const LS_USER = 'REVENGINE_USER';
 export const LS_CONTRIBUTOR = 'REVENGINE_CONTRIBUTOR';
+export const SS_CONTRIBUTOR = 'REVENGINE_CONTRIBUTOR';
 export const LS_CSRF_TOKEN = 'CSRF_TOKEN';
 export const CSRF_HEADER = 'X-CSRFTOKEN';
 export const PASSWORD_RESET_URL = '/users/password-reset/';

--- a/spa/src/components/ContributorRouter.tsx
+++ b/spa/src/components/ContributorRouter.tsx
@@ -91,7 +91,7 @@ function ContributorRouter() {
               <ContributorDashboard />
             </TrackPageView>
           )}
-          contributor
+          contributorType="CONTRIBUTOR"
         />
         <SentryRoute
           path={ROUTES.CONTRIBUTOR_ENTRY}

--- a/spa/src/components/PortalRouter.tsx
+++ b/spa/src/components/PortalRouter.tsx
@@ -22,8 +22,17 @@ function InnerPortalRouter() {
   return (
     <RouterSetup>
       {/* These don't get wrapped in <PortalPage> because the component styles it. */}
-      <ProtectedRoute path={ROUTES.PORTAL.CONTRIBUTIONS} render={() => <TransactionsList />} contributor exact />
-      <ProtectedRoute path={ROUTES.PORTAL.CONTRIBUTION_DETAIL} render={() => <TransactionsList />} contributor />
+      <ProtectedRoute
+        path={ROUTES.PORTAL.CONTRIBUTIONS}
+        render={() => <TransactionsList />}
+        contributorType="PORTAL"
+        exact
+      />
+      <ProtectedRoute
+        path={ROUTES.PORTAL.CONTRIBUTION_DETAIL}
+        render={() => <TransactionsList />}
+        contributorType="PORTAL"
+      />
       <SentryRoute
         exact
         path={ROUTES.PORTAL.ENTRY}

--- a/spa/src/components/authentication/ProtectedRoute.test.tsx
+++ b/spa/src/components/authentication/ProtectedRoute.test.tsx
@@ -20,46 +20,49 @@ function tree(props?: Partial<ProtectedRouteProps>) {
 }
 
 describe('ProtectedRoute', () => {
-  const isAuthenticatedMock = jest.mocked(isAuthenticated);
+  const isAuthenticatedMock = isAuthenticated as jest.Mock;
 
   beforeEach(() => isAuthenticatedMock.mockReturnValue(false));
 
-  describe('when the contributor prop is true', () => {
-    it('displays a SentryRoute if the user is authenticated as a contributor', () => {
-      isAuthenticatedMock.mockImplementation((value?: boolean) => !!value);
-      tree({ contributor: true });
-      expect(screen.getByTestId('mock-sentry-route')).toBeInTheDocument();
-    });
+  describe.each(['PORTAL', 'CONTRIBUTOR'] as Array<ProtectedRouteProps['contributorType']>)(
+    'when the contributor type prop is %s',
+    (contributorType) => {
+      it('displays a SentryRoute if the user is authenticated as a contributor', () => {
+        isAuthenticatedMock.mockImplementation((value?: boolean) => !!value);
+        tree({ contributorType });
+        expect(screen.getByTestId('mock-sentry-route')).toBeInTheDocument();
+      });
 
-    it('displays a signin redirect if the user is authenticated as an admin only', () => {
-      isAuthenticatedMock.mockImplementation((value?: boolean) => !value);
-      tree({ contributor: true });
-      expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
-    });
+      it('displays a signin redirect if the user is authenticated as an admin only', () => {
+        isAuthenticatedMock.mockImplementation((value?: boolean) => !value);
+        tree({ contributorType });
+        expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
+      });
 
-    it('displays a signin redirect if the user is not authenticated', () => {
-      isAuthenticatedMock.mockReturnValue(false);
-      tree({ contributor: true });
-      expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
-    });
-  });
+      it('displays a signin redirect if the user is not authenticated', () => {
+        isAuthenticatedMock.mockReturnValue(false);
+        tree({ contributorType });
+        expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
+      });
+    }
+  );
 
-  describe('when the contributor prop is false', () => {
+  describe('when the contributor prop is undefined', () => {
     it('displays a SentryRoute if the user is authenticated as an admin', () => {
       isAuthenticatedMock.mockImplementation((value?: boolean) => !value);
-      tree({ contributor: false });
+      tree({ contributorType: undefined });
       expect(screen.getByTestId('mock-sentry-route')).toBeInTheDocument();
     });
 
     it('displays a signin redirect if the user is authenticated as a contributor only', () => {
       isAuthenticatedMock.mockImplementation((value?: boolean) => !!value);
-      tree({ contributor: false });
+      tree({ contributorType: undefined });
       expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
     });
 
     it('displays a signin redirect if the user is not authenticated', () => {
       isAuthenticatedMock.mockReturnValue(false);
-      tree({ contributor: false });
+      tree({ contributorType: undefined });
       expect(screen.getByTestId('mock-redirect')).toHaveTextContent(SIGN_IN);
     });
   });

--- a/spa/src/components/authentication/ProtectedRoute.tsx
+++ b/spa/src/components/authentication/ProtectedRoute.tsx
@@ -8,15 +8,15 @@ export interface ProtectedRouteProps extends RouteProps {
    * If true, then the user must be a contributor, not an admin, to access this
    * route.
    */
-  contributor?: boolean;
+  contributorType?: 'CONTRIBUTOR' | 'PORTAL';
 }
 
 /**
  * ProtectedRoute either verifies authentication status or redirects to SIGN_IN.
  * Accepts 'contributor' prop so isAuthenticated can check for the right user type.
  */
-function ProtectedRoute({ contributor, ...props }: ProtectedRouteProps) {
-  if (isAuthenticated(contributor)) {
+function ProtectedRoute({ contributorType, ...props }: ProtectedRouteProps) {
+  if (isAuthenticated(contributorType)) {
     return <SentryRoute {...props} />;
   }
 

--- a/spa/src/components/contributor/ContributorVerify.styled.ts
+++ b/spa/src/components/contributor/ContributorVerify.styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const ContributorVerify = styled.main`
+export const ContributorVerifyWrapper = styled.main`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -10,7 +10,3 @@ export const ContributorVerify = styled.main`
     font-family: ${(props) => props.theme.systemFont};
   }
 `;
-
-export const CouldNotVerify = styled.div``;
-
-export const LoadingVerification = styled.h1``;

--- a/spa/src/components/contributor/ContributorVerify.test.tsx
+++ b/spa/src/components/contributor/ContributorVerify.test.tsx
@@ -1,0 +1,106 @@
+import Axios from 'ajax/axios';
+import { VERIFY_TOKEN } from 'ajax/endpoints';
+import { LS_CONTRIBUTOR, LS_CSRF_TOKEN, SS_CONTRIBUTOR } from 'appSettings';
+import MockAdapter from 'axios-mock-adapter';
+import { useHistory } from 'react-router-dom';
+import { render, screen, waitFor } from 'test-utils';
+import ContributorVerify from './ContributorVerify';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    search: ''
+  }),
+  useHistory: jest.fn()
+}));
+
+describe('ContributorVerify', () => {
+  const axiosMock = new MockAdapter(Axios);
+  const useHistoryMock = useHistory as jest.Mock;
+
+  beforeEach(() => {
+    useHistoryMock.mockReturnValue({ replace: jest.fn() });
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterAll(() => {
+    axiosMock.restore();
+  });
+
+  describe('Loading state', () => {
+    it('should show loading', () => {
+      render(<ContributorVerify />);
+      expect(screen.getByText('Looking for your contributions...')).toBeInTheDocument();
+    });
+
+    it('should not redirect', () => {
+      const replace = jest.fn();
+      useHistoryMock.mockReturnValue({ replace });
+
+      render(<ContributorVerify />);
+      expect(screen.getByText('Looking for your contributions...')).toBeInTheDocument();
+      expect(replace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Verify success (when response is 200)', () => {
+    beforeEach(() => {
+      axiosMock.onPost(VERIFY_TOKEN).reply(200, { contributor: 'mock-contributor', csrftoken: 'mock-token' });
+    });
+
+    it('should redirect to dashboard', async () => {
+      render(<ContributorVerify />);
+      await waitFor(() => {
+        expect(useHistoryMock().replace).toHaveBeenCalledWith('/contributor/contributions/');
+      });
+    });
+
+    it('should set contributor in local and session storage', async () => {
+      render(<ContributorVerify />);
+
+      await waitFor(() => {
+        expect(window.localStorage.getItem(LS_CONTRIBUTOR)).toBe(JSON.stringify('mock-contributor'));
+      });
+      expect(window.sessionStorage.getItem(SS_CONTRIBUTOR)).toBe(JSON.stringify('mock-contributor'));
+    });
+
+    it('should set csrf token in local storage', async () => {
+      render(<ContributorVerify />);
+      await waitFor(() => {
+        expect(window.localStorage.getItem(LS_CSRF_TOKEN)).toBe('mock-token');
+      });
+    });
+  });
+
+  describe('Verify failed', () => {
+    beforeEach(() => {
+      axiosMock.onPost(VERIFY_TOKEN).reply(400);
+    });
+
+    it('should render could not verify message', async () => {
+      render(<ContributorVerify />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/We were unable to log you in./i)).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText(/Magic links have short expiration times. If your link expired/i, {
+          exact: false
+        })
+      ).toBeInTheDocument();
+    });
+
+    it('should render link to contributor entry', async () => {
+      render(<ContributorVerify />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /click here/i })).toHaveAttribute('href', '/contributor/');
+      });
+    });
+  });
+});

--- a/spa/src/hooks/usePortalAuth.test.tsx
+++ b/spa/src/hooks/usePortalAuth.test.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 import MockAdapter from 'axios-mock-adapter';
 import { useState } from 'react';
 import Axios from 'ajax/axios';
-import { LS_CONTRIBUTOR, LS_CSRF_TOKEN } from 'appSettings';
+import { SS_CONTRIBUTOR, LS_CSRF_TOKEN } from 'appSettings';
 import { fireEvent, render, screen, waitFor } from 'test-utils';
 import { PortalAuthContextProvider, usePortalAuthContext } from './usePortalAuth';
 
@@ -52,39 +52,40 @@ describe('PortalAuthContextProvider', () => {
 
   beforeEach(() => {
     window.localStorage.clear();
+    window.sessionStorage.clear();
     setUserMock = jest.fn();
     SentryMock.setUser = setUserMock;
   });
 
   afterAll(() => axiosMock.restore());
 
-  it("initially sets the contributor object to undefined if it's not in local storage", () => {
+  it("initially sets the contributor object to undefined if it's not in session storage", () => {
     tree();
     expect(screen.queryByTestId('contributor')).not.toBeInTheDocument();
   });
 
-  it('loads the contributor object from local storage if available', () => {
-    window.localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify(testContributor));
+  it('loads the contributor object from session storage if available', () => {
+    window.sessionStorage.setItem(SS_CONTRIBUTOR, JSON.stringify(testContributor));
     tree();
     expect(screen.getByTestId('contributor')).toHaveTextContent(JSON.stringify(testContributor));
   });
 
-  it('sets the user in Sentry if the contributor was set in local storage', () => {
-    window.localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify(testContributor));
+  it('sets the user in Sentry if the contributor was set in session storage', () => {
+    window.sessionStorage.setItem(SS_CONTRIBUTOR, JSON.stringify(testContributor));
     tree();
     expect(setUserMock.mock.calls).toEqual([
       [{ email: testContributor.email, id: testContributor.id, ip_address: '{{auto}}' }]
     ]);
   });
 
-  it("doesn't provide a verifyToken function if a contributor was loaded from local storage", () => {
-    window.localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify(testContributor));
+  it("doesn't provide a verifyToken function if a contributor was loaded from session storage", () => {
+    window.sessionStorage.setItem(SS_CONTRIBUTOR, JSON.stringify(testContributor));
     tree();
     expect(screen.queryByText('verifyToken')).not.toBeInTheDocument();
   });
 
-  it('ignores a malformed object in local storage', () => {
-    window.localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify({ ...testContributor, email: undefined }));
+  it('ignores a malformed object in session storage', () => {
+    window.sessionStorage.setItem(SS_CONTRIBUTOR, JSON.stringify({ ...testContributor, email: undefined }));
     tree();
     expect(screen.queryByTestId('contributor')).not.toBeInTheDocument();
     expect(setUserMock).not.toBeCalled();
@@ -137,12 +138,12 @@ describe('PortalAuthContextProvider', () => {
         expect(screen.queryByText('verifyToken')).not.toBeInTheDocument();
       });
 
-      it('saves the contributor to local storage', async () => {
+      it('saves the contributor to session storage', async () => {
         tree();
-        expect(window.localStorage.getItem(LS_CONTRIBUTOR)).toBe(null);
+        expect(window.sessionStorage.getItem(SS_CONTRIBUTOR)).toBe(null);
         fireEvent.click(screen.getByText('verifyToken'));
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
-        expect(window.localStorage.getItem(LS_CONTRIBUTOR)).toBe(JSON.stringify(testContributor));
+        expect(window.sessionStorage.getItem(SS_CONTRIBUTOR)).toBe(JSON.stringify(testContributor));
       });
 
       it('saves the CSRF token to local storage', async () => {

--- a/spa/src/hooks/usePortalAuth.tsx
+++ b/spa/src/hooks/usePortalAuth.tsx
@@ -3,7 +3,7 @@ import PropTypes, { InferProps } from 'prop-types';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import axios from 'ajax/axios';
 import { VERIFY_TOKEN } from 'ajax/endpoints';
-import { LS_CONTRIBUTOR, LS_CSRF_TOKEN } from 'appSettings';
+import { SS_CONTRIBUTOR, LS_CSRF_TOKEN } from 'appSettings';
 
 /**
  * A contributor who has logged into the portal.
@@ -94,14 +94,14 @@ export function PortalAuthContextProvider({ children }: InferProps<typeof Portal
 
     setContributor(data.contributor);
     identifyUserInSentry(data.contributor);
-    localStorage.setItem(LS_CONTRIBUTOR, JSON.stringify(data.contributor));
+    sessionStorage.setItem(SS_CONTRIBUTOR, JSON.stringify(data.contributor));
     localStorage.setItem(LS_CSRF_TOKEN, data.csrftoken);
   }, []);
 
   // Try to initally set the contributor based on local storage.
 
   useEffect(() => {
-    const lsContributor = localStorage.getItem(LS_CONTRIBUTOR);
+    const lsContributor = sessionStorage.getItem(SS_CONTRIBUTOR);
 
     if (!lsContributor) {
       // The contributor hasn't previously logged in.

--- a/spa/src/hooks/usePortalAuth.tsx
+++ b/spa/src/hooks/usePortalAuth.tsx
@@ -88,8 +88,8 @@ export function PortalAuthContextProvider({ children }: InferProps<typeof Portal
       throw new Error('No CSRF in token verification response');
     }
 
-    // Set values in context and in local storage for later usage. The local
-    // storage key is also needed for backwards compat with isAuthenticated() in
+    // Set values in context, in local storage, and session storage for later usage. The session
+    // storage key is also needed for compatibility with isAuthenticated(contributorType) in
     // utilities/, used by ProtectedRoute.
 
     setContributor(data.contributor);
@@ -124,7 +124,7 @@ export function PortalAuthContextProvider({ children }: InferProps<typeof Portal
         identifyUserInSentry(loadedContributor);
       }
     } catch {
-      // Fail silently--their local storage has become malformed, so we want
+      // Fail silently--their session storage has become malformed, so we want
       // them to sign in again.
     }
   }, []);

--- a/spa/src/utilities/isAuthenticated.test.ts
+++ b/spa/src/utilities/isAuthenticated.test.ts
@@ -1,18 +1,30 @@
-import { LS_CONTRIBUTOR, LS_USER } from 'appSettings';
+import { LS_CONTRIBUTOR, LS_USER, SS_CONTRIBUTOR } from 'appSettings';
 import isAuthenticated from './isAuthenticated';
 
 describe('isAuthenticated', () => {
-  beforeEach(() => window.localStorage.clear());
-  afterEach(() => window.localStorage.clear());
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
 
-  describe('when asked for a contributor', () => {
-    it("returns false if there isn't the appropriate local storage key", () => {
-      expect(isAuthenticated(true)).toBe(false);
+  afterEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  describe.each(['CONTRIBUTOR', 'PORTAL'])('when asked for a contributor type %s', (type: any) => {
+    const [storageKey, storageType, storage] =
+      type === 'CONTRIBUTOR'
+        ? [LS_CONTRIBUTOR, 'local', window.localStorage]
+        : [SS_CONTRIBUTOR, 'session', window.sessionStorage];
+
+    it(`returns false if there isn't the appropriate ${storageType} storage key`, () => {
+      expect(isAuthenticated(type)).toBe(false);
     });
 
-    it('returns true if there is the appropriate local storage key', () => {
-      window.localStorage.setItem(LS_CONTRIBUTOR, '');
-      expect(isAuthenticated(true)).toBe(true);
+    it(`returns true if there is the appropriate ${storageType} storage key`, () => {
+      storage.setItem(storageKey, '');
+      expect(isAuthenticated(type)).toBe(true);
     });
   });
 

--- a/spa/src/utilities/isAuthenticated.ts
+++ b/spa/src/utilities/isAuthenticated.ts
@@ -1,12 +1,15 @@
-import { LS_CONTRIBUTOR, LS_USER } from 'appSettings';
+import { LS_CONTRIBUTOR, SS_CONTRIBUTOR, LS_USER } from 'appSettings';
 
 /**
  * Returns whether the user is currently authenticated. **This is only
  * advisory** because a user could manipulate their browser local storage.
  */
-function isAuthenticated(forContributor?: boolean): boolean {
-  if (forContributor) {
-    return window.localStorage.getItem(LS_CONTRIBUTOR) !== null;
+function isAuthenticated(contributorType?: 'CONTRIBUTOR' | 'PORTAL'): boolean {
+  switch (contributorType) {
+    case 'CONTRIBUTOR':
+      return window.localStorage.getItem(LS_CONTRIBUTOR) !== null;
+    case 'PORTAL':
+      return window.sessionStorage.getItem(SS_CONTRIBUTOR) !== null;
   }
 
   return window.localStorage.getItem(LS_USER) !== null;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
Swaps new portal authentication from localStorage to sessionStorage so that the user "logs out" when the tab is closed
#### Why are we doing this? How does it help us?
Implementing a logout to new portal
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no
#### Have automated unit tests been added? If not, why?
yes
#### How should this change be communicated to end users?
Closing the tab logs the donors out of the new portal
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
no
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-4500
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no