### PR TITLE
DEV-4859 | Fix bug with `update_payment_stats`

### DIFF
--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -789,13 +789,13 @@ class StripeTransactionsImporter:
             )
             if payment:
                 logger.info("Payment %s for contribution %s was %s", payment.id, contribution.id, action)
+                self.update_payment_stats(action, payment)
             else:
                 logger.info(
                     "No payment created for contribution %s and balance transaction %s",
                     contribution.id,
                     balance_transaction["id"],
                 )
-            self.update_payment_stats(action, payment)
 
     def get_provider_payment_id_for_subscription(self, subscription: dict) -> str | None:
         """Get provider payment id for a subscription."""


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Fixes a bug where we called `update_payment_stats` when a payment was neither created nor found.  This bug didn't crash the import, but it did cause noise in Sentry logs.


#### Why are we doing this? How does it help us?

Reduce Sentry noise.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

No. Getting Stripe in required state to reproduce in review app is difficult.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

No. I don't think we want unit tests about something this specific (namely that `update_payment_stats` does not get called in certain circumstances).

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-4859](https://news-revenue-hub.atlassian.net/browse/DEV-4859)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No

[DEV-4859]: https://news-revenue-hub.atlassian.net/browse/DEV-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ