### PR TITLE
Dev 4660 stripe data import fails when 1 charge with same balance transaction

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -204,7 +204,7 @@ class Contribution(IndexedTimeStampedModel):
         ]
 
     def __str__(self):
-        return f"{self.formatted_amount}, {self.created.strftime('%Y-%m-%d %H:%M:%S')}"
+        return f"Contribution #{self.id} {self.formatted_amount}, {self.created.strftime('%Y-%m-%d %H:%M:%S')}"
 
     @property
     def next_payment_date(self) -> datetime.datetime | None:

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, Tuple
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
 
 import backoff
 import reversion
@@ -60,17 +60,35 @@ def upsert_payment_for_transaction(
         (getattr(transaction, "id", "<no transaction>")),
     )
     if transaction:
-        payment, action = upsert_with_diff_check(
-            model=Payment,
-            unique_identifier={"contribution": contribution, "stripe_balance_transaction_id": transaction.id},
-            defaults={
-                "net_amount_paid": transaction.net if not is_refund else 0,
-                "gross_amount_paid": transaction.amount if not is_refund else 0,
-                "amount_refunded": transaction.amount if is_refund else 0,
-                "transaction_time": datetime.datetime.fromtimestamp(int(transaction.created), tz=datetime.timezone.utc),
-            },
-            caller_name="upsert_payment_for_transaction",
-        )
+        try:
+            payment, action = upsert_with_diff_check(
+                model=Payment,
+                unique_identifier={"contribution": contribution, "stripe_balance_transaction_id": transaction.id},
+                defaults={
+                    "net_amount_paid": transaction.net if not is_refund else 0,
+                    "gross_amount_paid": transaction.amount if not is_refund else 0,
+                    "amount_refunded": transaction.amount if is_refund else 0,
+                    "transaction_time": datetime.datetime.fromtimestamp(
+                        int(transaction.created), tz=datetime.timezone.utc
+                    ),
+                },
+                caller_name="upsert_payment_for_transaction",
+            )
+        # There is an infrequently occurring edge case. If it happens, we should log exception so record in Sentry, and
+        # then move on. See DEV-4666 for more detail.
+        except IntegrityError:
+            existing = Payment.objects.filter(stripe_balance_transaction_id=transaction.id).first()
+            logger.exception(
+                (
+                    "Integrity error occurred while upserting payment with balance transaction %s for contribution %s "
+                    "The existing payment is %s for contribution %s"
+                ),
+                transaction.id,
+                contribution.id,
+                existing.id if existing else None,
+                existing.contribution.id if existing else None,
+            )
+            return None, None
         logger.info("%s payment %s for contribution %s", action, payment.id, contribution.id)
         return payment, action
     else:
@@ -592,7 +610,7 @@ class StripeTransactionsImporter:
 
     def assemble_data_for_pi(self, payment_intent: stripe.PaymentIntent) -> Dict[str, Any]:
         """Assemble data for a given stripe payment intent"""
-        logger.debug("Assembling data for payment intent %s", payment_intent.id)
+        logger.info("Assembling data for payment intent %s", payment_intent.id)
         # NB: The value returned by .get_charges_for_payment_intent is a generator, and in this case, we want to go ahead
         # and get all the results. The number of charges for a single payment intent will be low so there's no danger of running out of memory.
         charges = list(self.get_charges_for_payment_intent(payment_intent_id=payment_intent.id))

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -182,7 +182,7 @@ class TestContributionModel:
     def test_str(self, one_time_contribution):
         assert (
             str(one_time_contribution)
-            == f"{one_time_contribution.formatted_amount}, {one_time_contribution.created.strftime('%Y-%m-%d %H:%M:%S')}"
+            == f"Contribution #{one_time_contribution.id} {one_time_contribution.formatted_amount}, {one_time_contribution.created.strftime('%Y-%m-%d %H:%M:%S')}"
         )
 
     @pytest.mark.parametrize(

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -260,7 +260,7 @@ class Test_upsert_payment_for_transaction:
         )
         logger_spy = mocker.patch("apps.contributions.stripe_import.logger.exception")
         count = Payment.objects.count()
-        upsert_payment_for_transaction(contribution=contribution, transaction=balance_transaction)
+        payment, action = upsert_payment_for_transaction(contribution=contribution, transaction=balance_transaction)
         assert Payment.objects.count() == count
         logger_spy.assert_called_once_with(
             (
@@ -272,6 +272,8 @@ class Test_upsert_payment_for_transaction:
             existing_payment.id,
             different_contribution.id,
         )
+        assert payment is None
+        assert action is None
 
 
 @pytest.mark.django_db

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -16,6 +16,7 @@ from apps.contributions.models import (
     ContributionInterval,
     ContributionStatus,
     Contributor,
+    Payment,
 )
 from apps.contributions.stripe_import import (
     MAX_STRIPE_RESPONSE_LIMIT,
@@ -251,6 +252,26 @@ class Test_upsert_payment_for_transaction:
         mock_upsert.assert_not_called()
         assert payment is None
         assert action is None
+
+    def test_when_integrity_error(self, contribution, balance_transaction, mocker):
+        different_contribution = ContributionFactory()
+        existing_payment = PaymentFactory(
+            contribution=different_contribution, stripe_balance_transaction_id=balance_transaction.id
+        )
+        logger_spy = mocker.patch("apps.contributions.stripe_import.logger.exception")
+        count = Payment.objects.count()
+        upsert_payment_for_transaction(contribution=contribution, transaction=balance_transaction)
+        assert Payment.objects.count() == count
+        logger_spy.assert_called_once_with(
+            (
+                "Integrity error occurred while upserting payment with balance transaction %s for contribution %s "
+                "The existing payment is %s for contribution %s"
+            ),
+            balance_transaction.id,
+            contribution.id,
+            existing_payment.id,
+            different_contribution.id,
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR solves for a bug that caused the Stripe transactions import command to fail when it encountered a balance transaction that was already associated with an existing contribution. Because `stripe_balance_transaction_id` has a uniqueness constraint, that caused the upsert to fail, and the exception was not caught, so it crashed the command.

This PR narrowly addresses the uncaught exception, making it caught, and logging. It is up to a different tickets (DEV-4609 / DEV-4666) to solve for the root cause.

Additionally, this PR makes a small change to `Contribution.__str__` — adding the contribution id to its string representation — because that would have been helpful when running down this bug.

#### Why are we doing this? How does it help us?

Unblock data import, which unblocks portal.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Not as such. This needs to be tested in prod against the account that was causing this to happen.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

N/A

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-4660](https://news-revenue-hub.atlassian.net/browse/DEV-4660)
- [DEV-4609](https://news-revenue-hub.atlassian.net/browse/DEV-4609)
- [DEV-4666](https://news-revenue-hub.atlassian.net/browse/DEV-4666)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:


No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No


[DEV-4660]: https://news-revenue-hub.atlassian.net/browse/DEV-4660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ