### PR TITLE
DEV-4638 | reimplemented to use less memory

### DIFF
--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -1,5 +1,7 @@
 import logging
+import random
 import re
+import time
 from typing import List, Tuple
 
 from django.conf import settings
@@ -196,3 +198,18 @@ def upsert_with_diff_check(
                 reversion.set_comment(f"{caller_name} updated {model.__name__}")
 
         return instance, "created" if created else "updated" if bool(fields_to_update) else "left unchanged"
+
+
+def stripe_call_with_backoff(callable, *args, **kwargs):
+    max_retries = 5
+    base_delay = 1  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            return callable(*args, **kwargs)
+        except stripe.error.RateLimitError:
+            if attempt == max_retries - 1:
+                raise
+            delay = base_delay * (2**attempt) + random.uniform(0, base_delay)
+            logger.info("Rate limit exceeded, retrying in %s seconds...", delay)
+            time.sleep(delay)

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -217,6 +217,12 @@ class ContributionImportBaseClass(ABC):
         self, charges: list[stripe.Charge], refunds: list[stripe.Refund], contribution: Contribution
     ) -> None:
         for x, is_refund in list(map(lambda y: (y, False), charges)) + list(map(lambda y: (y, True), refunds)):
+            if not x or not getattr(x, "balance_transaction", None):
+                logger.warning(
+                    "Data associated with contribution %s has no balance transaction associated with it. No payment will be created.",
+                    contribution.id,
+                )
+                continue
             payment, action = upsert_payment_for_transaction(contribution, x.balance_transaction, is_refund=is_refund)
             if payment:
                 match action:

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -3,7 +3,7 @@ import logging
 from abc import ABC
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Tuple
+from typing import Any, Dict, Iterable, Tuple
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -42,7 +42,7 @@ logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 def upsert_payment_for_transaction(
     contribution: Contribution, transaction: stripe.BalanceTransaction, is_refund: bool = False
-) -> None:
+) -> Tuple[Payment | None, str | None]:
     """Upsert a payment object for a given stripe balance transaction and contribution"""
     logger.debug(
         "Upserting payment for contribution %s and transaction %s",
@@ -62,6 +62,7 @@ def upsert_payment_for_transaction(
             caller_name="upsert_payment_for_transaction",
         )
         logger.info("%s payment %s for contribution %s", action, payment.id, contribution.id)
+        return payment, action
     else:
         # NB. This is a rare case. It happened running locally with test Stripe. Seems unlikely in prod, but need to handle so command
         # works in all cases
@@ -69,6 +70,7 @@ def upsert_payment_for_transaction(
             "Data associated with contribution %s has no balance transaction associated with it. No payment will be created.",
             contribution.id,
         )
+        return None, None
 
 
 def parse_slug_from_url(url: str) -> str | None:
@@ -89,6 +91,11 @@ class ContributionImportBaseClass(ABC):
 
     def __post_init__(self) -> None:
         self.validate()
+        self.created_contribution_ids = set()
+        self.updated_contribution_ids = set()
+        self.created_payment_ids = set()
+        self.updated_payment_ids = set()
+        self.created_contributor_ids = set()
 
     def validate(self) -> None:
         """Does several validation checks that should ensure the data can be upserted to revengine.
@@ -99,6 +106,13 @@ class ContributionImportBaseClass(ABC):
         self.validate_metadata()
         self.validate_customer()
         self.validate_email_id()
+
+    def get_effects_string(self) -> str:
+        """Return a string summarizing the effects of the import"""
+        return (
+            f"For {self.entity_name} {self.entity_id}, created {len(self.created_contribution_ids)} contributions, {len(self.created_contributor_ids)} contributors, {len(self.created_payment_ids)} payments; "
+            f"updated {len(self.updated_contribution_ids)} contributions, {len(self.updated_payment_ids)} payments."
+        )
 
     @property
     def entity_id(self) -> str:
@@ -168,6 +182,12 @@ class ContributionImportBaseClass(ABC):
 
     def validate_metadata(self) -> None:
         """Validate the metadata associated with the stripe entity"""
+        if (
+            schema_version := self.stripe_entity.metadata.get("schema_version", None)
+        ) not in STRIPE_PAYMENT_METADATA_SCHEMA_VERSIONS:
+            raise InvalidMetadataError(
+                f"Invalid schema version {schema_version} for {self.entity_name} {self.entity_id}"
+            )
         # Callling this will raise a `InvalidMetadataError` if the metadata is invalid
         cast_metadata_to_stripe_payment_metadata_schema(self.stripe_entity.metadata)
 
@@ -183,6 +203,29 @@ class ContributionImportBaseClass(ABC):
                 contribution.save(update_fields={"donation_page"})
                 reversion.set_comment("Donation page was updated from Stripe metadata")
         return contribution
+
+    def get_or_create_contributor(self) -> Contributor:
+        """Get or create a contributor"""
+        logger.debug("Upserting contributor for %s %s", self.entity_name, self.entity_id)
+        contributor, created = Contributor.objects.get_or_create(email=self.email_id)
+        if created:
+            logger.info("Created new contributor %s for %s %s", contributor.id, self.entity_name, self.entity_id)
+            self.created_contributor_ids.add(contributor.id)
+        return contributor
+
+    def upsert_payments(
+        self, charges: list[stripe.Charge], refunds: list[stripe.Refund], contribution: Contribution
+    ) -> None:
+        for x, is_refund in list(map(lambda y: (y, False), charges)) + list(map(lambda y: (y, True), refunds)):
+            payment, action = upsert_payment_for_transaction(contribution, x.balance_transaction, is_refund=is_refund)
+            if payment:
+                match action:
+                    case "created":
+                        self.created_payment_ids.add(payment.id)
+                    case "updated":
+                        self.updated_payment_ids.add(payment.id)
+                    case _:
+                        pass
 
 
 @dataclass
@@ -259,7 +302,7 @@ class PaymentIntentForOneTimeContribution(ContributionImportBaseClass):
         return self.customer.invoice_settings.default_payment_method if self.customer.invoice_settings else None
 
     @transaction.atomic
-    def upsert(self) -> Tuple[Contribution, str]:
+    def upsert(self) -> None:
         """Upsert a contribution, contributor, and payments for a given Stripe payment intent.
 
         If the payment intent has a charge associated, we'll upsert a payment.
@@ -270,9 +313,7 @@ class PaymentIntentForOneTimeContribution(ContributionImportBaseClass):
         contribution not having a value for donation page, the entire transaction is rolled back.
         """
         logger.debug("Upserting untracked payment intent %s", self.payment_intent.id)
-        contributor, created = Contributor.objects.get_or_create(email=self.email_id)
-        if created:
-            logger.info("Created new contributor %s for payment intent %s", contributor.id, self.payment_intent.id)
+        contributor = self.get_or_create_contributor()
         pm = self.payment_method
         contribution, action = upsert_with_diff_check(
             model=Contribution,
@@ -306,12 +347,20 @@ class PaymentIntentForOneTimeContribution(ContributionImportBaseClass):
             raise InvalidStripeTransactionDataError(
                 f"Contribution {contribution.id} has no donation page associated with it"
             )
-        if charge := self.successful_charge:
-            upsert_payment_for_transaction(contribution, charge.balance_transaction, is_refund=False)
+        match action:
+            case "created":
+                self.created_contribution_ids.add(contribution.id)
+            case "updated":
+                self.updated_contribution_ids.add(contribution.id)
+            case _:
+                pass
         # Even though we only expect one successful charge, it's possible to have multiple refunds
-        for x in self.refunds:
-            upsert_payment_for_transaction(contribution, x.balance_transaction, is_refund=True)
-        return contribution, action
+        charge = self.successful_charge
+        self.upsert_payments(
+            charges=[charge if charge else None],
+            refunds=self.refunds,
+            contribution=contribution,
+        )
 
 
 @dataclass
@@ -376,7 +425,7 @@ class SubscriptionForRecurringContribution(ContributionImportBaseClass):
         return self.customer.invoice_settings.default_payment_method if self.customer.invoice_settings else None
 
     @transaction.atomic
-    def upsert(self) -> Tuple[Contribution, str]:
+    def upsert(self) -> None:
         """Upsert contribution, contributor and payments for given Stripe subscription
 
         Additionally, we'll conditionally update the contribution with donation page if it's missing. Note that if the upsert action would result in the
@@ -419,11 +468,14 @@ class SubscriptionForRecurringContribution(ContributionImportBaseClass):
             raise InvalidStripeTransactionDataError(
                 f"Contribution {contribution.id} has no donation page associated with it"
             )
-        for x in self.charges:
-            upsert_payment_for_transaction(contribution, x.balance_transaction, is_refund=False)
-        for x in self.refunds:
-            upsert_payment_for_transaction(contribution, x.balance_transaction, is_refund=True)
-        return contribution, action
+        match action:
+            case "created":
+                self.created_contribution_ids.add(contribution.id)
+            case "updated":
+                self.updated_contribution_ids.add(contribution.id)
+            case _:
+                pass
+        self.upsert_payments(charges=self.charges, refunds=self.refunds, contribution=contribution)
 
 
 @dataclass
@@ -435,8 +487,13 @@ class StripeTransactionsImporter:
     to_date: datetime.datetime = None
 
     def __post_init__(self) -> None:
-        self._SUBSCRIPTIONS_DATA = {}
-        self._ONE_TIMES_DATA = []
+        self.payment_intents_processed = 0
+        self.subscriptions_processed = 0
+        self.created_contribution_ids = set()
+        self.updated_contribution_ids = set()
+        self.created_contributor_ids = set()
+        self.created_payment_ids = set()
+        self.updated_payment_ids = set()
 
     @property
     def created_query(self) -> dict:
@@ -468,18 +525,12 @@ class StripeTransactionsImporter:
             ).auto_paging_iter()
         ]
 
-    def get_payment_intents(self) -> list[stripe.PaymentIntent]:
-        """Gets payment intents for a given stripe account
-
-        NB: This method only lets through payment intents that have a supported schema version.
-        """
+    def get_payment_intents(self) -> Iterable[stripe.PaymentIntent]:
+        """Gets payment intents for a given stripe account"""
         logger.debug("Getting payment intents for account %s", self.stripe_account_id)
-        return [
-            x
-            for x in stripe.PaymentIntent.list(
-                stripe_account=self.stripe_account_id, limit=MAX_STRIPE_RESPONSE_LIMIT, created=self.created_query
-            ).auto_paging_iter()
-        ]
+        return stripe.PaymentIntent.list(
+            stripe_account=self.stripe_account_id, limit=MAX_STRIPE_RESPONSE_LIMIT, created=self.created_query
+        ).auto_paging_iter()
 
     @staticmethod
     def is_for_one_time_contribution(pi: stripe.PaymentIntent, invoice: stripe.Invoice | None) -> bool:
@@ -529,52 +580,7 @@ class StripeTransactionsImporter:
         """Retrieve a stripe payment intent for a given stripe account"""
         return self.get_stripe_entity(entity_id=entity_id, entity_name="PaymentIntent", expand=("payment_method",))
 
-    def handle_recurring_contribution_data(
-        self,
-        subscription: stripe.Subscription,
-        charges: list[stripe.Charge],
-        refunds: list[stripe.Refund],
-        customer: stripe.Customer,
-    ) -> None:
-        """Assemble upsert data for a given stripe subscription. This will utlimately get used to initialize a `SubscriptionForRecurringContribution` object."""
-        if subscription.metadata.get("schema_version", None) not in STRIPE_PAYMENT_METADATA_SCHEMA_VERSIONS:
-            logger.debug("Skipping subscription %s because it has an unsupported schema version", subscription.id)
-            return
-        if subscription.id not in self._SUBSCRIPTIONS_DATA:
-            self._SUBSCRIPTIONS_DATA[subscription.id] = {
-                "subscription": subscription,
-                "charges": charges,
-                "refunds": refunds,
-                "customer": customer,
-            }
-        else:
-            self._SUBSCRIPTIONS_DATA[subscription.id]["charges"].extend(charges)
-            self._SUBSCRIPTIONS_DATA[subscription.id]["refunds"].extend(refunds)
-
-    def handle_one_time_contribution_data(
-        self,
-        payment_intent_id: str,
-        charges: list[stripe.Charge],
-        refunds: list[stripe.Refund],
-        customer: stripe.Customer,
-    ) -> None:
-        """Assemble upsert data for a given stripe payment intent. This will ultimately get used to initialize a `PaymentIntentForOneTimeContribution` object."""
-        # we re-retrieve the payment intent here in case of one-time because we need to get the payment method, and the PI
-        # sent as arg is retrieved via list api, where it's not possible to expand payment method
-        pi = self.get_payment_intent(entity_id=payment_intent_id)
-        if pi.metadata.get("schema_version", None) not in STRIPE_PAYMENT_METADATA_SCHEMA_VERSIONS:
-            logger.debug("Skipping payment intent %s because it has an unsupported schema version", pi.id)
-            return
-        self._ONE_TIMES_DATA.append(
-            {
-                "payment_intent": pi,
-                "charges": charges,
-                "refunds": refunds,
-                "customer": customer,
-            }
-        )
-
-    def assemble_data_for_pi(self, payment_intent: stripe.PaymentIntent) -> None:
+    def assemble_data_for_pi(self, payment_intent: stripe.PaymentIntent) -> Dict[str, Any]:
         """Assemble data for a given stripe payment intent"""
         logger.debug("Assembling data for payment intent %s", payment_intent.id)
         charges = self.get_charges_for_payment_intent(payment_intent_id=payment_intent.id)
@@ -583,25 +589,58 @@ class StripeTransactionsImporter:
             refunds.extend([x for x in charge.refunds.data])
         customer = self.get_stripe_customer(entity_id=payment_intent.customer)
         invoice = self.get_invoice(entity_id=payment_intent.invoice) if payment_intent.invoice else None
+        data = {
+            "charges": charges,
+            "refunds": refunds,
+            "customer": customer,
+        }
         if self.is_for_one_time_contribution(payment_intent, invoice):
-            self.handle_one_time_contribution_data(
-                payment_intent_id=payment_intent.id, charges=charges, refunds=refunds, customer=customer
-            )
+            # we re-retrieve the payment intent here in case of one-time because we need to get the expanded payment method, and the PI
+            # sent as arg is retrieved via list api, where it's not possible to expand payment method
+            pi = self.get_payment_intent(entity_id=payment_intent.id)
+            data = data | {"payment_intent": pi}
         else:
-            self.handle_recurring_contribution_data(
-                subscription=invoice.subscription, charges=charges, refunds=refunds, customer=customer
-            )
+            data = data | {"subscription": invoice.subscription}
+        return data
 
     def import_contributions_and_payments(self) -> None:
         """This method is responsible for upserting contributors, contributions, and payments for a given stripe account."""
+        logger.info("Retrieving all revengine-related payment intents for stripe account %s", self.stripe_account_id)
+        for pi in self.get_payment_intents():
+            data = self.assemble_data_for_pi(pi)
+            try:
+                self.upsert_transaction(data=data)
+            except InvalidStripeTransactionDataError as exc:
+                if data.get("payment_intent", None):
+                    entity = data["payment_intent"]
+                    entity_name = "Payment intent"
+                else:
+                    entity = data["subscription"]
+                    entity_name = "Subscription"
+                logger.debug("Unable to upsert %s %s", entity_name, entity.id, exc_info=exc)
+                continue
+            if "payment_intent" in data:
+                self.payment_intents_processed += 1
+            else:
+                self.subscriptions_processed += 1
+
         logger.info(
-            "Retrieving all revengine-related payment intents for stripe account %s. This may take several minutes.",
-            self.stripe_account_id,
+            (
+                "Here's what happened: \n"
+                "%s Stripe payment intents for one-time contributions were processed.\n"
+                "%s Stripe subscriptions for recurring contributions were processed.\n"
+                "%s contributions were created and %s were updated.\n"
+                "%s payments were created and %s were updated.\n"
+                "%s contributors were created."
+            ),
+            self.payment_intents_processed,
+            self.subscriptions_processed,
+            len(self.created_contribution_ids),
+            len(self.updated_contribution_ids),
+            len(self.created_payment_ids),
+            len(self.updated_payment_ids),
+            len(self.created_contributor_ids),
         )
-        pis = self.get_payment_intents()
-        for pi in pis:
-            self.assemble_data_for_pi(pi)
-        self.upsert_data()
 
     def upsert_one_time_contribution(self, data: dict) -> Tuple[Contribution, str]:
         """Upsert a one-time contribution for a given stripe payment intent and related data"""
@@ -614,51 +653,17 @@ class StripeTransactionsImporter:
         )
         return contribution, action
 
-    def upsert_recurring_contribution(self, data: dict) -> Tuple[Contribution, str]:
-        """Upsert a recurring contribution for a given stripe subscription and related data"""
-        contribution, action = SubscriptionForRecurringContribution(**data).upsert()
-        logger.info(
-            "%s contribution %s for stripe subscription with ID %s",
-            action,
-            contribution.id,
-            data["subscription"].id,
-        )
-        return contribution, action
-
-    def upsert_data(self) -> None:
-        """Upsert all relevant stripe transactions data to revengine for a given stripe account."""
-        total_count = len(self._ONE_TIMES_DATA) + len(self._SUBSCRIPTIONS_DATA)
-        created_count = 0
-        updated_count = 0
-        for x in [(item, "upsert_one_time_contribution") for item in self._ONE_TIMES_DATA] + [
-            (item, "upsert_recurring_contribution") for item in self._SUBSCRIPTIONS_DATA.values()
-        ]:
-            data, method = x
-            try:
-                _, action = getattr(self, method)(data)
-            except (InvalidStripeTransactionDataError, InvalidMetadataError, InvalidIntervalError) as exc:
-                logger.warning(
-                    "Unable to upsert %s contribution data for %s %s for stripe account %s",
-                    "one-time" if method == "upsert_one_time_contribution" else "recurring",
-                    "payment intent" if method == "upsert_one_time_contribution" else "subscription",
-                    data["payment_intent"].id if method == "upsert_one_time_contribution" else data["subscription"].id,
-                    self.stripe_account_id,
-                    exc_info=exc,
-                )
-                continue
-            match action:
-                case "created":
-                    created_count += 1
-                case "updated":
-                    updated_count += 1
-                case _:
-                    pass
-        logger.info(
-            "Out of %s Stripe subscriptions and one-time payment intents, %s were created and %s were updated",
-            total_count,
-            created_count,
-            updated_count,
-        )
+    def upsert_transaction(self, data: Dict[str, Any]) -> None:
+        handler = (
+            PaymentIntentForOneTimeContribution if "payment_intent" in data else SubscriptionForRecurringContribution
+        )(**data)
+        handler.upsert()
+        logger.info(handler.get_effects_string())
+        self.created_contribution_ids |= handler.created_contribution_ids
+        self.updated_contribution_ids |= handler.updated_contribution_ids
+        self.created_payment_ids |= handler.created_payment_ids
+        self.updated_payment_ids |= handler.updated_payment_ids
+        self.created_contributor_ids |= handler.created_contributor_ids
 
 
 @dataclass(frozen=True)

--- a/apps/contributions/tasks.py
+++ b/apps/contributions/tasks.py
@@ -209,7 +209,7 @@ def process_stripe_webhook_task(self, raw_event_data: dict) -> None:
         logger.info("Could not find contribution. Here's the event data: %s", event, exc_info=True)
 
 
-@shared_task(bind=True, autoretry_for=(RateLimitError,), retry_backoff=True, retry_kwargs={"max_retries": 3})
+@shared_task(bind=True)
 def task_import_contributions_and_payments_for_stripe_account(
     self,
     from_date: str,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR refactors the Stripe import code so we do not use an excessive amount of memory. It does this by collecting required data and upserting transactions one a time instead of retrieving all required data, storing in memory, and then upserting all transactions at the end.

Some specific changes:

- Adds `apps.common.utils.stripe_call_with_backoff` which can be used to make Stripe API calls that will retry with exponential backoff if Stripe returns a rate limit error. I encountered a Stripe rate limit error one time when running this code in the review app, which prompted this change.
- No longer "unravels" the iterable returned by .`auto_paging_iter` in place in methods that use `.list` methods from Stripe. This means that we don't retrieve all list items up front.
- Removes `StripeTransactionsImporter.get_stripe_event` and related test because this method was not actually used anywhere.

#### Why are we doing this? How does it help us?

Make stripe transactions data importer usable, and thus unblock new portal.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-4638](https://news-revenue-hub.atlassian.net/browse/DEV-4638)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No

[DEV-4638]: https://news-revenue-hub.atlassian.net/browse/DEV-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ