### PR TITLE
DEV-4634 | Fix bug with metadata validation for payment intents in Stripe transactions import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ After registering a model, you will need to run the following management command
 python manage.py createinitialrevisions
 ```
 
+Also note that if your model admin inherits from `RevEngineBaseAdmin`, you will get VersionAdmin (and therefore model registration) for free.
+
 ### How to register a view
 
 We use `reversion.views.RevisionMixin` in select API-layer viewsets in order to record changes to the model instances that happen via that view. To set up a view to record changes, do:

--- a/apps/common/admin.py
+++ b/apps/common/admin.py
@@ -9,10 +9,12 @@ from django_json_widget.widgets import JSONEditorWidget
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import JsonLexer
+from reversion.admin import VersionAdmin
 from reversion.models import Revision, Version
+from reversion_compare.admin import CompareVersionAdmin
 
 
-class RevEngineBaseAdmin(ModelAdmin):
+class RevEngineBaseAdmin(CompareVersionAdmin, VersionAdmin):
     formfield_overrides = {
         models.JSONField: {"widget": JSONEditorWidget},
     }

--- a/apps/config/admin.py
+++ b/apps/config/admin.py
@@ -1,13 +1,11 @@
 from django.contrib import admin
 
-from reversion_compare.admin import CompareVersionAdmin
-
 from apps.common.admin import RevEngineBaseAdmin
 from apps.config.models import DenyListWord
 
 
 @admin.register(DenyListWord)
-class DenyListWordAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
+class DenyListWordAdmin(RevEngineBaseAdmin):
     list_display = ("word",)
 
     ordering = ("word",)

--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -4,8 +4,6 @@ from django.conf import settings
 from django.contrib import admin, messages
 from django.utils.html import format_html
 
-from reversion_compare.admin import CompareVersionAdmin
-
 from apps.common.admin import RevEngineBaseAdmin, prettify_json_field
 from apps.contributions.models import Contribution, ContributionStatus, Contributor, Payment
 from apps.contributions.payment_managers import PaymentProviderError
@@ -15,7 +13,7 @@ logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 
 @admin.register(Contributor)
-class ContributorAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
+class ContributorAdmin(RevEngineBaseAdmin):
     list_display = ("email",)
     list_filter = ("email",)
     ordering = ("email",)
@@ -74,7 +72,7 @@ class PaymentInline(admin.TabularInline):
 
 
 @admin.register(Contribution)
-class ContributionAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
+class ContributionAdmin(RevEngineBaseAdmin):
     fieldsets = (
         (
             "Payment",

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -110,7 +110,7 @@ class ContributionImportBaseClass(ABC):
 
     @property
     def email_id(self) -> str | None:
-        return self.customer.email
+        return self.customer.email if self.customer else None
 
     @property
     def stripe_entity(self) -> stripe.PaymentIntent | stripe.Subscription:

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -110,7 +110,7 @@ class ContributionImportBaseClass(ABC):
 
     @property
     def email_id(self) -> str | None:
-        return getattr(self.customer, "email", None)
+        return self.customer.email if self.customer else None
 
     @property
     def stripe_entity(self) -> stripe.PaymentIntent | stripe.Subscription:

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -110,7 +110,7 @@ class ContributionImportBaseClass(ABC):
 
     @property
     def email_id(self) -> str | None:
-        return self.customer.email if self.customer else None
+        return getattr(self.customer, "email", None)
 
     @property
     def stripe_entity(self) -> stripe.PaymentIntent | stripe.Subscription:

--- a/apps/organizations/admin.py
+++ b/apps/organizations/admin.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from rest_framework.serializers import ValidationError as DRFValidationError
-from reversion_compare.admin import CompareVersionAdmin
 from sorl.thumbnail.admin import AdminImageMixin
 
 from apps.common.admin import RevEngineBaseAdmin
@@ -91,7 +90,7 @@ class BenefitLevelBenefit(NoRelatedInlineAddEditAdminMixin, ReadOnlyOrgLimitedTa
 
 
 @admin.register(Organization)
-class OrganizationAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
+class OrganizationAdmin(RevEngineBaseAdmin):
     organization_fieldset = (
         (
             "Organization",
@@ -169,7 +168,7 @@ class OrganizationAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
 
 
 @admin.register(Benefit)
-class BenefitAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
+class BenefitAdmin(RevEngineBaseAdmin):
     list_display = ["name", "description", "revenue_program"]
 
     list_filter = ["revenue_program"]
@@ -178,7 +177,7 @@ class BenefitAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
 
 
 @admin.register(BenefitLevel)
-class BenefitLevelAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
+class BenefitLevelAdmin(RevEngineBaseAdmin):
     list_display = ["name", "donation_range", "revenue_program"]
 
     list_filter = ["revenue_program"]
@@ -210,7 +209,7 @@ class BenefitLevelAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
 
 
 @admin.register(RevenueProgram)
-class RevenueProgramAdmin(RevEngineBaseAdmin, CompareVersionAdmin, AdminImageMixin):
+class RevenueProgramAdmin(RevEngineBaseAdmin, AdminImageMixin):
     fieldsets = (
         (
             "RevenueProgram",
@@ -333,7 +332,7 @@ class RevenueProgramAdmin(RevEngineBaseAdmin, CompareVersionAdmin, AdminImageMix
 
 
 @admin.register(PaymentProvider)
-class PaymentProviderAdmin(RevEngineBaseAdmin, CompareVersionAdmin):
+class PaymentProviderAdmin(RevEngineBaseAdmin):
     search_fields = ("stripe_account_id",)
     list_display = [
         "stripe_account_id",

--- a/apps/pages/admin.py
+++ b/apps/pages/admin.py
@@ -6,7 +6,6 @@ from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 
-from reversion_compare.admin import CompareVersionAdmin
 from solo.admin import SingletonModelAdmin
 from sorl.thumbnail.admin import AdminImageMixin
 
@@ -90,7 +89,7 @@ class DonationPageAdminForm(forms.ModelForm):
 
 
 @admin.register(models.DonationPage)
-class DonationPageAdmin(CompareVersionAdmin, DonationPageAdminAbstract):
+class DonationPageAdmin(DonationPageAdminAbstract):
     form = DonationPageAdminForm
     fieldsets = (
         (
@@ -168,7 +167,7 @@ class DonationPageAdmin(CompareVersionAdmin, DonationPageAdminAbstract):
 
 
 @admin.register(models.Style)
-class StyleAdmin(CompareVersionAdmin):
+class StyleAdmin(RevEngineBaseAdmin):
     list_display = (
         "name",
         "revenue_program",
@@ -188,7 +187,7 @@ class StyleAdmin(CompareVersionAdmin):
 
 
 @admin.register(models.Font)
-class FontAdmin(CompareVersionAdmin):
+class FontAdmin(RevEngineBaseAdmin):
     list_display = (
         "name",
         "source",

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -3,14 +3,13 @@ from django.contrib.auth.admin import UserAdmin
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
-from reversion_compare.admin import CompareVersionAdmin
-
+from apps.common.admin import RevEngineBaseAdmin
 from apps.users.forms import RoleAssignmentAdminForm
 from apps.users.models import RoleAssignment, User
 
 
 @admin.register(User)
-class CustomUserAdmin(UserAdmin, CompareVersionAdmin):
+class CustomUserAdmin(RevEngineBaseAdmin, UserAdmin):
     list_display = ("email", "is_superuser", "is_staff", "role_assignment", "last_login")
     list_filter = ("is_active", "is_staff", "groups")
     search_fields = ("email",)
@@ -68,7 +67,7 @@ class CustomUserAdmin(UserAdmin, CompareVersionAdmin):
 
 
 @admin.register(RoleAssignment)
-class RoleAssignment(CompareVersionAdmin):
+class RoleAssignmentAdmin(RevEngineBaseAdmin):
     list_display = (
         "user",
         "role_type",

--- a/apps/users/tests/test_admin.py
+++ b/apps/users/tests/test_admin.py
@@ -26,7 +26,7 @@ class TestUsersAdmin(TestCase):
         self.client.get("/nrhadmin/users/roleassignment/add/")
 
     def test_get_readonly_fields(self):
-        t = apps.users.admin.RoleAssignment(apps.users.models.RoleAssignment, "")
+        t = apps.users.admin.RoleAssignmentAdmin(apps.users.models.RoleAssignment, "")
         assert [
             "user",
         ] == t.get_readonly_fields(None, obj=self.user)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

- Fixes a bug in `StripeTransactionsImporter` that caused it to exclude PIs that didn't have conforming payment metadata. This was a relic of earlier iteration of that code that used a different strategy for retrieving subscriptions and payment intents for one-time contributions (earlier, that exclusion made sense because we didn't look to PIs to determine which subscriptions to retrieve). This bug was causing subscriptions and therefore recurring contributions to be excluded from upsertion.
- Updates `RevEngineBaseAdmin` to inherit from `CompareVersionAdmin` and replaces inline usage of modeladmins inheriting from CompareVersionAdmin/VersionAdmin. This standardizes the reversion behavior across modeladmins that inherit from RevEngineBaseAdmin.  This came into scope because although revisions were being created for payments, they were not visible in the Django admin for that model.
- Solves for bug in `StripeTransactionsImporter.email` whereby it would raise an uncaught error when a stripe customer did not have an email property.
- Moves `_SUBSCRIPTIONS_DATA` and `_ONE_TIMES_DATA` so they're no longer class vars on `StripeTransactionsImporter` and instead get set in `__post_init__`. This was necessary because those values were persisting between test runs and causing tests to fail. This may be a sign that setting class vars that later get mutated like I was formerly doing is an antipattern when using dataclasses (indeed, this is one of the use cases for __post_init__).


#### Why are we doing this? How does it help us?

Allows us to run stripe transactions data import in prod across accounts, and unblock new portal.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes


#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-4634](https://news-revenue-hub.atlassian.net/browse/DEV-4634)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No

[DEV-4634]: https://news-revenue-hub.atlassian.net/browse/DEV-4634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ