### PR TITLE
DEV-4772: Add management command to fix contributions w/o sub IDs

### DIFF
--- a/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
+++ b/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from django.core.management.base import BaseCommand
 
 import reversion
@@ -7,8 +9,12 @@ from apps.contributions.models import Contribution
 
 
 class Command(BaseCommand):
+    @property
+    def name(self):
+        return Path(__file__).name
+
     def handle(self, *args, **options):
-        self.stdout.write(self.style.HTTP_INFO("Running `fix_recurring_contribution_missing_provider_subscription_id`"))
+        self.stdout.write(self.style.HTTP_INFO(f"Running {self.name}"))
         contributions = Contribution.objects.recurring().filter(provider_subscription_id=None)
         if not contributions.exists():
             self.stdout.write(
@@ -56,4 +62,6 @@ class Command(BaseCommand):
                 )
             )
             fixed += 1
-        self.stdout.write(self.style.HTTP_INFO(f"Finished: {fixed} of {len(contributions)} contributions fixed"))
+        self.stdout.write(
+            self.style.HTTP_INFO(f"{self.name} finished: {fixed} of {len(contributions)} contributions fixed")
+        )

--- a/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
+++ b/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
@@ -30,6 +30,9 @@ class Command(BaseCommand):
             # payment intent -> invoice -> subscription
 
             self.stdout.write(self.style.HTTP_INFO(f"Investigating contribution ID {contribution.id}"))
+            if not contribution.stripe_account_id:
+                self.stdout.write(self.style.WARNING("Contribution has no Stripe account ID, skipping"))
+                continue
             if not contribution.provider_payment_id:
                 self.stdout.write(self.style.WARNING("Contribution has no provider payment intent ID, skipping"))
                 continue

--- a/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
+++ b/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
@@ -53,9 +53,6 @@ class Command(BaseCommand):
             # payment intent -> invoice -> subscription
 
             self.stdout.write(self.style.HTTP_INFO(f"Investigating contribution ID {contribution.id}"))
-            if not contribution.stripe_account_id:
-                self.stdout.write(self.style.WARNING("Contribution has no Stripe account ID, skipping"))
-                continue
             if not contribution.provider_payment_id:
                 self.stdout.write(self.style.WARNING("Contribution has no provider payment intent ID, skipping"))
                 continue

--- a/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
+++ b/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
@@ -55,10 +55,9 @@ class Command(BaseCommand):
                 contribution.provider_subscription_id = intent.invoice.subscription
                 contribution.save(update_fields={"modified", "provider_subscription_id"})
                 reversion.set_comment("Updated by fix_recurring_contribution_missing_provider_subscription_id command")
-            c_id = contribution.id
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Set subscription ID {contribution.provider_subscription_id} on contribution {c_id}"
+                    f"Set subscription ID {contribution.provider_subscription_id} on contribution {contribution.id}"
                 )
             )
             fixed += 1

--- a/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
+++ b/apps/contributions/management/commands/fix_recurring_contribution_missing_provider_subscription_id.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
             )
             fixed.append(contribution)
         with reversion.create_revision():
-            Contribution.objects.bulk_update(fixed, fields=["provider_subscription_id"])
+            Contribution.objects.bulk_update(fixed, fields={"provider_subscription_id"})
             reversion.set_comment("Updated by fix_recurring_contribution_missing_provider_subscription_id command")
         self.stdout.write(
             self.style.HTTP_INFO(f"{self.name} finished: {len(fixed)} of {len(contributions)} contributions fixed")

--- a/apps/contributions/tests/test_management_commands.py
+++ b/apps/contributions/tests/test_management_commands.py
@@ -298,6 +298,16 @@ class Test_fix_recurring_contribution_missing_provider_subscription_id:
         contribution.refresh_from_db()
         assert contribution.provider_subscription_id == "existing-id"
 
+    def test_skips_missing_stripe_account_id(self, contribution, mocker):
+        mocker.patch(
+            "apps.contributions.models.Contribution.stripe_account_id",
+            return_value=None,
+            new_callable=mocker.PropertyMock,
+        )
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id is None
+
     def test_skips_missing_provider_payment_id(self, contribution):
         contribution.provider_payment_id = None
         contribution.save()

--- a/apps/contributions/tests/test_management_commands.py
+++ b/apps/contributions/tests/test_management_commands.py
@@ -322,6 +322,16 @@ class Test_fix_recurring_contribution_missing_provider_subscription_id:
         contribution.refresh_from_db()
         assert contribution.provider_subscription_id is None
 
+    def test_skips_when_intent_invoice_has_sub_linked_to_existing_contribution(self, contribution, mocker):
+        ContributionFactory(provider_subscription_id="existing-id")
+        mocker.patch(
+            "stripe.PaymentIntent.retrieve",
+            return_value=mocker.Mock(invoice=mocker.Mock(subscription="existing-id")),
+        )
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id is None
+
     def test_skips_when_intent_invoice_has_no_subscription(self, contribution, mocker):
         mocker.patch(
             "stripe.PaymentIntent.retrieve",

--- a/apps/contributions/tests/test_management_commands.py
+++ b/apps/contributions/tests/test_management_commands.py
@@ -274,6 +274,64 @@ class Test_fix_recurring_contribution_missing_provider_payment_id:
         assert contribution.provider_payment_id is None
 
 
+@pytest.mark.django_db()
+class Test_fix_recurring_contribution_missing_provider_subscription_id:
+    @pytest.fixture()
+    def contribution(self):
+        return ContributionFactory(
+            provider_payment_id="test-payment-id", provider_subscription_id=None, monthly_subscription=True
+        )
+
+    def test_happy_path(self, contribution, mocker):
+        mocker.patch(
+            "stripe.PaymentIntent.retrieve",
+            return_value=mocker.Mock(invoice=mocker.Mock(subscription="test-sub-id")),
+        )
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id == "test-sub-id"
+
+    def test_skips_contribution_with_subscription_id(self, contribution):
+        contribution.provider_subscription_id = "existing-id"
+        contribution.save()
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id == "existing-id"
+
+    def test_skips_missing_provider_payment_id(self, contribution):
+        contribution.provider_payment_id = None
+        contribution.save()
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id is None
+
+    def test_handles_stripe_retrieval_exception(self, contribution, mocker):
+        mocker.patch(
+            "stripe.PaymentIntent.retrieve", side_effect=stripe.error.InvalidRequestError("test-error", param={})
+        )
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id is None
+
+    def test_skips_when_intent_has_no_invoice(self, contribution, mocker):
+        mocker.patch(
+            "stripe.PaymentIntent.retrieve",
+            return_value={},
+        )
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id is None
+
+    def test_skips_when_intent_invoice_has_no_subscription(self, contribution, mocker):
+        mocker.patch(
+            "stripe.PaymentIntent.retrieve",
+            return_value=mocker.Mock(invoice=mocker.Mock(subscription=None)),
+        )
+        call_command("fix_recurring_contribution_missing_provider_subscription_id")
+        contribution.refresh_from_db()
+        assert contribution.provider_subscription_id is None
+
+
 def test_clear_stripe_transactions_import_cache(mocker):
     mock_clear_cache = mocker.patch(
         "apps.contributions.stripe_import.StripeTransactionsImporter.clear_all_stripe_transactions_cache"

--- a/apps/contributions/tests/test_management_commands.py
+++ b/apps/contributions/tests/test_management_commands.py
@@ -309,17 +309,6 @@ class Test_fix_recurring_contribution_missing_provider_subscription_id:
         contribution.refresh_from_db()
         assert contribution.provider_subscription_id == "existing-id"
 
-    @pytest.mark.usefixtures("_mock_get_account_status")
-    def test_skips_missing_stripe_account_id(self, contribution, mocker):
-        mocker.patch(
-            "apps.contributions.models.Contribution.stripe_account_id",
-            return_value=None,
-            new_callable=mocker.PropertyMock,
-        )
-        call_command("fix_recurring_contribution_missing_provider_subscription_id")
-        contribution.refresh_from_db()
-        assert contribution.provider_subscription_id is None
-
     def test_skips_disconnected_stripe_account(self, contribution, mocker):
         mocker.patch(
             "apps.common.utils.get_stripe_accounts_and_their_connection_status",


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Adds a management command to locate contributions that are missing subscription IDs, and attempts to repair the data by walking through other Stripe objects.

#### Why are we doing this? How does it help us?

Fixes a data issue that occurred in the past.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

I tried out adding a Jupyter notebook to the ticket. Not sure if I did it the correct way as it requires filling in IDs into the notebook for it work.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4772

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

Root cause investigation for the data issue.