### PR TITLE
DEV-4852 | Memoize redis.scan_iter key lookups to speed up subscription processing in Stripe transactions importer

### DIFF
--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Callable, Iterable
 from contextlib import nullcontext
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Any
 from urllib.parse import urlparse
 
@@ -609,15 +610,13 @@ class StripeTransactionsImporter:
             "interval": cls.get_interval_from_plan(plan),
         }
 
+    @cached_property
+    def _invoice_by_sub_id_keys(self) -> list[str]:
+        return list(self.redis.scan_iter(match=self.make_key(entity_name="InvoiceBySubId", entity_id="*")))
+
     def get_invoices_for_subscription(self, subscription_id: str) -> list[dict]:
         """Get cached invoices, if any for a given subscription id."""
-        return [
-            self.get_resource_from_cache(key)
-            for key in self.redis.scan_iter(
-                match=self.make_key(entity_name="InvoiceBySubId", entity_id=f"{subscription_id}*"),
-                count=REDIS_SCAN_ITER_COUNT,
-            )
-        ]
+        return [self.get_resource_from_cache(key) for key in self._invoice_by_sub_id_keys if subscription_id in key]
 
     def get_charges_for_subscription(self, subscription_id: str) -> list[dict]:
         """Get cached charges, if any for a given subscription id."""
@@ -634,15 +633,14 @@ class StripeTransactionsImporter:
             )
         )
 
+    @cached_property
+    def _refund_by_charge_id_keys(self) -> list[str]:
+        return list(self.redis.scan_iter(match=self.make_key(entity_name="RefundByChargeId", entity_id="*")))
+
     def get_refunds_for_charge(self, charge_id: str) -> list[dict]:
         """Get cached refunds, if any for a given charge id."""
         logger.info("Getting refunds for charge %s", charge_id)
-        return [
-            self.get_resource_from_cache(key)
-            for key in self.redis.scan_iter(
-                match=self.make_key(entity_name="RefundByChargeId", entity_id=f"{charge_id}*")
-            )
-        ]
+        return [self.get_resource_from_cache(key) for key in self._refund_by_charge_id_keys]
 
     def get_or_create_contributor_from_customer(self, customer_id: str) -> tuple[Contributor, str]:
         """Get or create a contributor from a stripe customer id."""
@@ -703,16 +701,15 @@ class StripeTransactionsImporter:
             case _:
                 logger.warning("Unexpected action %s for payment %s", action, getattr(payment, "id", "<no payment>"))
 
+    @cached_property
+    def _charge_by_payment_intent_id_keys(self) -> list[str]:
+        return list(self.redis.scan_iter(match=self.make_key(entity_name="ChargeByPaymentIntentId", entity_id="*")))
+
     def get_charges_for_payment_intent(self, payment_intent_id: str) -> list[dict]:
         """Get charges for a payment intent from cache."""
-        charges = []
-        for key in self.redis.scan_iter(
-            match=self.make_key(entity_name="ChargeByPaymentIntentId", entity_id=f"{payment_intent_id}*"),
-            count=REDIS_SCAN_ITER_COUNT,
-        ):
-            charge = self.get_resource_from_cache(key)
-            charges.append(charge)
-        return charges
+        return [
+            self.get_resource_from_cache(k) for k in self._charge_by_payment_intent_id_keys if payment_intent_id in k
+        ]
 
     def get_successful_charge_for_payment_intent(self, payment_intent_id: str) -> dict | None:
         """Get single successful charge for a PI. If >1 successful, raises an error."""
@@ -905,10 +902,14 @@ class StripeTransactionsImporter:
         self.update_contributor_stats(contributor_action, contributor)
         return contribution, contribution_action
 
+    @cached_property
+    def _subscription_keys(self) -> list[str]:
+        return list(self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*")))
+
     def process_transactions_for_recurring_contributions(self) -> None:
         """Assemble data and ultimately upsert data for a recurring contribution."""
         logger.info("Processing transactions for recurring contributions")
-        for key in self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*"), count=REDIS_SCAN_ITER_COUNT):
+        for key in self._subscription_keys:
             subscription = self.get_resource_from_cache(key)
             try:
                 contribution, action = self.upsert_contribution(stripe_entity=subscription, is_one_time=False)
@@ -925,6 +926,10 @@ class StripeTransactionsImporter:
             )
             self.subscriptions_processed += 1
 
+    @cached_property
+    def _payment_intent_keys(self) -> list[str]:
+        return list(self.redis.scan_iter(match=self.make_key(entity_name="PaymentIntent_*")))
+
     def process_transactions_for_one_time_contributions(self) -> None:
         """Process transactions for one-time contributions.
 
@@ -932,9 +937,7 @@ class StripeTransactionsImporter:
         without referer and schema_version, we know ahead of time that all of the PIs we're looking at are for one-time contributions.
         """
         logger.info("Processing transactions for one-time contributions")
-        for key in self.redis.scan_iter(
-            match=self.make_key(entity_name="PaymentIntent_*"), count=REDIS_SCAN_ITER_COUNT
-        ):
+        for key in self._payment_intent_keys:
             pi = self.get_resource_from_cache(key)
             try:
                 contribution, action = self.upsert_contribution(stripe_entity=pi, is_one_time=True)
@@ -1073,49 +1076,25 @@ class StripeTransactionsImporter:
 
     def log_memory_usage(self):
         """Log memory usage for a given stripe account."""
-        num_subs_in_cache = len(
-            list(self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*"), count=REDIS_SCAN_ITER_COUNT))
-        )
-        num_pis_in_cache = len(
-            list(self.redis.scan_iter(match=self.make_key(entity_name="PaymentIntent_*"), count=REDIS_SCAN_ITER_COUNT))
-        )
-        num_invoices_in_cache = len(
-            list(self.redis.scan_iter(match=self.make_key(entity_name="Invoice_*"), count=REDIS_SCAN_ITER_COUNT))
-        )
-        num_charges_in_cache = len(
-            list(self.redis.scan_iter(match=self.make_key(entity_name="Charge_*"), count=REDIS_SCAN_ITER_COUNT))
-        )
-        num_refunds_in_cache = len(
-            list(self.redis.scan_iter(match=self.make_key(entity_name="Refund_*"), count=REDIS_SCAN_ITER_COUNT))
-        )
-        num_customers_in_cache = len(
-            list(self.redis.scan_iter(match=self.make_key(entity_name="Customer_*"), count=REDIS_SCAN_ITER_COUNT))
-        )
-        num_bts_in_cache = len(
-            list(
-                self.redis.scan_iter(
-                    match=self.make_key(entity_name="BalanceTransaction_*"), count=REDIS_SCAN_ITER_COUNT
-                )
-            )
-        )
-
         logger.info(
-            "With %s cached subscriptions,"
-            " %s cached payment intents,"
-            " %s cached invoices,"
-            " %s cached charges,"
-            " %s cached refunds,"
-            " %s cached customers,"
-            " and %s cached balance transactions,"
-            " Redis memory usage for transactions"
-            " import for stripe account %s is: %s",
-            num_subs_in_cache,
-            num_pis_in_cache,
-            num_invoices_in_cache,
-            num_charges_in_cache,
-            num_refunds_in_cache,
-            num_customers_in_cache,
-            num_bts_in_cache,
+            (
+                "With %s cached subscriptions, "
+                "%s cached payment intents, "
+                "%s cached invoices, "
+                "%s cached charges, "
+                "%s cached refunds, "
+                "%s cached customers, "
+                "and %s cached balance transactions, "
+                "Redis memory usage for transactions "
+                "import for stripe account %s is: %s"
+            ),
+            len(self._subscription_keys),
+            len(self._payment_intent_keys),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Invoice_*")))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Charge_*")))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Refund_*")))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Customer_*")))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="BalanceTransaction_*")))),
             self.stripe_account_id,
             self.convert_bytes(self.get_redis_memory_usage()),
         )

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -902,16 +902,10 @@ class StripeTransactionsImporter:
         self.update_contributor_stats(contributor_action, contributor)
         return contribution, contribution_action
 
-    @cached_property
-    def _subscription_keys(self) -> list[str]:
-        return list(
-            self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*"), count=REDIS_SCAN_ITER_COUNT)
-        )
-
     def process_transactions_for_recurring_contributions(self) -> None:
         """Assemble data and ultimately upsert data for a recurring contribution."""
         logger.info("Processing transactions for recurring contributions")
-        for key in self._subscription_keys:
+        for key in self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*"), count=REDIS_SCAN_ITER_COUNT):
             subscription = self.get_resource_from_cache(key)
             try:
                 contribution, action = self.upsert_contribution(stripe_entity=subscription, is_one_time=False)

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -620,7 +620,9 @@ class StripeTransactionsImporter:
 
     def get_invoices_for_subscription(self, subscription_id: str) -> list[dict]:
         """Get cached invoices, if any for a given subscription id."""
-        return [self.get_resource_from_cache(key) for key in self._invoice_by_sub_id_keys if subscription_id in key]
+        return [
+            self.get_resource_from_cache(key) for key in self._invoice_by_sub_id_keys if subscription_id in str(key)
+        ]
 
     def get_charges_for_subscription(self, subscription_id: str) -> list[dict]:
         """Get cached charges, if any for a given subscription id."""
@@ -720,7 +722,9 @@ class StripeTransactionsImporter:
     def get_charges_for_payment_intent(self, payment_intent_id: str) -> list[dict]:
         """Get charges for a payment intent from cache."""
         return [
-            self.get_resource_from_cache(k) for k in self._charge_by_payment_intent_id_keys if payment_intent_id in k
+            self.get_resource_from_cache(k)
+            for k in self._charge_by_payment_intent_id_keys
+            if payment_intent_id in str(k)
         ]
 
     def get_successful_charge_for_payment_intent(self, payment_intent_id: str) -> dict | None:

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -84,23 +84,14 @@ TTL_WARNING_THRESHOLD_PERCENT = 0.75
 # We set up some custom logging for this module so we get timestamps, which are helpful
 # in running down timing/rate limiting issues we're facing when this code runs.
 logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
-
-console_handler = logging.StreamHandler()
-
-new_formatter = logging.Formatter(
-    "%(asctime)s %(levelname)s %(name)s:%(lineno)d - [%(funcName)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-)
-
-# Add the formatter to the handler
-console_handler.setFormatter(new_formatter)
-
-# Remove any existing handlers from the logger
 if logger.handlers:
     for handler in logger.handlers:
-        logger.removeHandler(handler)
-
-# Add the handler to the logger
-logger.addHandler(console_handler)
+        handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s %(levelname)s %(name)s:%(lineno)d - [%(funcName)s] %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
 
 
 class OnBackoffDetails(BaseModel):

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -904,7 +904,9 @@ class StripeTransactionsImporter:
 
     @cached_property
     def _subscription_keys(self) -> list[str]:
-        return list(self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*")))
+        return list(
+            self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*"), count=REDIS_SCAN_ITER_COUNT)
+        )
 
     def process_transactions_for_recurring_contributions(self) -> None:
         """Assemble data and ultimately upsert data for a recurring contribution."""
@@ -1088,8 +1090,8 @@ class StripeTransactionsImporter:
                 "Redis memory usage for transactions "
                 "import for stripe account %s is: %s"
             ),
-            len(self._subscription_keys),
-            len(self._payment_intent_keys),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*")))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="PaymentIntent_*")))),
             len(list(self.redis.scan_iter(match=self.make_key(entity_name="Invoice_*")))),
             len(list(self.redis.scan_iter(match=self.make_key(entity_name="Charge_*")))),
             len(list(self.redis.scan_iter(match=self.make_key(entity_name="Refund_*")))),

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -612,7 +612,11 @@ class StripeTransactionsImporter:
 
     @cached_property
     def _invoice_by_sub_id_keys(self) -> list[str]:
-        return list(self.redis.scan_iter(match=self.make_key(entity_name="InvoiceBySubId", entity_id="*")))
+        return list(
+            self.redis.scan_iter(
+                match=self.make_key(entity_name="InvoiceBySubId", entity_id="*"), count=REDIS_SCAN_ITER_COUNT
+            )
+        )
 
     def get_invoices_for_subscription(self, subscription_id: str) -> list[dict]:
         """Get cached invoices, if any for a given subscription id."""
@@ -635,7 +639,11 @@ class StripeTransactionsImporter:
 
     @cached_property
     def _refund_by_charge_id_keys(self) -> list[str]:
-        return list(self.redis.scan_iter(match=self.make_key(entity_name="RefundByChargeId", entity_id="*")))
+        return list(
+            self.redis.scan_iter(
+                match=self.make_key(entity_name="RefundByChargeId", entity_id="*"), count=REDIS_SCAN_ITER_COUNT
+            )
+        )
 
     def get_refunds_for_charge(self, charge_id: str) -> list[dict]:
         """Get cached refunds, if any for a given charge id."""
@@ -703,7 +711,11 @@ class StripeTransactionsImporter:
 
     @cached_property
     def _charge_by_payment_intent_id_keys(self) -> list[str]:
-        return list(self.redis.scan_iter(match=self.make_key(entity_name="ChargeByPaymentIntentId", entity_id="*")))
+        return list(
+            self.redis.scan_iter(
+                match=self.make_key(entity_name="ChargeByPaymentIntentId", entity_id="*"), count=REDIS_SCAN_ITER_COUNT
+            )
+        )
 
     def get_charges_for_payment_intent(self, payment_intent_id: str) -> list[dict]:
         """Get charges for a payment intent from cache."""
@@ -924,7 +936,9 @@ class StripeTransactionsImporter:
 
     @cached_property
     def _payment_intent_keys(self) -> list[str]:
-        return list(self.redis.scan_iter(match=self.make_key(entity_name="PaymentIntent_*")))
+        return list(
+            self.redis.scan_iter(match=self.make_key(entity_name="PaymentIntent_*"), count=REDIS_SCAN_ITER_COUNT)
+        )
 
     def process_transactions_for_one_time_contributions(self) -> None:
         """Process transactions for one-time contributions.
@@ -1084,13 +1098,29 @@ class StripeTransactionsImporter:
                 "Redis memory usage for transactions "
                 "import for stripe account %s is: %s"
             ),
-            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*")))),
-            len(list(self.redis.scan_iter(match=self.make_key(entity_name="PaymentIntent_*")))),
-            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Invoice_*")))),
-            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Charge_*")))),
-            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Refund_*")))),
-            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Customer_*")))),
-            len(list(self.redis.scan_iter(match=self.make_key(entity_name="BalanceTransaction_*")))),
+            len(
+                list(
+                    self.redis.scan_iter(match=self.make_key(entity_name="Subscription_*"), count=REDIS_SCAN_ITER_COUNT)
+                )
+            ),
+            len(
+                list(
+                    self.redis.scan_iter(
+                        match=self.make_key(entity_name="PaymentIntent_*"), count=REDIS_SCAN_ITER_COUNT
+                    )
+                )
+            ),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Invoice_*"), count=REDIS_SCAN_ITER_COUNT))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Charge_*"), count=REDIS_SCAN_ITER_COUNT))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Refund_*"), count=REDIS_SCAN_ITER_COUNT))),
+            len(list(self.redis.scan_iter(match=self.make_key(entity_name="Customer_*"), count=REDIS_SCAN_ITER_COUNT))),
+            len(
+                list(
+                    self.redis.scan_iter(
+                        match=self.make_key(entity_name="BalanceTransaction_*"), count=REDIS_SCAN_ITER_COUNT
+                    )
+                )
+            ),
             self.stripe_account_id,
             self.convert_bytes(self.get_redis_memory_usage()),
         )

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -84,14 +84,23 @@ TTL_WARNING_THRESHOLD_PERCENT = 0.75
 # We set up some custom logging for this module so we get timestamps, which are helpful
 # in running down timing/rate limiting issues we're facing when this code runs.
 logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
+
+console_handler = logging.StreamHandler()
+
+new_formatter = logging.Formatter(
+    "%(asctime)s %(levelname)s %(name)s:%(lineno)d - [%(funcName)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+)
+
+# Add the formatter to the handler
+console_handler.setFormatter(new_formatter)
+
+# Remove any existing handlers from the logger
 if logger.handlers:
     for handler in logger.handlers:
-        handler.setFormatter(
-            logging.Formatter(
-                "%(asctime)s %(levelname)s %(name)s:%(lineno)d - [%(funcName)s] %(message)s",
-                datefmt="%Y-%m-%d %H:%M:%S",
-            )
-        )
+        logger.removeHandler(handler)
+
+# Add the handler to the logger
+logger.addHandler(console_handler)
 
 
 class OnBackoffDetails(BaseModel):

--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -922,7 +922,12 @@ class StripeTransactionsImporter:
         """Assemble data and ultimately upsert data for a recurring contribution."""
         logger.info("Processing transactions for recurring contributions")
         for i, key in enumerate(self._subscription_keys):
-            logger.info("Processing subscription %s of %s for account %s", i + 1, key, self.stripe_account_id)
+            logger.info(
+                "Processing subscription %s of %s for account %s",
+                i + 1,
+                len(self._subscription_keys),
+                self.stripe_account_id,
+            )
             subscription = self.get_resource_from_cache(key)
             try:
                 contribution, action = self.upsert_contribution(stripe_entity=subscription, is_one_time=False)
@@ -960,7 +965,12 @@ class StripeTransactionsImporter:
         logger.info("Processing transactions for one-time contributions")
 
         for i, key in enumerate(self._payment_intent_keys):
-            logger.info("Processing payment intent %s of %s for account %s", i + 1, key, self.stripe_account_id)
+            logger.info(
+                "Processing payment intent %s of %s for account %s",
+                i + 1,
+                len(self._payment_intent_keys),
+                self.stripe_account_id,
+            )
             pi = self.get_resource_from_cache(key)
             try:
                 contribution, action = self.upsert_contribution(stripe_entity=pi, is_one_time=True)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR uses `@cached_property` in several places to store the results of costly (in terms of time) calls to `redis.scan_iter`. 

Additionally, adds log that indicates how many total contributions to be processed (subscription count + 1-time PI count) and logs for each individual contribution being processed indicating which number transaction currently being processed.

#### Why are we doing this? How does it help us?

Greatly speed up transaction importer command.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Not for review app. This will of necessity need to be tested vis a vis prod.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

#### Have automated unit tests been added? If not, why?

Existing updated

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-4852](https://news-revenue-hub.atlassian.net/browse/DEV-4852)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A


[DEV-4852]: https://news-revenue-hub.atlassian.net/browse/DEV-4852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ