### PR TITLE
DEV-4645 | add option to backfill command to skip updates of payment and contributions only do inserts for speed

### DIFF
--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -1,7 +1,5 @@
 import logging
-import random
 import re
-import time
 from typing import List, Tuple
 
 from django.conf import settings
@@ -198,18 +196,3 @@ def upsert_with_diff_check(
                 reversion.set_comment(f"{caller_name} updated {model.__name__}")
 
         return instance, "created" if created else "updated" if bool(fields_to_update) else "left unchanged"
-
-
-def stripe_call_with_backoff(callable, *args, **kwargs):
-    max_retries = 5
-    base_delay = 1  # seconds
-
-    for attempt in range(max_retries):
-        try:
-            return callable(*args, **kwargs)
-        except stripe.error.RateLimitError:
-            if attempt == max_retries - 1:
-                raise
-            delay = base_delay * (2**attempt) + random.uniform(0, base_delay)
-            logger.info("Rate limit exceeded, retrying in %s seconds...", delay)
-            time.sleep(delay)

--- a/apps/contributions/management/commands/import_stripe_transactions_data.py
+++ b/apps/contributions/management/commands/import_stripe_transactions_data.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
             help="Optional comma-separated list of stripe accounts to limit to",
         )
         parser.add_argument("--async-mode", action="store_true", default=False)
+        parser.add_argument("--skip-one-times-with-payment", action="store_true", default=False)
 
     def get_stripe_account_ids(self, for_orgs: list[str], for_stripe_accounts: list[str]) -> list[str]:
         query = PaymentProvider.objects.filter(stripe_account_id__isnull=False)
@@ -68,6 +69,7 @@ class Command(BaseCommand):
                     stripe_account_id=account,
                     from_date=int(options["gte"].timestamp()) if options["gte"] else None,
                     to_date=int(options["lte"].timestamp()) if options["lte"] else None,
+                    skip_one_times_with_payment=options["skip_one_times_with_payment"],
                 )
                 self.stdout.write(
                     self.style.SUCCESS(
@@ -79,6 +81,7 @@ class Command(BaseCommand):
                     from_date=options["gte"],
                     to_date=options["lte"],
                     stripe_account_id=account,
+                    skip_one_times_with_payment=options["skip_one_times_with_payment"],
                 ).import_contributions_and_payments()
                 self.stdout.write(self.style.SUCCESS(f"Import transactions for account {account} is done"))
 

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -217,7 +217,7 @@ class ContributionImportBaseClass(ABC):
     ) -> None:
         for x, is_refund in list(map(lambda y: (y, False), charges)) + list(map(lambda y: (y, True), refunds)):
             if not x or not getattr(x, "balance_transaction", None):
-                logger.warning(
+                logger.info(
                     "Data associated with contribution %s has no balance transaction associated with it. No payment will be created.",
                     contribution.id,
                 )

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -588,7 +588,7 @@ class StripeTransactionsImporter:
         refunds = []
         for charge in charges:
             refunds.extend([x for x in charge.refunds.data])
-        customer = self.get_stripe_customer(entity_id=payment_intent.customer)
+        customer = self.get_stripe_customer(entity_id=payment_intent.customer) if payment_intent.customer else None
         invoice = self.get_invoice(entity_id=payment_intent.invoice) if payment_intent.invoice else None
         data = {
             "charges": charges,

--- a/apps/contributions/tasks.py
+++ b/apps/contributions/tasks.py
@@ -215,17 +215,22 @@ def task_import_contributions_and_payments_for_stripe_account(
     from_date: str,
     to_date: str,
     stripe_account_id: str,
+    skip_one_times_with_payment: bool,
 ):
     """Task for syncing Stripe payment data to revengine."""
     logger.info(
-        "Running `task_import_contributions_and_payments_for_stripe_account` with params: from_date=%s, to_date=%s, stripe_account=%s",
+        "Running `task_import_contributions_and_payments_for_stripe_account` with params: from_date=%s, to_date=%s, stripe_account=%s, skip_one_times_with_payment=%s",
         from_date,
         to_date,
         stripe_account_id,
+        skip_one_times_with_payment,
     )
     from_date = datetime.fromtimestamp(int(from_date)) if from_date else None
     to_date = datetime.fromtimestamp(int(to_date)) if to_date else None
     StripeTransactionsImporter(
-        from_date=from_date, to_date=to_date, stripe_account_id=stripe_account_id
+        from_date=from_date,
+        to_date=to_date,
+        stripe_account_id=stripe_account_id,
+        skip_one_times_with_payment=skip_one_times_with_payment,
     ).import_contributions_and_payments()
     logger.info("`task_import_contributions_and_payments` is done")

--- a/apps/contributions/tests/test_tasks.py
+++ b/apps/contributions/tests/test_tasks.py
@@ -428,5 +428,5 @@ def test_process_stripe_webhook_task_when_contribution_not_exist_error(payment_i
 def test_task_import_contributions_and_payments_for_stripe_account(mocker):
     mocker.patch("apps.contributions.stripe_import.StripeTransactionsImporter.import_contributions_and_payments")
     contribution_tasks.task_import_contributions_and_payments_for_stripe_account(
-        from_date="", to_date="", stripe_account_id=""
+        from_date="", to_date="", stripe_account_id="", skip_one_times_with_payment=False
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -124,6 +124,17 @@ tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
 tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "bandit"
 version = "1.7.8"
 description = "Security oriented static analyser for python code."
@@ -3299,4 +3310,4 @@ bandit = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "753691870ea6af676640edd07a12a109b341504ec492d70133e8d1cfad7dc494"
+content-hash = "60700a3479dbbeffb7cee6232387bd8de460a5ad3e9eef8a59879302d6bc5bfc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ pydantic = "^2.2.0"
 uwsgitop = "^0.11"
 dateparser = "^1.2.0"
 tldextract = "^5.1.1"
+backoff = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 appnope = "*"


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR adds an option to the Stripe transaction import command (defaulting to false) to skip processing for retrieved payment intents that already a.) have a corresponding contribution; and b.) have at least one payment for that corresponding contribution.

Additionally:

- Retires `stripe_call_with_backoff` in favor of using the (newly added) [backoff](https://pypi.org/project/backoff/) library for handling API rate limit errors from Stripe
- Changes log message from warning to info when a charge or refund is encountered that does not have a balance transaction. It turns out this is a normal/expected occurrence and we don't need this polluting Sentry.
- Solves for [DEV-4648](https://news-revenue-hub.atlassian.net/browse/DEV-4648) by no longer trying to retrieve a Stripe customer for a retrieved payment intent that has null value for the customer field.

#### Why are we doing this? How does it help us?

- Speed of Stripe transaction import so it will be faster to get to new portal release
- Cleanup some other issues along the way

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-4645](https://news-revenue-hub.atlassian.net/browse/DEV-4645)
- [DEV-4648](https://news-revenue-hub.atlassian.net/browse/DEV-4648)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A

[DEV-4648]: https://news-revenue-hub.atlassian.net/browse/DEV-4648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-4645]: https://news-revenue-hub.atlassian.net/browse/DEV-4645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ