### PR TITLE
DEV-4789 | better logging when backoff for stripe rate limit

### DIFF
--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -91,7 +91,7 @@ logger.addHandler(logger_handler)
 
 
 def log_backoff(details):
-    """ """
+    """Custom logging handler for backoff decorator that logs details from Stripe rate limit errors."""
     if isinstance((exc := details["value"]), stripe.error.RateLimitError):
         logger.warning(
             "Backing off %s seconds after %s tries due to rate limit error. "

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -83,7 +83,7 @@ logger = logging.getLogger(
 logger_handler = logging.StreamHandler()
 logger_handler.setFormatter(
     logging.Formatter(
-        "%(asctime)s %(levelname)s request_id=%(request_id)s %(name)s:%(lineno)d - [%(funcName)s] %(message)s",
+        "%(asctime)s %(levelname)s %(name)s:%(lineno)d - [%(funcName)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 )

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -97,12 +97,14 @@ def log_backoff(details):
             "Backing off %s seconds after %s tries due to rate limit error. "
             "Error message: %s. "
             "Status code: %s. "
-            "Stripe request ID: %s.",
+            "Stripe request ID: %s. "
+            "Stripe error: %s.",
             details["wait"],
             details["tries"],
             exc.user_message,
             exc.http_status,
             exc.request_id,
+            exc.error,
             exc_info=True,
         )
     else:

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -1132,13 +1132,14 @@ class Test_log_backoff:
             mock_logger.assert_called_once_with(
                 (
                     "Backing off %s seconds after %s tries due to rate limit error. Error message: %s. "
-                    "Status code: %s. Stripe request ID: %s."
+                    "Status code: %s. Stripe request ID: %s. Stripe error: %s."
                 ),
                 details["wait"],
                 details["tries"],
                 details["value"].user_message,
                 details["value"].http_status,
                 details["value"].request_id,
+                details["value"].error,
                 exc_info=True,
             )
         else:


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

The base for this PR is initially DEV-4776 because this branch presupposes those changes. After DEV-4776 has been merged, this should point to main.


#### What's this PR do?

This PR makes some small changes to `apps.contributions.stripe_import` in order to improve logging around API rate limiting from Stripe, as encountered by backoff, which is the decorator we use to manage exponential backoff when facing rate limits.

- Adds a customer logging handler in `stripe_import.py` that prepends a timestamp to all logs
- Adds a custom logging function as argument for `on_backoff` param of `_STRIPE_API_BACKOFF_ARGS` which will cause custom logging that includes relevant details from Stripe (such as status code, user message, etc.) when a rate limit is encountered.
- Tests the custom logging function (log_backoff)

#### Why are we doing this? How does it help us?

Unblock portal. This is incremental step to determining why import command is so slow as to be unusable when working on large accounts.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Not really. There are instructions on how to observe the timestamp, but there's no good way to trigger the rate limit errors in a review app that would allow us to test that custom handler.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?


N/A

#### Are there any smells or added technical debt to note?

No


#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-4789](https://news-revenue-hub.atlassian.net/browse/DEV-4789)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

Related ticket:  [DEV-4791](https://news-revenue-hub.atlassian.net/browse/DEV-4791)

[DEV-4789]: https://news-revenue-hub.atlassian.net/browse/DEV-4789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ