### PR TITLE
DEV-4633 | upsert with diff check should insert revision comment when creates entity

### DIFF
--- a/apps/common/tests/test_utils.py
+++ b/apps/common/tests/test_utils.py
@@ -379,11 +379,11 @@ class Test_upsert_with_diff_check:
     @pytest.fixture(
         params=[
             {"instance": "instance_is_none", "dont_update": [], "action": "created"},
-            {"instance": "instance_needs_update", "dont_update": [], "action": "updated"},
-            {"instance": "instance_not_need_update", "dont_update": [], "action": "left unchanged"},
-            {"instance": "instance_only_needs_amount_update", "dont_update": [], "action": "updated"},
-            {"instance": "instance_only_needs_amount_update", "dont_update": ["amount"], "action": "left unchanged"},
-            {"instance": "instance_is_none", "dont_update": ["amount"], "action": "created"},
+            # {"instance": "instance_needs_update", "dont_update": [], "action": "updated"},
+            # {"instance": "instance_not_need_update", "dont_update": [], "action": "left unchanged"},
+            # {"instance": "instance_only_needs_amount_update", "dont_update": [], "action": "updated"},
+            # {"instance": "instance_only_needs_amount_update", "dont_update": ["amount"], "action": "left unchanged"},
+            # {"instance": "instance_is_none", "dont_update": ["amount"], "action": "created"},
         ]
     )
     def upsert_with_diff_check_case(self, request):
@@ -411,7 +411,10 @@ class Test_upsert_with_diff_check:
             assert action == expected_action
             create_revision_mock.assert_called_once()
 
-            if action == "updated":
-                mock_set_comment.assert_called_once_with(f"{caller} updated {self.model.__name__}")
-            else:
-                mock_set_comment.assert_not_called()
+            match action:
+                case "updated":
+                    mock_set_comment.assert_called_once_with(f"{caller} updated {self.model.__name__}")
+                case "created":
+                    mock_set_comment.assert_called_once_with(f"{caller} created {self.model.__name__}")
+                case _:
+                    mock_set_comment.assert_not_called()

--- a/apps/common/tests/test_utils.py
+++ b/apps/common/tests/test_utils.py
@@ -379,11 +379,11 @@ class Test_upsert_with_diff_check:
     @pytest.fixture(
         params=[
             {"instance": "instance_is_none", "dont_update": [], "action": "created"},
-            # {"instance": "instance_needs_update", "dont_update": [], "action": "updated"},
-            # {"instance": "instance_not_need_update", "dont_update": [], "action": "left unchanged"},
-            # {"instance": "instance_only_needs_amount_update", "dont_update": [], "action": "updated"},
-            # {"instance": "instance_only_needs_amount_update", "dont_update": ["amount"], "action": "left unchanged"},
-            # {"instance": "instance_is_none", "dont_update": ["amount"], "action": "created"},
+            {"instance": "instance_needs_update", "dont_update": [], "action": "updated"},
+            {"instance": "instance_not_need_update", "dont_update": [], "action": "left unchanged"},
+            {"instance": "instance_only_needs_amount_update", "dont_update": [], "action": "updated"},
+            {"instance": "instance_only_needs_amount_update", "dont_update": ["amount"], "action": "left unchanged"},
+            {"instance": "instance_is_none", "dont_update": ["amount"], "action": "created"},
         ]
     )
     def upsert_with_diff_check_case(self, request):


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This updates `upsert_with_diff_check` so that it inserts a revision comment in case of creation. Formerly, it only set a comment in case of update. 


#### Why are we doing this? How does it help us?

Will allow us to set up metabase reporting to show how many contributions created / updated per org by new import stripe transactions data command.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?


Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

no

#### Has this been documented? If so, where?


n/a/


#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-4633](https://news-revenue-hub.atlassian.net/browse/DEV-4633)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No
