### PR TITLE
Hotfix: solve for payment_intent id is null causing recurring calls to retreive PM id and update all null provider payment id contributions

### DIFF
--- a/apps/contributions/tests/test_webhooks.py
+++ b/apps/contributions/tests/test_webhooks.py
@@ -151,3 +151,25 @@ class TestStripeWebhookProcessor:
         processor = StripeWebhookProcessor(event=StripeEventData(**payment_intent_succeeded_one_time_event))
         mocker.patch.object(processor, "contribution", return_value=None, new_callable=mocker.PropertyMock)
         processor._add_pm_id_and_payment_method_details(pm_id="pm_id", update_data={})
+
+    def test_handle_payment_method_attached_when_no_customer_id(self, mocker, payment_method_attached_event):
+        payment_method_attached_event["data"]["object"]["customer"] = None
+        processor = StripeWebhookProcessor(event=StripeEventData(**payment_method_attached_event))
+        mocker.patch.object(processor, "contribution", return_value=None, new_callable=mocker.PropertyMock)
+        mock_update_pm = mocker.patch.object(processor, "_handle_pm_update_event")
+        processor.handle_payment_method_attached()
+        mock_update_pm.assert_not_called()
+
+    def test_handle_charge_succeeded_when_payment_intent_is_null(self, mocker, charge_succeeded_event):
+        mock_logger = mocker.patch("apps.contributions.webhooks.logger.warning")
+        charge_succeeded_event["data"]["object"]["payment_intent"] = None
+        processor = StripeWebhookProcessor(event=StripeEventData(**charge_succeeded_event))
+        mock_update_pm = mocker.patch.object(processor, "_handle_pm_update_event")
+        mocker.patch.object(processor, "contribution", return_value=None, new_callable=mocker.PropertyMock)
+        processor.handle_charge_succeeded()
+        mock_logger.assert_called_once_with(
+            "No payment intent ID found in charge succeeded event with id %s for account %s",
+            charge_succeeded_event["id"],
+            processor.event.account,
+        )
+        mock_update_pm.assert_not_called()

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -165,6 +165,7 @@ class StripeWebhookProcessor:
         return data
 
     def _handle_pm_update_event(self, query: dict, pm_id: str, caller: str) -> None:
+        logger.info("Updating contributions matching query %s with payment method data for id %s", query, pm_id)
         updated = 0
         # TODO @BW: Make this a .get() instead of .filter() once provider_payment_id is unique
         # DEV-4915

--- a/apps/contributions/webhooks.py
+++ b/apps/contributions/webhooks.py
@@ -215,7 +215,11 @@ class StripeWebhookProcessor:
                 caller="StripeWebhookProcessor.handle_charge_succeeded",
             )
         else:
-            logger.warning("No payment intent ID found in charge succeeded event")
+            logger.warning(
+                "No payment intent ID found in charge succeeded event with id %s for account %s",
+                self.event_id,
+                self.event.account,
+            )
 
     def handle_payment_intent_canceled(self):
         self._handle_contribution_update(


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

Hotfix a bug to unbreak prod. Come back later and figure out tests and any other next steps.  We'll specifically want to run down which circumstances cause a charge.succeeded with no PI.

#### What's this PR do?

Solves for a bug whereby:

- We attempt to update contributions for a charge.succeeded event even if payment intent for the charge is null
- We retrieve the PM from stripe for each contribution in our db that has null value for provider payment ID

#### Why are we doing this? How does it help us?

Unbreak prod

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

No

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

No. This is urgent hotfix.

#### How should this change be communicated to end users?


TBD. Will need to determine if affected transactions.


#### Are there any smells or added technical debt to note?


Not testing new conditional paths introduced just yet, but can do in followup.


#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

ITS-2445

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No tickets yet but we will continue ongoing discussion in Slack and create tickets as needed.