### PR TITLE
DEV-4644 | fix bug around payment creation, remove unused method

### DIFF
--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -503,7 +503,10 @@ class StripeTransactionsImporter:
         return {k: v for k, v in {"gte": self.from_date, "lte": self.to_date}.items() if v}
 
     def get_charges_for_payment_intent(self, payment_intent_id: str) -> Iterable[stripe.Charge]:
-        """Gets charges for a given stripe payment intent"""
+        """Gets charges for a given stripe payment intent
+
+        NB: This method returns an exhaustible iterator, and its results can only be consumed once.
+        """
         logger.debug("Getting charges for payment intent %s", payment_intent_id)
         return stripe_call_with_backoff(
             stripe.Charge.list,
@@ -514,7 +517,10 @@ class StripeTransactionsImporter:
         ).auto_paging_iter()
 
     def get_payment_intents(self) -> Iterable[stripe.PaymentIntent]:
-        """Gets payment intents for a given stripe account"""
+        """Gets payment intents for a given stripe account
+
+        NB: This method returns an exhaustible iterator, and its results can only be consumed once.
+        """
         logger.debug("Getting payment intents for account %s", self.stripe_account_id)
         return stripe_call_with_backoff(
             stripe.PaymentIntent.list,

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -576,7 +576,9 @@ class StripeTransactionsImporter:
     def assemble_data_for_pi(self, payment_intent: stripe.PaymentIntent) -> Dict[str, Any]:
         """Assemble data for a given stripe payment intent"""
         logger.debug("Assembling data for payment intent %s", payment_intent.id)
-        charges = self.get_charges_for_payment_intent(payment_intent_id=payment_intent.id)
+        # NB: The value returned by .get_charges_for_payment_intent is a generator, and in this case, we want to go ahead
+        # and get all the results. The number of charges for a single payment intent will be low so there's no danger of running out of memory.
+        charges = list(self.get_charges_for_payment_intent(payment_intent_id=payment_intent.id))
         refunds = []
         for charge in charges:
             refunds.extend([x for x in charge.refunds.data])
@@ -634,17 +636,6 @@ class StripeTransactionsImporter:
             len(self.updated_payment_ids),
             len(self.created_contributor_ids),
         )
-
-    def upsert_one_time_contribution(self, data: dict) -> Tuple[Contribution, str]:
-        """Upsert a one-time contribution for a given stripe payment intent and related data"""
-        contribution, action = PaymentIntentForOneTimeContribution(**data).upsert()
-        logger.info(
-            "%s contribution %s for stripe payment intent with ID %s",
-            action,
-            contribution.id,
-            data["payment_intent"].id,
-        )
-        return contribution, action
 
     def upsert_transaction(self, data: Dict[str, Any]) -> None:
         handler = (

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -831,9 +831,12 @@ class TestStripeTransactionsImporter:
     @pytest.mark.parametrize("invoice", ["invoice_with_subscription", "invoice_without_subscription"])
     def test_assemble_data_for_pi(self, payment_intent, mocker, customer, invoice, request, charge_with_refund):
         invoice = request.getfixturevalue(invoice)
+        charges = (x for x in [charge_with_refund])
+        # want this to be an generator, as that what original method returns and there was a bug caused by treating it like
+        # a list in DEV-4644
         mocker.patch(
             "apps.contributions.stripe_import.StripeTransactionsImporter.get_charges_for_payment_intent",
-            return_value=[charge_with_refund],
+            return_value=charges,
         )
         mocker.patch(
             "apps.contributions.stripe_import.StripeTransactionsImporter.get_stripe_customer",

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -832,7 +832,7 @@ class TestStripeTransactionsImporter:
     def test_assemble_data_for_pi(self, payment_intent, mocker, customer, invoice, request, charge_with_refund):
         invoice = request.getfixturevalue(invoice)
         charges = (x for x in [charge_with_refund])
-        # want this to be an generator, as that what original method returns and there was a bug caused by treating it like
+        # want this to be a generator, as that what original method returns and there was a bug caused by treating it like
         # a list in DEV-4644
         mocker.patch(
             "apps.contributions.stripe_import.StripeTransactionsImporter.get_charges_for_payment_intent",

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -899,12 +899,6 @@ class TestStripeTransactionsImporter:
             )
         StripeTransactionsImporter(stripe_account_id="test").import_contributions_and_payments()
 
-    def test_upsert_one_time_contribution(self, mocker, payment_intent):
-        mock_pi_class = mocker.patch("apps.contributions.stripe_import.PaymentIntentForOneTimeContribution")
-        mock_pi_class.return_value.upsert.return_value = (result := (mocker.Mock(id="pi_foo"), "action"))
-        instance = StripeTransactionsImporter(stripe_account_id="test")
-        assert instance.upsert_one_time_contribution({"payment_intent": payment_intent}) == result
-
     @pytest.fixture
     def subscription_upsert_data(self, subscription, customer):
         return {"subscription": subscription, "charges": [], "refunds": [], "customer": customer}

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -831,9 +831,9 @@ class TestStripeTransactionsImporter:
     @pytest.mark.parametrize("invoice", ["invoice_with_subscription", "invoice_without_subscription"])
     def test_assemble_data_for_pi(self, payment_intent, mocker, customer, invoice, request, charge_with_refund):
         invoice = request.getfixturevalue(invoice)
-        charges = (x for x in [charge_with_refund])
-        # want this to be a generator, as that what original method returns and there was a bug caused by treating it like
+        # We want this to be a generator, as that is what original method returns and there was a bug caused by treating it like
         # a list in DEV-4644
+        charges = (x for x in [charge_with_refund])
         mocker.patch(
             "apps.contributions.stripe_import.StripeTransactionsImporter.get_charges_for_payment_intent",
             return_value=charges,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Fixes a bug in import stripe transactions code that caused payments to not be created or updated.

Specifically, the bug stemmed from attempting to iterate results of a generator (charges returned by using stripe.Charge.list.auto_paging_iter) more than once. On the second time through the generator was empty, and that second run through was what fed the charges that are used to attempt to create payments.

Additionally, this PR removes a method that was no longer used that I missed removing in DEV-4638.

#### Why are we doing this? How does it help us?

Makes import transactions data command usable. Unblocks portal.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes: current test updated to have mock return a generator instead of a list, to better capture actual implementation

#### How should this change be communicated to end users?

#### Are there any smells or added technical debt to note?

#### Has this been documented? If so, where?

#### What are the relevant tickets? Add a link to any relevant ones.

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
