### PR TITLE
DEV-4622: Pare down Semantic UI

### DIFF
--- a/spa/index.html
+++ b/spa/index.html
@@ -39,8 +39,6 @@
   </script>
   {% endif %} {% include "spa_env.html" %}
 
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css" />
-
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link

--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -56,6 +56,7 @@
         "react-table": "^7.7.0",
         "react-test-renderer": "^17.0.2",
         "scroll-into-view": "^1.16.0",
+        "semantic-ui-css": "^2.4.1",
         "styled-components": "^5.2.3",
         "styled-normalize": "^8.0.7",
         "styled-system": "^5.1.5",
@@ -19756,6 +19757,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -24071,6 +24077,14 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/scroll-into-view/-/scroll-into-view-1.16.2.tgz",
       "integrity": "sha512-vyTE0i27o6eldt9xinjHec41Dw05y+faoI+s2zNKJAVOdbA5M2XZrYq/obJ8E+QDQulJ2gDjgui9w9m9RZSRng=="
+    },
+    "node_modules/semantic-ui-css": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
+      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
+      "dependencies": {
+        "jquery": "x.*"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/spa/package.json
+++ b/spa/package.json
@@ -51,6 +51,7 @@
     "react-table": "^7.7.0",
     "react-test-renderer": "^17.0.2",
     "scroll-into-view": "^1.16.0",
+    "semantic-ui-css": "^2.4.1",
     "styled-components": "^5.2.3",
     "styled-normalize": "^8.0.7",
     "styled-system": "^5.1.5",

--- a/spa/src/index.tsx
+++ b/spa/src/index.tsx
@@ -2,6 +2,8 @@ import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import './i18n';
+import 'semantic-ui-css/components/reset.css';
+import 'semantic-ui-css/components/site.css';
 
 // webpack CSP nonce concession
 (window as any).__webpack_nonce__ = (window as any).csp_nonce;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Removes the externally-CDN'd version of Semantic UI with an internally-served version, and only includes global styles.

#### Why are we doing this? How does it help us?

- The external link to Semantic UI CSS is being flagged by Lighthouse as blocking render.
- We are loading much more of Semantic UI than we actually need--this represents about a 60kb savings uncompressed.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

CSS-only change.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

Eventually, a goal is to remove Semantic UI entirely. But this pares it down to what we need right now to maintain the current appearance.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4622

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.