### PR TITLE
DEV-3878: Add send contribution receipt endpoint

### DIFF
--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -253,7 +253,7 @@ class TestContributionsViewSet:
         return request.getfixturevalue(request.param) if request.param else None
 
     def test_retrieve_when_unauthorized_user(self, api_client, contribution, unauthorized_user):
-        """Show behavior when an unauthorized user trise to retrieve a contribution"""
+        """Show behavior when an unauthorized user tries to retrieve a contribution"""
         api_client.force_authenticate(unauthorized_user)
         response = api_client.get(reverse("contribution-detail", args=(contribution.id,)))
         assert response.status_code == status.HTTP_403_FORBIDDEN if unauthorized_user else status.HTTP_401_UNAUTHORIZED
@@ -1540,6 +1540,36 @@ class TestPortalContributorsViewSet:
         return contribution
 
     @pytest.fixture
+    def yearly_contribution(
+        self,
+        revenue_program,
+        portal_contributor,
+        faker,
+        stripe_subscription,
+    ):
+        then = datetime.now() - timedelta(days=365)
+        contribution = ContributionFactory(
+            interval=ContributionInterval.YEARLY,
+            status=ContributionStatus.PAID,
+            created=then,
+            donation_page__revenue_program=revenue_program,
+            contributor=portal_contributor,
+            provider_payment_id=faker.pystr_format(string_format="pi_??????"),
+            provider_customer_id=faker.pystr_format(string_format="cus_??????"),
+            provider_subscription_id=stripe_subscription.id,
+            provider_payment_method_id=faker.pystr_format(string_format="pm_??????"),
+        )
+        for x in (then, then + timedelta(days=365)):
+            PaymentFactory(
+                created=x,
+                contribution=contribution,
+                amount_refunded=0,
+                gross_amount_paid=contribution.amount,
+                net_amount_paid=contribution.amount - 100,
+            )
+        return contribution
+
+    @pytest.fixture
     def portal_contributor(self):
         return ContributorFactory()
 
@@ -1547,6 +1577,7 @@ class TestPortalContributorsViewSet:
     def portal_contributor_with_multiple_contributions(
         self,
         portal_contributor,
+        yearly_contribution,
         monthly_contribution,
         one_time_contribution,
         stripe_customer_factory,
@@ -1556,6 +1587,8 @@ class TestPortalContributorsViewSet:
         cust_id = monthly_contribution.provider_customer_id
         one_time_contribution.provider_customer_id = cust_id
         one_time_contribution.save()
+        yearly_contribution.provider_customer_id = cust_id
+        yearly_contribution.save()
 
         mock_customer_retrieve = mocker.patch(
             "stripe.Customer.retrieve",
@@ -1599,7 +1632,7 @@ class TestPortalContributorsViewSet:
         response = api_client.get(reverse("portal-contributor-contributions-list", args=(contributor.id,)))
         assert response.status_code == status.HTTP_200_OK
         assert set(response.json().keys()) == {"count", "next", "previous", "results"}
-        assert len(response.json()["results"]) == 2
+        assert len(response.json()["results"]) == 3
         assert set(x["id"] for x in response.json()["results"]) == set(
             contributor.contribution_set.all().values_list("id", flat=True)
         )
@@ -1634,9 +1667,13 @@ class TestPortalContributorsViewSet:
             + f"?status={ContributionStatus.PAID}"
         )
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()["results"]) == 1
+        assert len(response.json()["results"]) == 2
         assert (
             response.json()["results"][0]["id"]
+            == contributor.contribution_set.filter(status=ContributionStatus.PAID).last().id
+        )
+        assert (
+            response.json()["results"][1]["id"]
             == contributor.contribution_set.filter(status=ContributionStatus.PAID).first().id
         )
 
@@ -1680,7 +1717,13 @@ class TestPortalContributorsViewSet:
         for index, x in enumerate(Contribution.objects.all()):
             x.amount = amount
             amount += 1000
-            x.status = ContributionStatus.PAID.label if index % 2 == 0 else ContributionStatus.FAILED.label
+            match index:
+                case 0:
+                    x.status = ContributionStatus.PAID.label
+                case 1:
+                    x.status = ContributionStatus.FAILED.label
+                case 2:
+                    x.status = ContributionStatus.FLAGGED.label
             x.payment_set.all().update(gross_amount_paid=x.amount, net_amount_paid=x.amount - 100)
             x.save()
         api_client.force_authenticate(contributor)
@@ -1711,7 +1754,13 @@ class TestPortalContributorsViewSet:
         for index, x in enumerate(Contribution.objects.all()):
             x.amount = amount
             amount += 1000
-            x.status = ContributionStatus.PAID.label if index % 2 == 0 else ContributionStatus.FAILED.label
+            match index:
+                case 0:
+                    x.status = ContributionStatus.PAID.label
+                case 1:
+                    x.status = ContributionStatus.FAILED.label
+                case 2:
+                    x.status = ContributionStatus.FLAGGED.label
             x.payment_set.all().update(gross_amount_paid=x.amount, net_amount_paid=x.amount - 100)
             # Create identical contribution with different date (test second field ordering by date)
             Contribution.objects.create(amount=x.amount, status=x.status, contributor=contributor)
@@ -1797,6 +1846,7 @@ class TestPortalContributorsViewSet:
         self,
         status,
         api_client,
+        yearly_contribution,
         monthly_contribution,
         one_time_contribution,
         portal_contributor_with_multiple_contributions,
@@ -1806,8 +1856,9 @@ class TestPortalContributorsViewSet:
         one_time_contribution.save()
         api_client.force_authenticate(contributor)
         response = api_client.get(reverse("portal-contributor-contributions-list", args=(contributor.id,)))
-        assert len(response.json()["results"]) == 1
-        assert response.json()["results"][0]["id"] == monthly_contribution.id
+        assert len(response.json()["results"]) == 2
+        assert response.json()["results"][0]["id"] == yearly_contribution.id
+        assert response.json()["results"][1]["id"] == monthly_contribution.id
 
     def test_contribution_detail_get_happy_path(
         self,
@@ -1913,6 +1964,85 @@ class TestPortalContributorsViewSet:
                     not_mine.id,
                 ),
             )
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {"detail": "Contribution not found"}
+
+    @pytest.mark.parametrize(
+        "interval",
+        (
+            ContributionInterval.ONE_TIME,
+            ContributionInterval.MONTHLY,
+            ContributionInterval.YEARLY,
+        ),
+    )
+    def test_contribution_send_receipt(
+        self,
+        interval,
+        api_client,
+        portal_contributor_with_multiple_contributions,
+        mocker,
+    ):
+        contributor = portal_contributor_with_multiple_contributions[0]
+        contribution = contributor.contribution_set.filter(interval=interval).first()
+        mock_send_receipt = mocker.patch("apps.contributions.models.Contribution.handle_thank_you_email")
+        api_client.force_authenticate(contributor)
+        response = api_client.post(
+            reverse("portal-contributor-contribution-receipt", args=(contributor.id, contribution.id))
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_send_receipt.assert_called_once()
+
+    def test_contribution_send_receipt_when_im_not_contributor(
+        self, portal_contributor_with_multiple_contributions, non_contributor_user, api_client, mocker
+    ):
+        contributor = portal_contributor_with_multiple_contributions[0]
+        api_client.force_authenticate(non_contributor_user)
+        response = api_client.post(
+            reverse(
+                "portal-contributor-contribution-receipt",
+                args=(
+                    contributor.id,
+                    contributor.contribution_set.first().id,
+                ),
+            ),
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_contribution_send_receipt_when_contribution_not_found(
+        self, api_client, portal_contributor_with_multiple_contributions
+    ):
+        contributor = portal_contributor_with_multiple_contributions[0]
+        deleted = contributor.contribution_set.first()
+        deleted_id = deleted.id
+        deleted.delete()
+        api_client.force_authenticate(contributor)
+        response = api_client.post(
+            reverse(
+                "portal-contributor-contribution-receipt",
+                args=(
+                    contributor.id,
+                    deleted_id,
+                ),
+            ),
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {"detail": "Contribution not found"}
+
+    def test_contribution_send_receipt_when_not_own_contribution(
+        self, api_client, portal_contributor_with_multiple_contributions
+    ):
+        contributor = portal_contributor_with_multiple_contributions[0]
+        not_mine = ContributionFactory()
+        api_client.force_authenticate(contributor)
+        response = api_client.post(
+            reverse(
+                "portal-contributor-contribution-receipt",
+                args=(
+                    contributor.id,
+                    not_mine.id,
+                ),
+            ),
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Contribution not found"}

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -586,7 +586,7 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
     # we need to set a queryset to satisfy DRF's viewset machinery
     queryset = Contributor.objects.all()
 
-    def exclude_hidden_statuses(self, queryset):
+    def exclude_hidden_statuses(self, queryset: QuerySet[Contribution]):
         return queryset.exclude(status__in=self.HIDDEN_STATUSES)
 
     def _get_contributor_and_check_permissions(self, request, contributor_id):
@@ -634,6 +634,24 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         )
         qs = self.handle_ordering(qs, request)
         return self.paginate_results(qs, request)
+
+    @action(
+        methods=["post"],
+        url_path="contributions/(?P<contribution_id>[^/.]+)/send-receipt",
+        url_name="contribution-receipt",
+        detail=True,
+        serializer_class=serializers.PortalContributionDetailSerializer,
+    )
+    def send_contribution_receipt(self, request, pk=None, contribution_id=None) -> Response:
+        """Endpoint to send a contribution receipt email for a given contributor"""
+        logger.info("send receipt with contribution_id %s", contribution_id)
+        contributor = self._get_contributor_and_check_permissions(request, pk)
+        try:
+            contribution = self.exclude_hidden_statuses(contributor.contribution_set).get(pk=contribution_id)
+        except Contribution.DoesNotExist:
+            return Response({"detail": "Contribution not found"}, status=status.HTTP_404_NOT_FOUND)
+        contribution.handle_thank_you_email()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(
         methods=["get", "patch", "delete"],

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -643,7 +643,7 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         serializer_class=serializers.PortalContributionDetailSerializer,
     )
     def send_contribution_receipt(self, request, pk=None, contribution_id=None) -> Response:
-        """Endpoint to send a contribution receipt email for a given contributor"""
+        """Endpoint to send a contribution receipt email for a given contribution"""
         logger.info("send receipt with contribution_id %s", contribution_id)
         contributor = self._get_contributor_and_check_permissions(request, pk)
         try:

--- a/spa/src/ajax/endpoints.ts
+++ b/spa/src/ajax/endpoints.ts
@@ -46,6 +46,10 @@ export function getContributionDetailEndpoint(contributorId: number, contributio
   return `/contributors/${contributorId}/contributions/${contributionId}/`;
 }
 
+export function getContributionSendEmailReceiptEndpoint(contributorId: number, contributionId: number) {
+  return `${getContributionDetailEndpoint(contributorId, contributionId)}send-receipt/`;
+}
+
 export const CONTRIBUTIONS = 'contributions/';
 export const EMAIL_CONTRIBUTIONS = 'email-contributions/';
 export const PROCESS_FLAGGED = 'process-flagged/';

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -1,17 +1,21 @@
-import PropTypes, { InferProps } from 'prop-types';
 import { Table, TableBody } from 'components/base';
 import { PortalContributionPayment } from 'hooks/usePortalContribution';
+import PropTypes, { InferProps } from 'prop-types';
 import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
-import { TableCell, TableHead, TableRow } from './BillingHistory.styled';
 import { DetailSection } from '../DetailSection';
+import { TableCell, TableHead, TableRow } from './BillingHistory.styled';
+import { SectionControlButton } from '../common.styled';
+import usePortal from 'hooks/usePortal';
 
 const BillingHistoryPropTypes = {
   disabled: PropTypes.bool,
-  payments: PropTypes.array.isRequired
+  payments: PropTypes.array.isRequired,
+  onSendEmailReceipt: PropTypes.func.isRequired
 };
 
 export interface BillingHistoryProps extends InferProps<typeof BillingHistoryPropTypes> {
   payments: PortalContributionPayment[];
+  onSendEmailReceipt: () => void;
 }
 
 const PAYMENT_STATUS_NAMES: Record<PortalContributionPayment['status'], string> = {
@@ -21,9 +25,18 @@ const PAYMENT_STATUS_NAMES: Record<PortalContributionPayment['status'], string> 
 
 const dateFormatter = Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'numeric', year: 'numeric' });
 
-export function BillingHistory({ disabled, payments }: BillingHistoryProps) {
+export function BillingHistory({ disabled, payments, onSendEmailReceipt }: BillingHistoryProps) {
+  const { page } = usePortal();
+  const sendNreEmail = page?.revenue_program?.organization?.send_receipt_email_via_nre;
+
   return (
-    <DetailSection disabled={disabled} title="Billing History">
+    <DetailSection
+      disabled={disabled}
+      title="Billing History"
+      controls={
+        sendNreEmail && <SectionControlButton onClick={onSendEmailReceipt}>Resend receipt</SectionControlButton>
+      }
+    >
       <Table>
         <TableHead>
           <TableRow>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/__mocks__/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/__mocks__/BillingHistory.tsx
@@ -1,6 +1,8 @@
 import { BillingHistoryProps } from '..';
 
-export const BillingHistory = ({ disabled, payments }: BillingHistoryProps) => (
-  <div data-testid="mock-billing-history" data-disabled={disabled} data-payments={JSON.stringify(payments)} />
+export const BillingHistory = ({ disabled, payments, onSendEmailReceipt }: BillingHistoryProps) => (
+  <div data-testid="mock-billing-history" data-disabled={disabled} data-payments={JSON.stringify(payments)}>
+    <button onClick={onSendEmailReceipt}>Resend receipt</button>
+  </div>
 );
 export default BillingHistory;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
@@ -38,7 +38,8 @@ describe('ContributionDetail', () => {
       isFetching: false,
       refetch: jest.fn(),
       cancelContribution: jest.fn(),
-      updateContribution: jest.fn()
+      updateContribution: jest.fn(),
+      sendEmailReceipt: jest.fn()
     });
 
     tree();
@@ -54,7 +55,8 @@ describe('ContributionDetail', () => {
         isFetching: false,
         refetch: jest.fn(),
         cancelContribution: jest.fn(),
-        updateContribution: jest.fn()
+        updateContribution: jest.fn(),
+        sendEmailReceipt: jest.fn()
       });
     });
 
@@ -84,7 +86,8 @@ describe('ContributionDetail', () => {
         isFetching: false,
         refetch: jest.fn(),
         cancelContribution: jest.fn(),
-        updateContribution: jest.fn()
+        updateContribution: jest.fn(),
+        sendEmailReceipt: jest.fn()
       });
     });
 
@@ -115,7 +118,8 @@ describe('ContributionDetail', () => {
         isFetching: false,
         refetch: jest.fn(),
         cancelContribution: jest.fn(),
-        updateContribution: jest.fn()
+        updateContribution: jest.fn(),
+        sendEmailReceipt: jest.fn()
       });
     });
 
@@ -142,6 +146,27 @@ describe('ContributionDetail', () => {
       const history = screen.getByTestId('mock-billing-history');
 
       expect(history.dataset.payments).toBe(JSON.stringify(mockContribution.payments));
+    });
+
+    it('calls sendEmailReceipt when the "Resend receipt" button is clicked', () => {
+      const sendEmailReceipt = jest.fn();
+      usePortalContributionMock.mockReturnValue({
+        isLoading: false,
+        contribution: mockContribution as any,
+        isError: false,
+        isFetching: false,
+        refetch: jest.fn(),
+        updateContribution: jest.fn(),
+        cancelContribution: jest.fn(),
+        sendEmailReceipt
+      });
+
+      tree();
+      expect(sendEmailReceipt).not.toHaveBeenCalled();
+
+      screen.getByText('Resend receipt').click();
+
+      expect(sendEmailReceipt).toBeCalledTimes(1);
     });
 
     it("doesn't disable any section initially", () => {
@@ -230,7 +255,8 @@ describe('ContributionDetail', () => {
           isFetching: false,
           refetch: jest.fn(),
           updateContribution: jest.fn(),
-          cancelContribution
+          cancelContribution,
+          sendEmailReceipt: jest.fn()
         });
 
         tree();

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
@@ -24,10 +24,8 @@ const ContributionDetailPropTypes = {
 export type ContributionDetailProps = InferProps<typeof ContributionDetailPropTypes>;
 
 export function ContributionDetail({ domAnchor, contributionId, contributorId }: ContributionDetailProps) {
-  const { cancelContribution, contribution, isError, isLoading, refetch, updateContribution } = usePortalContribution(
-    contributorId,
-    contributionId
-  );
+  const { cancelContribution, contribution, isError, isLoading, refetch, updateContribution, sendEmailReceipt } =
+    usePortalContribution(contributorId, contributionId);
   const [editableSection, setEditableSection] = useState<'paymentMethod'>();
 
   // We need to store the root element in state so that changes to it trigger
@@ -80,7 +78,11 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
             onEditComplete={() => setEditableSection(undefined)}
             onUpdatePaymentMethod={handlePaymentMethodUpdate}
           />
-          <BillingHistory disabled={!!editableSection} payments={contribution.payments} />
+          <BillingHistory
+            disabled={!!editableSection}
+            payments={contribution.payments}
+            onSendEmailReceipt={sendEmailReceipt}
+          />
           <Actions contribution={contribution} onCancelContribution={cancelContribution} />
         </Content>
       </Root>

--- a/spa/src/hooks/usePortalContribution.tsx
+++ b/spa/src/hooks/usePortalContribution.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getContributionDetailEndpoint } from 'ajax/endpoints';
+import { getContributionDetailEndpoint, getContributionSendEmailReceiptEndpoint } from 'ajax/endpoints';
 import axios from 'ajax/portal-axios';
 import { AxiosError } from 'axios';
 import SystemNotification from 'components/common/SystemNotification';
@@ -169,5 +169,37 @@ export function usePortalContribution(contributorId: number, contributionId: num
     [updateContributionMutation]
   );
 
-  return { contribution: data, isError, isFetching, isLoading, refetch, updateContribution, cancelContribution };
+  const sendEmailReceiptMutation = useMutation(
+    () => axios.post(getContributionSendEmailReceiptEndpoint(contributorId, contributionId)),
+    {
+      onError: () => {
+        enqueueSnackbar('Your receipt has failed to send to your email. Please wait and try again.', {
+          persist: true,
+          content: (key: string, message: string) => (
+            <SystemNotification id={key} message={message} header="Failed to Send" type="error" />
+          )
+        });
+      },
+      onSuccess: () => {
+        enqueueSnackbar('Your receipt has been sent to your email.', {
+          persist: true,
+          content: (key: string, message: string) => (
+            <SystemNotification id={key} message={message} header="Receipt Sent!" type="success" />
+          )
+        });
+      }
+    }
+  );
+  const sendEmailReceipt = useCallback(() => sendEmailReceiptMutation.mutateAsync(), [sendEmailReceiptMutation]);
+
+  return {
+    contribution: data,
+    isError,
+    isFetching,
+    isLoading,
+    refetch,
+    updateContribution,
+    cancelContribution,
+    sendEmailReceipt
+  };
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
Stacked PRs:
main <- [DEV-3878 <- DEV-3879](https://github.com/newsrevenuehub/rev-engine/pull/1492)

#### What's this PR do?
Adds endpoint for donors to send a receipt email from a contribution
#### Why are we doing this? How does it help us?
Allow for re-sending of receipts
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no
#### Have automated unit tests been added? If not, why?
yes
#### How should this change be communicated to end users?
n/a
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
no
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-3878
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
Yes, here is the parent ticket: https://news-revenue-hub.atlassian.net/browse/DEV-3782