### PR TITLE
DEV-4892: Use react-hook-form with signup form

### DIFF
--- a/spa/cypress/e2e/12-account.cy.js
+++ b/spa/cypress/e2e/12-account.cy.js
@@ -142,7 +142,7 @@ describe('Account', () => {
       cy.visit(SIGN_UP);
       cy.url().should('include', SIGN_UP);
       cy.findByRole('textbox', { name: 'Email' }).type('test@test.com');
-      cy.findByLabelText('Password *').type('P1#password');
+      cy.findByLabelText('Password').type('P1#password');
       cy.findByRole('checkbox').check();
       cy.intercept('POST', getEndpoint(USER), {
         statusCode: 400,
@@ -156,7 +156,7 @@ describe('Account', () => {
       cy.visit(SIGN_UP);
       cy.url().should('include', SIGN_UP);
       cy.findByRole('textbox', { name: 'Email' }).type('test@test.com');
-      cy.findByLabelText('Password *').type('P1#password');
+      cy.findByLabelText('Password').type('P1#password');
       cy.findByRole('checkbox').check();
       cy.intercept(getEndpoint(TOKEN), TOKEN_API_200);
       cy.intercept({ method: 'GET', pathname: getEndpoint(USER) }, { body: rpAdminUnverifiedNewUser });

--- a/spa/src/components/account/SignUp/SignUpForm.styled.ts
+++ b/spa/src/components/account/SignUp/SignUpForm.styled.ts
@@ -1,9 +1,21 @@
+import { FormHelperText } from '@material-ui/core';
 import { TextField } from 'components/base';
 import styled from 'styled-components';
 
 export const Root = styled.form`
   display: grid;
   gap: 20px;
+`;
+
+export const AgreedError = styled(FormHelperText)`
+  && {
+    background: rgba(200, 32, 63, 0.16);
+    border-radius: ${({ theme }) => theme.muiBorderRadius.sm};
+    /* This matches MUI style for TextField. */
+    color: #3c3c3c;
+    font-size: ${({ theme }) => theme.fontSizesUpdated.xs};
+    padding: 4px;
+  }
 `;
 
 export const EmailField = styled(TextField)`

--- a/spa/src/components/account/SignUp/SignUpForm.test.tsx
+++ b/spa/src/components/account/SignUp/SignUpForm.test.tsx
@@ -1,5 +1,5 @@
 import { axe } from 'jest-axe';
-import { fireEvent, render, screen } from 'test-utils';
+import { act, fireEvent, render, screen, waitFor } from 'test-utils';
 import SignUpForm, { SignUpFormProps } from './SignUpForm';
 
 function tree(props?: Partial<SignUpFormProps>) {
@@ -15,77 +15,84 @@ describe('SignUpForm', () => {
     expect(screen.getByText('Password must be at least 8 characters long.')).toBeInTheDocument();
   });
 
-  it("doesn't submit if password is smaller than 8 chars", () => {
+  it("doesn't submit if password is smaller than 8 chars", async () => {
     const onSubmit = jest.fn();
 
     tree({ onSubmit });
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), { target: { value: 'test@test.com' } });
-    fireEvent.change(screen.getByLabelText('Password *'), { target: { value: '1234567' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: '1234567' } });
     fireEvent.click(screen.getByRole('checkbox'));
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    await act(() => Promise.resolve());
     expect(onSubmit).not.toBeCalled();
   });
 
-  it("doesn't submit if email and password are blank", () => {
+  it("doesn't submit if email and password are blank", async () => {
     const onSubmit = jest.fn();
 
     tree({ onSubmit });
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    await act(() => Promise.resolve());
     expect(onSubmit).not.toBeCalled();
   });
 
-  it("doesn't submit if email is valid but password is blank", () => {
+  it("doesn't submit if email is valid but password is blank", async () => {
     const onSubmit = jest.fn();
 
     tree({ onSubmit });
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), { target: { value: 'test@test.com' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    await act(() => Promise.resolve());
     expect(onSubmit).not.toBeCalled();
   });
 
-  it("doesn't submit if email is invalid, but password is valid and terms are selected", () => {
+  it("doesn't submit if email is invalid, but password is valid and terms are selected", async () => {
     const onSubmit = jest.fn();
 
     tree({ onSubmit });
-    fireEvent.change(screen.getByLabelText('Password *'), { target: { value: 'password123' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), { target: { value: 'test' } });
     fireEvent.click(screen.getByRole('checkbox'));
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    await act(() => Promise.resolve());
     expect(onSubmit).not.toBeCalled();
   });
 
-  it("doesn't submit if email and password are set but invalid, and terms are selected", () => {
+  it("doesn't submit if email and password are set but invalid, and terms are selected", async () => {
     const onSubmit = jest.fn();
 
     tree({ onSubmit });
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), { target: { value: 'test' } });
-    fireEvent.change(screen.getByLabelText('Password *'), { target: { value: 'foo' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'foo' } });
     fireEvent.click(screen.getByRole('checkbox'));
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    await act(() => Promise.resolve());
     expect(onSubmit).not.toBeCalled();
   });
 
-  it("doesn't submit if email and password are valid, but terms aren't selected", () => {
+  it("doesn't submit if email and password are valid, but terms aren't selected", async () => {
     const onSubmit = jest.fn();
 
     tree({ onSubmit });
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), { target: { value: 'test@test.com' } });
-    fireEvent.change(screen.getByLabelText('Password *'), { target: { value: 'password123' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
     expect(screen.getByRole('checkbox')).not.toBeChecked();
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    await act(() => Promise.resolve());
     expect(onSubmit).not.toBeCalled();
   });
 
-  it('submits if email and password are valid and terms are selected', () => {
+  it('submits if email and password are valid and terms are selected', async () => {
     const onSubmit = jest.fn();
 
     tree({ onSubmit });
     fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), { target: { value: 'test@test.com' } });
-    fireEvent.change(screen.getByLabelText('Password *'), { target: { value: 'password123' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
     expect(screen.getByRole('checkbox')).not.toBeChecked();
     fireEvent.click(screen.getByRole('checkbox'));
     expect(screen.getByRole('checkbox')).toBeChecked();
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    await waitFor(() => expect(onSubmit).toBeCalled());
     expect(onSubmit.mock.calls).toEqual([['test@test.com', 'password123']]);
   });
 

--- a/spa/src/components/account/SignUp/SignUpForm.tsx
+++ b/spa/src/components/account/SignUp/SignUpForm.tsx
@@ -1,9 +1,9 @@
 import PropTypes, { InferProps } from 'prop-types';
-import { FormEvent, useEffect, useRef, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { Button, Checkbox, FormControlLabel, Link } from 'components/base';
 import PasswordField from 'components/common/TextField/PasswordField/PasswordField';
 import { PRIVACY_POLICY_URL, TS_AND_CS_URL } from 'constants/helperUrls';
-import { EmailField, Root } from './SignUpForm.styled';
+import { AgreedError, EmailField, Root } from './SignUpForm.styled';
 
 const SignUpFormPropTypes = {
   disabled: PropTypes.bool,
@@ -19,77 +19,97 @@ export interface SignUpFormProps extends InferProps<typeof SignUpFormPropTypes> 
 }
 
 export function SignUpForm({ disabled, errorMessage, onSubmit }: SignUpFormProps) {
-  const formRef = useRef<HTMLFormElement>(null);
-  const passwordRef = useRef<HTMLInputElement>(null);
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [agreed, setAgreed] = useState(false);
-
-  // Update field validation.
-
-  useEffect(() => {
-    if (!passwordRef.current) {
-      return;
+  const {
+    control,
+    formState: { errors },
+    handleSubmit
+  } = useForm({
+    defaultValues: {
+      agreed: false,
+      email: '',
+      password: ''
     }
-
-    if (password.length < 8) {
-      passwordRef.current.setCustomValidity('Passwords must be at least 8 characters long.');
-    } else {
-      passwordRef.current.setCustomValidity('');
-    }
-  }, [password.length]);
-
-  function handleSubmit(event: FormEvent) {
-    event.preventDefault();
-
-    if (disabled || !formRef.current || !formRef.current.reportValidity()) {
-      return;
-    }
-
-    onSubmit(email, password);
-  }
+  });
 
   return (
-    <Root onSubmit={handleSubmit} ref={formRef}>
-      <EmailField
-        error={!!errorMessage?.email}
-        fullWidth
-        helperText={errorMessage?.email}
-        id="email"
-        label="Email"
-        onChange={({ target }) => setEmail(target.value)}
-        required
-        type="email"
-        value={email}
+    <Root noValidate onSubmit={handleSubmit(({ email, password }) => onSubmit(email, password))}>
+      <Controller
+        control={control}
+        name="email"
+        rules={{
+          pattern: {
+            value: /\S+@\S+\.\S+/,
+            message: 'Please enter a valid email address.'
+          },
+          required: 'Please enter your email address.'
+        }}
+        render={({ field }) => (
+          <EmailField
+            error={!!errors.email || !!errorMessage?.email}
+            fullWidth
+            helperText={errors.email?.message ?? errorMessage?.email}
+            id="email"
+            label="Email"
+            type="email"
+            {...field}
+          />
+        )}
       />
-      <PasswordField
-        error={!!errorMessage?.password}
-        fullWidth
-        helperText={errorMessage?.password ?? 'Password must be at least 8 characters long.'}
-        id="password"
-        inputRef={passwordRef}
-        label="Password"
-        onChange={({ target }) => setPassword(target.value)}
-        required
-        value={password}
+      <Controller
+        control={control}
+        name="password"
+        rules={{
+          required: 'Please enter a password.',
+          minLength: {
+            value: 8,
+            message: 'Your password must be at least 8 characters long.'
+          }
+        }}
+        render={({ field }) => {
+          const { ref, ...other } = field;
+
+          return (
+            <PasswordField
+              error={!!errors.password || !!errorMessage?.password}
+              fullWidth
+              helperText={
+                errors.password?.message ?? errorMessage?.password ?? 'Password must be at least 8 characters long.'
+              }
+              id="password"
+              inputRef={ref}
+              label="Password"
+              {...other}
+            />
+          );
+        }}
       />
-      <FormControlLabel
-        checked={agreed}
-        control={<Checkbox required />}
-        label={
+      <Controller
+        control={control}
+        name="agreed"
+        rules={{
+          required: 'You must agree to the terms and conditions in order to create an account.'
+        }}
+        render={({ field }) => (
           <>
-            I agree to News Revenue Hub's{' '}
-            <Link href={TS_AND_CS_URL} target="_blank">
-              Terms & Conditions
-            </Link>{' '}
-            and{' '}
-            <Link href={PRIVACY_POLICY_URL} target="_blank">
-              Privacy Policy
-            </Link>
-            .
+            <FormControlLabel
+              control={<Checkbox {...field} />}
+              label={
+                <>
+                  I agree to News Revenue Hub's{' '}
+                  <Link href={TS_AND_CS_URL} target="_blank">
+                    Terms & Conditions
+                  </Link>{' '}
+                  and{' '}
+                  <Link href={PRIVACY_POLICY_URL} target="_blank">
+                    Privacy Policy
+                  </Link>
+                  .
+                </>
+              }
+            />
+            {errors.agreed && <AgreedError>{errors.agreed.message}</AgreedError>}
           </>
-        }
-        onChange={({ target }) => setAgreed((target as HTMLInputElement).checked)}
+        )}
       />
       <Button disabled={!!disabled} fullWidth type="submit">
         Create Account


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Moves account signup form to use react-hook-form.

#### Why are we doing this? How does it help us?

Moves us toward using a consistent approach on validation.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4892

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

Continue migrating other account forms.