### PR TITLE
DEV-3879: Implement "Resend Receipt" button in Portal

### DIFF
--- a/spa/src/ajax/endpoints.ts
+++ b/spa/src/ajax/endpoints.ts
@@ -46,6 +46,10 @@ export function getContributionDetailEndpoint(contributorId: number, contributio
   return `/contributors/${contributorId}/contributions/${contributionId}/`;
 }
 
+export function getContributionSendEmailReceiptEndpoint(contributorId: number, contributionId: number) {
+  return `${getContributionDetailEndpoint(contributorId, contributionId)}send-receipt/`;
+}
+
 export const CONTRIBUTIONS = 'contributions/';
 export const EMAIL_CONTRIBUTIONS = 'email-contributions/';
 export const PROCESS_FLAGGED = 'process-flagged/';

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
@@ -5,6 +5,7 @@ import { PortalContributionPayment } from 'hooks/usePortalContribution';
 
 jest.mock('../DetailSection/DetailSection');
 
+const sendEmailReceipt = jest.fn();
 const mockPayments: PortalContributionPayment[] = [
   {
     amount_refunded: 0,
@@ -23,7 +24,7 @@ const mockPayments: PortalContributionPayment[] = [
 ];
 
 function tree(props?: Partial<BillingHistoryProps>) {
-  return render(<BillingHistory payments={mockPayments} {...props} />);
+  return render(<BillingHistory sendEmailReceipt={sendEmailReceipt} payments={mockPayments} {...props} />);
 }
 
 describe('BillingHistory', () => {
@@ -80,6 +81,21 @@ describe('BillingHistory', () => {
 
     expect(within(rows[1]).getAllByRole('cell')[2]).toHaveTextContent('Paid');
     expect(within(rows[2]).getAllByRole('cell')[2]).toHaveTextContent('Refunded');
+  });
+
+  it('shows a resend receipt button', () => {
+    tree();
+
+    expect(screen.getByRole('button', { name: 'Resend receipt' })).toBeInTheDocument();
+  });
+
+  it('calls sendEmailReceipt when the resend receipt button is clicked', () => {
+    tree();
+    expect(sendEmailReceipt).not.toHaveBeenCalled();
+
+    screen.getByRole('button', { name: 'Resend receipt' }).click();
+
+    expect(sendEmailReceipt).toBeCalledTimes(1);
   });
 
   it('is accessible', async () => {

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -5,16 +5,17 @@ import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
 import { DetailSection } from '../DetailSection';
 import { TableCell, TableHead, TableRow } from './BillingHistory.styled';
 import { SectionControlButton } from '../common.styled';
+import usePortal from 'hooks/usePortal';
 
 const BillingHistoryPropTypes = {
   disabled: PropTypes.bool,
   payments: PropTypes.array.isRequired,
-  sendEmailReceipt: PropTypes.func.isRequired
+  onSendEmailReceipt: PropTypes.func.isRequired
 };
 
 export interface BillingHistoryProps extends InferProps<typeof BillingHistoryPropTypes> {
   payments: PortalContributionPayment[];
-  sendEmailReceipt: () => void;
+  onSendEmailReceipt: () => void;
 }
 
 const PAYMENT_STATUS_NAMES: Record<PortalContributionPayment['status'], string> = {
@@ -24,12 +25,17 @@ const PAYMENT_STATUS_NAMES: Record<PortalContributionPayment['status'], string> 
 
 const dateFormatter = Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'numeric', year: 'numeric' });
 
-export function BillingHistory({ disabled, payments, sendEmailReceipt }: BillingHistoryProps) {
+export function BillingHistory({ disabled, payments, onSendEmailReceipt }: BillingHistoryProps) {
+  const { page } = usePortal();
+  const sendNreEmail = page?.revenue_program?.organization?.send_receipt_email_via_nre;
+
   return (
     <DetailSection
       disabled={disabled}
       title="Billing History"
-      controls={<SectionControlButton onClick={sendEmailReceipt}>Resend receipt</SectionControlButton>}
+      {...(sendNreEmail && {
+        controls: <SectionControlButton onClick={onSendEmailReceipt}>Resend receipt</SectionControlButton>
+      })}
     >
       <Table>
         <TableHead>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -33,9 +33,9 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
     <DetailSection
       disabled={disabled}
       title="Billing History"
-      {...(sendNreEmail && {
-        controls: <SectionControlButton onClick={onSendEmailReceipt}>Resend receipt</SectionControlButton>
-      })}
+      controls={
+        sendNreEmail && <SectionControlButton onClick={onSendEmailReceipt}>Resend receipt</SectionControlButton>
+      }
     >
       <Table>
         <TableHead>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -1,17 +1,20 @@
-import PropTypes, { InferProps } from 'prop-types';
 import { Table, TableBody } from 'components/base';
 import { PortalContributionPayment } from 'hooks/usePortalContribution';
+import PropTypes, { InferProps } from 'prop-types';
 import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
-import { TableCell, TableHead, TableRow } from './BillingHistory.styled';
 import { DetailSection } from '../DetailSection';
+import { TableCell, TableHead, TableRow } from './BillingHistory.styled';
+import { SectionControlButton } from '../common.styled';
 
 const BillingHistoryPropTypes = {
   disabled: PropTypes.bool,
-  payments: PropTypes.array.isRequired
+  payments: PropTypes.array.isRequired,
+  sendEmailReceipt: PropTypes.func.isRequired
 };
 
 export interface BillingHistoryProps extends InferProps<typeof BillingHistoryPropTypes> {
   payments: PortalContributionPayment[];
+  sendEmailReceipt: () => void;
 }
 
 const PAYMENT_STATUS_NAMES: Record<PortalContributionPayment['status'], string> = {
@@ -21,9 +24,13 @@ const PAYMENT_STATUS_NAMES: Record<PortalContributionPayment['status'], string> 
 
 const dateFormatter = Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'numeric', year: 'numeric' });
 
-export function BillingHistory({ disabled, payments }: BillingHistoryProps) {
+export function BillingHistory({ disabled, payments, sendEmailReceipt }: BillingHistoryProps) {
   return (
-    <DetailSection disabled={disabled} title="Billing History">
+    <DetailSection
+      disabled={disabled}
+      title="Billing History"
+      controls={<SectionControlButton onClick={sendEmailReceipt}>Resend receipt</SectionControlButton>}
+    >
       <Table>
         <TableHead>
           <TableRow>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/__mocks__/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/__mocks__/BillingHistory.tsx
@@ -1,8 +1,8 @@
 import { BillingHistoryProps } from '..';
 
-export const BillingHistory = ({ disabled, payments, sendEmailReceipt }: BillingHistoryProps) => (
+export const BillingHistory = ({ disabled, payments, onSendEmailReceipt }: BillingHistoryProps) => (
   <div data-testid="mock-billing-history" data-disabled={disabled} data-payments={JSON.stringify(payments)}>
-    <button onClick={sendEmailReceipt}>Resend receipt</button>
+    <button onClick={onSendEmailReceipt}>Resend receipt</button>
   </div>
 );
 export default BillingHistory;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/__mocks__/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/__mocks__/BillingHistory.tsx
@@ -1,6 +1,8 @@
 import { BillingHistoryProps } from '..';
 
-export const BillingHistory = ({ disabled, payments }: BillingHistoryProps) => (
-  <div data-testid="mock-billing-history" data-disabled={disabled} data-payments={JSON.stringify(payments)} />
+export const BillingHistory = ({ disabled, payments, sendEmailReceipt }: BillingHistoryProps) => (
+  <div data-testid="mock-billing-history" data-disabled={disabled} data-payments={JSON.stringify(payments)}>
+    <button onClick={sendEmailReceipt}>Resend receipt</button>
+  </div>
 );
 export default BillingHistory;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
@@ -38,7 +38,8 @@ describe('ContributionDetail', () => {
       isFetching: false,
       refetch: jest.fn(),
       cancelContribution: jest.fn(),
-      updateContribution: jest.fn()
+      updateContribution: jest.fn(),
+      sendEmailReceipt: jest.fn()
     });
 
     tree();
@@ -54,7 +55,8 @@ describe('ContributionDetail', () => {
         isFetching: false,
         refetch: jest.fn(),
         cancelContribution: jest.fn(),
-        updateContribution: jest.fn()
+        updateContribution: jest.fn(),
+        sendEmailReceipt: jest.fn()
       });
     });
 
@@ -84,7 +86,8 @@ describe('ContributionDetail', () => {
         isFetching: false,
         refetch: jest.fn(),
         cancelContribution: jest.fn(),
-        updateContribution: jest.fn()
+        updateContribution: jest.fn(),
+        sendEmailReceipt: jest.fn()
       });
     });
 
@@ -115,7 +118,8 @@ describe('ContributionDetail', () => {
         isFetching: false,
         refetch: jest.fn(),
         cancelContribution: jest.fn(),
-        updateContribution: jest.fn()
+        updateContribution: jest.fn(),
+        sendEmailReceipt: jest.fn()
       });
     });
 
@@ -142,6 +146,27 @@ describe('ContributionDetail', () => {
       const history = screen.getByTestId('mock-billing-history');
 
       expect(history.dataset.payments).toBe(JSON.stringify(mockContribution.payments));
+    });
+
+    it('calls sendEmailReceipt when the "Resend receipt" button is clicked', () => {
+      const sendEmailReceipt = jest.fn();
+      usePortalContributionMock.mockReturnValue({
+        isLoading: false,
+        contribution: mockContribution as any,
+        isError: false,
+        isFetching: false,
+        refetch: jest.fn(),
+        updateContribution: jest.fn(),
+        cancelContribution: jest.fn(),
+        sendEmailReceipt
+      });
+
+      tree();
+      expect(sendEmailReceipt).not.toHaveBeenCalled();
+
+      screen.getByText('Resend receipt').click();
+
+      expect(sendEmailReceipt).toBeCalledTimes(1);
     });
 
     it("doesn't disable any section initially", () => {
@@ -230,7 +255,8 @@ describe('ContributionDetail', () => {
           isFetching: false,
           refetch: jest.fn(),
           updateContribution: jest.fn(),
-          cancelContribution
+          cancelContribution,
+          sendEmailReceipt: jest.fn()
         });
 
         tree();

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
@@ -24,10 +24,8 @@ const ContributionDetailPropTypes = {
 export type ContributionDetailProps = InferProps<typeof ContributionDetailPropTypes>;
 
 export function ContributionDetail({ domAnchor, contributionId, contributorId }: ContributionDetailProps) {
-  const { cancelContribution, contribution, isError, isLoading, refetch, updateContribution } = usePortalContribution(
-    contributorId,
-    contributionId
-  );
+  const { cancelContribution, contribution, isError, isLoading, refetch, updateContribution, sendEmailReceipt } =
+    usePortalContribution(contributorId, contributionId);
   const [editableSection, setEditableSection] = useState<'paymentMethod'>();
 
   // We need to store the root element in state so that changes to it trigger
@@ -80,7 +78,11 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
             onEditComplete={() => setEditableSection(undefined)}
             onUpdatePaymentMethod={handlePaymentMethodUpdate}
           />
-          <BillingHistory disabled={!!editableSection} payments={contribution.payments} />
+          <BillingHistory
+            disabled={!!editableSection}
+            payments={contribution.payments}
+            sendEmailReceipt={sendEmailReceipt}
+          />
           <Actions contribution={contribution} onCancelContribution={cancelContribution} />
         </Content>
       </Root>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
@@ -81,7 +81,7 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
           <BillingHistory
             disabled={!!editableSection}
             payments={contribution.payments}
-            sendEmailReceipt={sendEmailReceipt}
+            onSendEmailReceipt={sendEmailReceipt}
           />
           <Actions contribution={contribution} onCancelContribution={cancelContribution} />
         </Content>

--- a/spa/src/hooks/usePortalContribution.test.tsx
+++ b/spa/src/hooks/usePortalContribution.test.tsx
@@ -303,9 +303,10 @@ describe('usePortalContribution', () => {
 
   describe('The sendEmailReceipt function', () => {
     it('is returned even when a contribution is loading', async () => {
-      const { result } = hook(123, 1);
+      const { result, waitForNextUpdate } = hook(123, 1);
 
       expect(typeof result.current.sendEmailReceipt).toBe('function');
+      await waitForNextUpdate();
     });
 
     it('makes a POST to /api/v1/contributions/{id}/send-receipt/', async () => {
@@ -315,11 +316,7 @@ describe('usePortalContribution', () => {
 
       result.current.sendEmailReceipt();
       await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
-      expect(axiosMock.history.post[0]).toEqual(
-        expect.objectContaining({
-          url: '/contributors/123/contributions/1/send-receipt/'
-        })
-      );
+      expect(axiosMock.history.post[0].url).toBe('/contributors/123/contributions/1/send-receipt/');
     });
 
     it('resolves with the request and shows a notification if the POST succeeds', async () => {

--- a/spa/src/hooks/usePortalContribution.test.tsx
+++ b/spa/src/hooks/usePortalContribution.test.tsx
@@ -302,13 +302,6 @@ describe('usePortalContribution', () => {
   });
 
   describe('The sendEmailReceipt function', () => {
-    it('is returned even when a contribution is loading', async () => {
-      const { result, waitForNextUpdate } = hook(123, 1);
-
-      expect(typeof result.current.sendEmailReceipt).toBe('function');
-      await waitForNextUpdate();
-    });
-
     it('makes a POST to /api/v1/contributions/{id}/send-receipt/', async () => {
       const { result, waitFor } = hook(123, 1);
 

--- a/spa/src/hooks/usePortalContribution.test.tsx
+++ b/spa/src/hooks/usePortalContribution.test.tsx
@@ -55,6 +55,7 @@ describe('usePortalContribution', () => {
     useHistoryMock.mockReturnValue({ push });
     axiosMock.onGet('contributors/123/contributions/1/').reply(200, mockContributionResponse);
     axiosMock.onPatch('contributors/123/contributions/1/').reply(200);
+    axiosMock.onPost('contributors/123/contributions/1/send-receipt/').reply(204);
     enqueueSnackbar = jest.fn();
     useSnackbarMock.mockReturnValue({ enqueueSnackbar } as any);
     useQueryClientMock.mockReturnValue({
@@ -293,6 +294,52 @@ describe('usePortalContribution', () => {
       expect(enqueueSnackbar.mock.calls).toEqual([
         [
           'A problem occurred while updating your contribution. Please try again.',
+          expect.objectContaining({ persist: true })
+        ]
+      ]);
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('The sendEmailReceipt function', () => {
+    it('is returned even when a contribution is loading', async () => {
+      const { result } = hook(123, 1);
+
+      expect(typeof result.current.sendEmailReceipt).toBe('function');
+    });
+
+    it('makes a POST to /api/v1/contributions/{id}/send-receipt/', async () => {
+      const { result, waitFor } = hook(123, 1);
+
+      expect(axiosMock.history.post.length).toBe(0);
+
+      result.current.sendEmailReceipt();
+      await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+      expect(axiosMock.history.post[0]).toEqual(
+        expect.objectContaining({
+          url: '/contributors/123/contributions/1/send-receipt/'
+        })
+      );
+    });
+
+    it('resolves with the request and shows a notification if the POST succeeds', async () => {
+      const { result } = hook(123, 1);
+
+      expect(await result.current.sendEmailReceipt()).not.toBe(undefined);
+      expect(enqueueSnackbar.mock.calls).toEqual([
+        ['Your receipt has been sent to your email.', expect.objectContaining({ persist: true })]
+      ]);
+    });
+
+    it('rejects and shows an error notification if the POST fails', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = hook(123, 1);
+
+      axiosMock.onPost('contributors/123/contributions/1/send-receipt/').networkError();
+      await expect(result.current.sendEmailReceipt()).rejects.toThrow();
+      expect(enqueueSnackbar.mock.calls).toEqual([
+        [
+          'Your receipt has failed to send to your email. Please wait and try again.',
           expect.objectContaining({ persist: true })
         ]
       ]);

--- a/spa/src/hooks/usePortalContribution.tsx
+++ b/spa/src/hooks/usePortalContribution.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getContributionDetailEndpoint } from 'ajax/endpoints';
+import { getContributionDetailEndpoint, getContributionSendEmailReceiptEndpoint } from 'ajax/endpoints';
 import axios from 'ajax/portal-axios';
 import { AxiosError } from 'axios';
 import SystemNotification from 'components/common/SystemNotification';
@@ -169,5 +169,37 @@ export function usePortalContribution(contributorId: number, contributionId: num
     [updateContributionMutation]
   );
 
-  return { contribution: data, isError, isFetching, isLoading, refetch, updateContribution, cancelContribution };
+  const sendEmailReceiptMutation = useMutation(
+    () => axios.post(getContributionSendEmailReceiptEndpoint(contributorId, contributionId)),
+    {
+      onError: () => {
+        enqueueSnackbar('Your receipt has failed to send to your email. Please wait and try again.', {
+          persist: true,
+          content: (key: string, message: string) => (
+            <SystemNotification id={key} message={message} header="Failed to Send" type="error" />
+          )
+        });
+      },
+      onSuccess: () => {
+        enqueueSnackbar('Your receipt has been sent to your email.', {
+          persist: true,
+          content: (key: string, message: string) => (
+            <SystemNotification id={key} message={message} header="Receipt Sent!" type="success" />
+          )
+        });
+      }
+    }
+  );
+  const sendEmailReceipt = useCallback(() => sendEmailReceiptMutation.mutateAsync(), [sendEmailReceiptMutation]);
+
+  return {
+    contribution: data,
+    isError,
+    isFetching,
+    isLoading,
+    refetch,
+    updateContribution,
+    cancelContribution,
+    sendEmailReceipt
+  };
 }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
Stacked PRs:
[main <- DEV-3878](https://github.com/newsrevenuehub/rev-engine/pull/1490) <- DEV-3879 (this)

#### What's this PR do?
- Implements "Resend Receipt" button in Portal
#### Why are we doing this? How does it help us?
- Allow for donors to get the receipt email if they lost the original one
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
- yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
- yes
#### Have automated unit tests been added? If not, why?
- yes
#### How should this change be communicated to end users?
- Contributors now are allowed to resend receipts
#### Are there any smells or added technical debt to note?
- no
#### Has this been documented? If so, where?
- no 
#### What are the relevant tickets? Add a link to any relevant ones.
- https://news-revenue-hub.atlassian.net/browse/DEV-3879
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
- no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
- no