### PR TITLE
DEV-4865: Return None for Mailchimp products when not connected

### DIFF
--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -798,10 +798,22 @@ class RevenueProgram(IndexedTimeStampedModel):
 
     @cached_property
     def mailchimp_one_time_contribution_product(self) -> MailchimpProduct | None:
+        if not self.mailchimp_integration_connected:
+            logger.debug(
+                "Mailchimp integration not connected for this revenue program (%s), returning None",
+                self.id,
+            )
+            return None
         return self.mailchimp_client.get_product(self.mailchimp_one_time_contribution_product_id)
 
     @cached_property
     def mailchimp_recurring_contribution_product(self) -> MailchimpProduct | None:
+        if not self.mailchimp_integration_connected:
+            logger.debug(
+                "Mailchimp integration not connected for this revenue program (%s), returning None",
+                self.id,
+            )
+            return None
         return self.mailchimp_client.get_product(self.mailchimp_recurring_contribution_product_id)
 
     # Below are not cached because they are dependent on model fields.

--- a/apps/organizations/tests/test_models.py
+++ b/apps/organizations/tests/test_models.py
@@ -1001,6 +1001,10 @@ class TestRevenueProgramMailchimpProducts:
         mc_connected_rp.save()
         assert getattr(mc_connected_rp, f"mailchimp_{product_type}_contribution_product") is None
 
+    def test_property_when_disconnected(self, product_type, revenue_program):
+        assert not revenue_program.mailchimp_integration_connected
+        assert getattr(revenue_program, f"mailchimp_{product_type}_contribution_product") is None
+
     def test_property_not_found(self, product_type, mc_connected_rp, mocker):
         patched_client = mocker.patch("apps.organizations.models.RevenueProgramMailchimpClient")
         patched_client.return_value.get_product.return_value = None
@@ -1055,6 +1059,10 @@ class TestRevenueProgramMailchimpSegments:
         mc_connected_rp.mailchimp_list_id = None
         mc_connected_rp.save()
         assert getattr(mc_connected_rp, f"mailchimp_{segment_type}_segment") is None
+
+    def test_property_when_disconnected(self, segment_type, revenue_program):
+        assert not revenue_program.mailchimp_integration_connected
+        assert getattr(revenue_program, f"mailchimp_{segment_type}_segment") is None
 
     def test_property_when_no_segment_id(self, segment_type, mc_connected_rp):
         setattr(mc_connected_rp, f"mailchimp_{segment_type}_segment_id", None)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Fixes a bug where trying to retrieve a Mailchimp product for a disconnected revenue program raises an exception instead of returning None.

#### Why are we doing this? How does it help us?

Fixes a regression in DEV-4244 affecting the switchboard endpoint.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4865
https://news-revenue-hub.atlassian.net/browse/DEV-4244

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.