### PR TITLE
DEV-4632: Fix RichTextEditor paste losing formatting issue

### DIFF
--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -45,7 +45,7 @@
         "react-alert": "^7.0.3",
         "react-cookie": "^4.1.1",
         "react-dom": "^17.0.2",
-        "react-draft-wysiwyg": "^1.14.7",
+        "react-draft-wysiwyg": "^1.15.0",
         "react-focus-lock": "^2.9.5",
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.34.2",

--- a/spa/package.json
+++ b/spa/package.json
@@ -40,7 +40,7 @@
     "react-alert": "^7.0.3",
     "react-cookie": "^4.1.1",
     "react-dom": "^17.0.2",
-    "react-draft-wysiwyg": "^1.14.7",
+    "react-draft-wysiwyg": "^1.15.0",
     "react-focus-lock": "^2.9.5",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.34.2",

--- a/spa/src/components/base/RichTextEditor/RichTextEditor.test.tsx
+++ b/spa/src/components/base/RichTextEditor/RichTextEditor.test.tsx
@@ -3,8 +3,12 @@ import { render, screen } from 'test-utils';
 import RichTextEditor, { RichTextEditorProps } from './RichTextEditor';
 
 jest.mock('react-draft-wysiwyg', () => ({
-  Editor: ({ toolbar }: { toolbar: any }) => (
-    <div data-testid="mock-react-draft-editor" data-toolbar={JSON.stringify(toolbar ?? '')} />
+  Editor: ({ toolbar, handlePastedText }: { toolbar: any; handlePastedText: () => boolean }) => (
+    <div
+      data-testid="mock-react-draft-editor"
+      data-toolbar={JSON.stringify(toolbar ?? '')}
+      data-handlePastedText={handlePastedText?.()}
+    />
   )
 }));
 
@@ -23,6 +27,11 @@ describe('RichTextEditor', () => {
 
     tree({ toolbar });
     expect(screen.getByTestId('mock-react-draft-editor')!.dataset.toolbar).toEqual(JSON.stringify(toolbar));
+  });
+
+  it('should have prop to fix paste formatting issue (handlePastedText)', () => {
+    tree();
+    expect(screen.getByTestId('mock-react-draft-editor')!.dataset.handlepastedtext).toEqual('false');
   });
 
   it('is accessible', async () => {

--- a/spa/src/components/base/RichTextEditor/RichTextEditor.tsx
+++ b/spa/src/components/base/RichTextEditor/RichTextEditor.tsx
@@ -40,7 +40,13 @@ const Root = styled.div`
 export function RichTextEditor(props: RichTextEditorProps) {
   return (
     <Root>
-      <Editor toolbar={defaultToolbar} {...props} />
+      <Editor
+        toolbar={defaultToolbar}
+        // Needed to prevent overriding the paste event and losing formatting
+        // ref: https://github.com/jpuri/react-draft-wysiwyg/issues/967#issuecomment-792075354
+        handlePastedText={() => false}
+        {...props}
+      />
     </Root>
   );
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
Fixes issue when pasting text into RichTextEditor 
#### Why are we doing this? How does it help us?
Makes copy&paste work as expected
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no
#### Have automated unit tests been added? If not, why?
yes
#### How should this change be communicated to end users?
Copy&Paste to RichTextEditor now keeps original's text formatting
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
no
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-4632
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no