### PR TITLE
DEV-4627 | Force currency to uppercase in stripe import command

### DIFF
--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -87,16 +87,6 @@ class ContributionImportBaseClass(ABC):
     refunds: list[stripe.Refund]
     customer: stripe.Customer | None
 
-    DONT_UPDATE_FIELDS = [
-        # If there's contribution metadata, we want to leave it intact.
-        # Otherwise we see spurious updates because of key ordering in the
-        # metadata and conversions of null <-> None.
-        "contribution_metadata",
-        # Currently revengine stores currency as uppercase, but there are older contributions where
-        # it's stored as lowercase. We don't want to update these contributions because it's not necessary
-        "currency",
-    ]
-
     def __post_init__(self) -> None:
         self.validate()
 
@@ -289,7 +279,8 @@ class PaymentIntentForOneTimeContribution(ContributionImportBaseClass):
             unique_identifier={"provider_payment_id": self.payment_intent.id},
             defaults={
                 "amount": self.payment_intent.amount,
-                "currency": self.payment_intent.currency,
+                # NB: Stripe currency is always uppercase, but we store it in Revengine as lowercase
+                "currency": self.payment_intent.currency.lower(),
                 "interval": ContributionInterval.ONE_TIME,
                 "payment_provider_used": PaymentProvider.STRIPE_LABEL,
                 "provider_customer_id": self.customer.id if self.customer else None,
@@ -300,7 +291,10 @@ class PaymentIntentForOneTimeContribution(ContributionImportBaseClass):
                 "contribution_metadata": self.payment_intent.metadata,
             },
             caller_name="PaymentIntentForOneTimeContribution.upsert",
-            dont_update=self.DONT_UPDATE_FIELDS,
+            # If there's contribution metadata, we want to leave it intact.
+            # Otherwise we see spurious updates because of key ordering in the
+            # metadata and conversions of null <-> None.
+            dont_update=["contribution_metadata"],
         )
         contribution = self.conditionally_update_contribution_donation_page(contribution=contribution)
         if not contribution.donation_page:
@@ -396,7 +390,8 @@ class SubscriptionForRecurringContribution(ContributionImportBaseClass):
             unique_identifier={"provider_subscription_id": self.subscription.id},
             defaults={
                 "amount": self.subscription.plan.amount,
-                "currency": self.subscription.plan.currency,
+                # NB: Stripe currency is always uppercase, but we store it in Revengine as lowercase
+                "currency": self.subscription.plan.currency.lower(),
                 "interval": self.interval,
                 "payment_provider_used": PaymentProvider.STRIPE_LABEL,
                 "provider_customer_id": self.customer.id,
@@ -407,7 +402,10 @@ class SubscriptionForRecurringContribution(ContributionImportBaseClass):
                 "status": self.status,
             },
             caller_name="SubscriptionForRecurringContribution.upsert",
-            dont_update=self.DONT_UPDATE_FIELDS,
+            # If there's contribution metadata, we want to leave it intact.
+            # Otherwise we see spurious updates because of key ordering in the
+            # metadata and removal of null/None entries.
+            dont_update=["contribution_metadata"],
         )
         contribution = self.conditionally_update_contribution_donation_page(contribution=contribution)
         if not contribution.donation_page:

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -279,8 +279,7 @@ class PaymentIntentForOneTimeContribution(ContributionImportBaseClass):
             unique_identifier={"provider_payment_id": self.payment_intent.id},
             defaults={
                 "amount": self.payment_intent.amount,
-                # NB: Stripe currency is always uppercase, but we store it in Revengine as lowercase
-                "currency": self.payment_intent.currency.lower(),
+                "currency": self.payment_intent.currency,
                 "interval": ContributionInterval.ONE_TIME,
                 "payment_provider_used": PaymentProvider.STRIPE_LABEL,
                 "provider_customer_id": self.customer.id if self.customer else None,
@@ -390,8 +389,7 @@ class SubscriptionForRecurringContribution(ContributionImportBaseClass):
             unique_identifier={"provider_subscription_id": self.subscription.id},
             defaults={
                 "amount": self.subscription.plan.amount,
-                # NB: Stripe currency is always uppercase, but we store it in Revengine as lowercase
-                "currency": self.subscription.plan.currency.lower(),
+                "currency": self.subscription.plan.currency,
                 "interval": self.interval,
                 "payment_provider_used": PaymentProvider.STRIPE_LABEL,
                 "provider_customer_id": self.customer.id,

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -279,7 +279,10 @@ class PaymentIntentForOneTimeContribution(ContributionImportBaseClass):
             unique_identifier={"provider_payment_id": self.payment_intent.id},
             defaults={
                 "amount": self.payment_intent.amount,
-                "currency": self.payment_intent.currency,
+                # NB: Stripe currency as returned by API is lowercased, but when we create contributions in revengine
+                # donation page flow, we use uppercase currency (see organizations.models.PaymentProvider.currency default of USD), so
+                # we need to uppercase it here, lest we superfluously update a large number of records from "USD" to "usd"
+                "currency": self.payment_intent.currency.upper(),
                 "interval": ContributionInterval.ONE_TIME,
                 "payment_provider_used": PaymentProvider.STRIPE_LABEL,
                 "provider_customer_id": self.customer.id if self.customer else None,
@@ -389,7 +392,12 @@ class SubscriptionForRecurringContribution(ContributionImportBaseClass):
             unique_identifier={"provider_subscription_id": self.subscription.id},
             defaults={
                 "amount": self.subscription.plan.amount,
-                "currency": self.subscription.plan.currency,
+                # NB: Stripe currency as returned by API is lowercased, but when we create contributions in revengine
+                # donation page flow, we use uppercase currency (see organizations.models.PaymentProvider.currency default of USD), so
+                # NB: Stripe currency as returned by API is lowercased, but when we create contributions in revengine
+                # donation page flow, we use uppercase currency (see organizations.models.PaymentProvider.currency default of USD), so
+                # we need to uppercase it here, lest we superfluously update a large number of records from "USD" to "usd"
+                "currency": self.subscription.plan.currency.upper(),
                 "interval": self.interval,
                 "payment_provider_used": PaymentProvider.STRIPE_LABEL,
                 "provider_customer_id": self.customer.id,

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -394,10 +394,8 @@ class SubscriptionForRecurringContribution(ContributionImportBaseClass):
                 "amount": self.subscription.plan.amount,
                 # NB: Stripe currency as returned by API is lowercased, but when we create contributions in revengine
                 # donation page flow, we use uppercase currency (see organizations.models.PaymentProvider.currency default of USD), so
-                # NB: Stripe currency as returned by API is lowercased, but when we create contributions in revengine
-                # donation page flow, we use uppercase currency (see organizations.models.PaymentProvider.currency default of USD), so
                 # we need to uppercase it here, lest we superfluously update a large number of records from "USD" to "usd"
-                "currency": self.subscription.plan.currency.upper(),
+                "currency": self.subscription.currency.upper(),
                 "interval": self.interval,
                 "payment_provider_used": PaymentProvider.STRIPE_LABEL,
                 "provider_customer_id": self.customer.id,

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -102,6 +102,7 @@ def subscription(mocker, customer, valid_metadata):
         customer=customer,
         metadata=valid_metadata,
         plan=plan,
+        currency="usd",
         status="active",
         default_payment_method=payment_method,
     )
@@ -394,7 +395,7 @@ class TestSubscriptionForRecurringContribution:
         contribution, action = instance.upsert()
         assert contribution.provider_subscription_id == subscription.id
         assert contribution.amount == subscription.plan.amount
-        assert contribution.currency == subscription.plan.currency.lower()
+        assert contribution.currency == subscription.plan.currency.upper()
         assert contribution.interval == ContributionInterval.MONTHLY
         assert contribution.payment_provider_used == PaymentProvider.STRIPE_LABEL
         assert contribution.provider_customer_id == subscription.customer.id
@@ -609,7 +610,7 @@ class TestPaymentIntentForOneTimeContribution:
         ).upsert()
         assert contribution.provider_payment_id == payment_intent.id
         assert contribution.amount == payment_intent.amount
-        assert contribution.currency == payment_intent.currency.lower()
+        assert contribution.currency == payment_intent.currency.upper()
         assert contribution.interval == ContributionInterval.ONE_TIME
         assert contribution.payment_provider_used == PaymentProvider.STRIPE_LABEL
         assert contribution.provider_payment_method_id == payment_intent.payment_method.id

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -6,7 +6,6 @@ from django.conf import settings
 import pytest
 import stripe
 
-from apps.contributions import stripe_import
 from apps.contributions.exceptions import (
     InvalidIntervalError,
     InvalidMetadataError,
@@ -384,7 +383,6 @@ class TestSubscriptionForRecurringContribution:
 
     def test_upsert(self, subscription_to_upsert, charge, refund, customer, mocker):
         subscription, existing_entities = subscription_to_upsert
-        upsert_with_diff_check_spy = mocker.spy(stripe_import, "upsert_with_diff_check")
         if existing_entities:
             orig_metadata = Contribution.objects.get(
                 provider_subscription_id=subscription.id
@@ -417,7 +415,6 @@ class TestSubscriptionForRecurringContribution:
         assert action == ("created" if not existing_entities else "updated")
         mock_upsert_payment.assert_any_call(contribution, charge.balance_transaction, is_refund=False)
         mock_upsert_payment.assert_any_call(contribution, refund.balance_transaction, is_refund=True)
-        assert upsert_with_diff_check_spy.call_args[1]["dont_update"] == ["contribution_metadata", "currency"]
 
     def test_upsert_when_no_donation_page(self, subscription, customer, charge, refund, mocker):
         mocker.patch(
@@ -604,7 +601,6 @@ class TestPaymentIntentForOneTimeContribution:
 
     def test_upsert(self, pi_to_upsert, customer, charge, refund, mocker):
         payment_intent, existing_entities = pi_to_upsert
-        upsert_with_diff_check_spy = mocker.spy(stripe_import, "upsert_with_diff_check")
         if existing_entities:
             orig_metadata = Contribution.objects.get(provider_payment_id=payment_intent.id).contribution_metadata.copy()
         mock_upsert_payment = mocker.patch("apps.contributions.stripe_import.upsert_payment_for_transaction")
@@ -635,7 +631,6 @@ class TestPaymentIntentForOneTimeContribution:
         assert Contributor.objects.filter(email=customer.email).exists
         mock_upsert_payment.assert_any_call(contribution, charge.balance_transaction, is_refund=False)
         mock_upsert_payment.assert_any_call(contribution, refund.balance_transaction, is_refund=True)
-        assert upsert_with_diff_check_spy.call_args[1]["dont_update"] == ["contribution_metadata", "currency"]
 
     def test_upsert_when_no_donation_page(self, payment_intent, customer, charge, refund, mocker):
         mocker.patch(


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR changes two lines of code that were lowercasing currency on contributions when importing/upserting from Stripe so that they instead uppercase.

I made the change that used .lower() in the PR for [DEV-4595](https://github.com/newsrevenuehub/rev-engine/pull/1462) because I mistakenly thought that all NRE contributions used lowercase currency on contribution creation (through donation page flow), and that by upserting data from Stripe (which uses uppercase currency) we would be making an unneeded change across all touched contributions. I also mistakenly thought that Stripe was storing currency as uppercase, when in fact it stores as lowercase.

As it turns out, the vast majority of our contributions made through donation pages use uppercase for currency, and only a small subset  (69 total) use lowercase (see here: https://metabase-test.revengine.org/question/91-contributions-count-grouped-by-currency).

This PR lets Stripe's values for currency flow through, which means that if the import command is run across all current contributions, those 69 lowercased ones will be updated. That will actually be a good thing because it will remove this inconsistency in our system.

Additionally, this pr takes the currency value from subscription.currency instead of subscription.plan.currency. This is how should have been originally implemented because it's simpler and because subscription.plan is deprecated.

#### Why are we doing this? How does it help us?

Unblock Stripe import command which in turn unblocks new contributor portal.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Not super detailed, but should make sense to the dev user who runs this command (namely, Daniel).


#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

No. Don't seem warranted in this case. If anything the change involving `.lower` that is now effectively reverted could have been tested.  

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

Charts and explanation in JIRA ticket. 

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-4267](https://news-revenue-hub.atlassian.net/browse/DEV-4627)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A

[DEV-4595]: https://news-revenue-hub.atlassian.net/browse/DEV-4595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-4267]: https://news-revenue-hub.atlassian.net/browse/DEV-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ