### PR TITLE
DEV-4868: Handle empty Billing History section in Portal

### DIFF
--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.stories.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.stories.tsx
@@ -29,3 +29,8 @@ Default.args = {
     }
   ]
 };
+
+export const NoPayments: Story = {};
+NoPayments.args = {
+  payments: []
+};

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.styled.ts
@@ -30,3 +30,9 @@ export const TableRow = styled(BaseTableRow)`
     }
   }
 `;
+
+export const EmptyBillingHistory = styled.p`
+  color: ${({ theme }) => theme.basePalette.greyscale.grey1};
+  font-size: ${({ theme }) => theme.fontSizesUpdated.sm};
+  font-weight: 400;
+`;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.styled.ts
@@ -35,4 +35,5 @@ export const EmptyBillingHistory = styled.p`
   color: ${({ theme }) => theme.basePalette.greyscale.grey1};
   font-size: ${({ theme }) => theme.fontSizesUpdated.sm};
   font-weight: 400;
+  margin: 0;
 `;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
@@ -34,7 +34,7 @@ describe('BillingHistory', () => {
 
   beforeEach(() => {
     usePortalMock.mockReturnValue({
-      page: { revenue_program: { organization: { send_receipt_email_via_nre: true } } }
+      page: { revenue_program: { name: 'Test Program', organization: { send_receipt_email_via_nre: true } } }
     } as any);
   });
 
@@ -119,9 +119,6 @@ describe('BillingHistory', () => {
 
   describe('when there are no payments (no billing history)', () => {
     it('shows a message with the revenue program name', () => {
-      usePortalMock.mockReturnValue({
-        page: { revenue_program: { name: 'Test Program' } }
-      } as any);
       tree({ payments: [] });
 
       expect(

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
@@ -6,6 +6,10 @@ import usePortal from 'hooks/usePortal';
 
 jest.mock('../DetailSection/DetailSection');
 jest.mock('hooks/usePortal');
+jest.mock('@material-ui/lab', () => ({
+  ...jest.requireActual('@material-ui/lab'),
+  Skeleton: () => <div data-testid="mock-skeleton" />
+}));
 
 const sendEmailReceipt = jest.fn();
 const mockPayments: PortalContributionPayment[] = [
@@ -143,6 +147,13 @@ describe('BillingHistory', () => {
       tree({ payments: [] });
 
       expect(screen.getByRole('button', { name: 'Resend receipt' })).toBeDisabled();
+    });
+
+    it('displays a skeleton if the revenue program name is not available (still loading)', () => {
+      usePortalMock.mockReturnValue({ page: { revenue_program: {} } } as any);
+      tree({ payments: [] });
+
+      expect(screen.getByTestId('mock-skeleton')).toBeInTheDocument();
     });
 
     it('is accessible', async () => {

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
@@ -117,6 +117,31 @@ describe('BillingHistory', () => {
     expect(sendEmailReceipt).toBeCalledTimes(1);
   });
 
+  describe('when there are no payments (no billing history)', () => {
+    it('shows a message with the revenue program name', () => {
+      usePortalMock.mockReturnValue({
+        page: { revenue_program: { name: 'Test Program' } }
+      } as any);
+      tree({ payments: [] });
+
+      expect(
+        screen.getByText('Please contact Test Program for billing history and prior receipts for this contribution.')
+      ).toBeInTheDocument();
+    });
+
+    it('disables the resend receipt button', () => {
+      tree({ payments: [] });
+
+      expect(screen.getByRole('button', { name: 'Resend receipt' })).toBeDisabled();
+    });
+
+    it('is accessible', async () => {
+      const { container } = tree({ payments: [] });
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
   it('is accessible', async () => {
     const { container } = tree();
 

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
@@ -129,6 +129,19 @@ describe('BillingHistory', () => {
       ).toBeInTheDocument();
     });
 
+    it('shows the revenue program email', () => {
+      usePortalMock.mockReturnValue({
+        page: { revenue_program: { name: 'Test Program', contact_email: 'mock@email.com' } }
+      } as any);
+      tree({ payments: [] });
+
+      expect(screen.getByText('Please contact Test Program', { exact: false })).toBeInTheDocument();
+      expect(
+        screen.getByText('for billing history and prior receipts for this contribution.', { exact: false })
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'mock@email.com' })).toHaveAttribute('href', 'mailto:mock@email.com');
+    });
+
     it('disables the resend receipt button', () => {
       tree({ payments: [] });
 

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -3,7 +3,7 @@ import { PortalContributionPayment } from 'hooks/usePortalContribution';
 import PropTypes, { InferProps } from 'prop-types';
 import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
 import { DetailSection } from '../DetailSection';
-import { TableCell, TableHead, TableRow } from './BillingHistory.styled';
+import { EmptyBillingHistory, TableCell, TableHead, TableRow } from './BillingHistory.styled';
 import { SectionControlButton } from '../common.styled';
 import usePortal from 'hooks/usePortal';
 
@@ -28,13 +28,18 @@ const dateFormatter = Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'n
 export function BillingHistory({ disabled, payments, onSendEmailReceipt }: BillingHistoryProps) {
   const { page } = usePortal();
   const sendNreEmail = page?.revenue_program?.organization?.send_receipt_email_via_nre;
+  const hasPayments = payments.length > 0;
 
   return (
     <DetailSection
       disabled={disabled}
       title="Billing History"
       controls={
-        sendNreEmail && <SectionControlButton onClick={onSendEmailReceipt}>Resend receipt</SectionControlButton>
+        sendNreEmail && (
+          <SectionControlButton onClick={onSendEmailReceipt} disabled={!hasPayments}>
+            Resend receipt
+          </SectionControlButton>
+        )
       }
     >
       <Table>
@@ -46,13 +51,24 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
           </TableRow>
         </TableHead>
         <TableBody>
-          {payments.map((payment, index) => (
-            <TableRow key={index}>
-              <TableCell>{dateFormatter.format(new Date(payment.created))}</TableCell>
-              <TableCell>{formatCurrencyAmount(payment.gross_amount_paid)}</TableCell>
-              <TableCell>{PAYMENT_STATUS_NAMES[payment.status]}</TableCell>
+          {hasPayments ? (
+            payments.map((payment, index) => (
+              <TableRow key={index}>
+                <TableCell>{dateFormatter.format(new Date(payment.created))}</TableCell>
+                <TableCell>{formatCurrencyAmount(payment.gross_amount_paid)}</TableCell>
+                <TableCell>{PAYMENT_STATUS_NAMES[payment.status]}</TableCell>
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={3}>
+                <EmptyBillingHistory>
+                  Please contact {page?.revenue_program.name} for billing history and prior receipts for this
+                  contribution.
+                </EmptyBillingHistory>
+              </TableCell>
             </TableRow>
-          ))}
+          )}
         </TableBody>
       </Table>
     </DetailSection>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -60,25 +60,21 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
               </TableRow>
             ))
           ) : (
-            <TableRow>
-              <TableCell colSpan={3}>
-                <EmptyBillingHistory>
-                  Please contact {page?.revenue_program.name}
-                  {page?.revenue_program.contact_email ? (
-                    <>
-                      {' '}
-                      at{' '}
-                      <Link href={`mailto:${page?.revenue_program.contact_email}`}>
-                        {page?.revenue_program.contact_email}
-                      </Link>
-                    </>
-                  ) : (
-                    ''
-                  )}{' '}
-                  for billing history and prior receipts for this contribution.
-                </EmptyBillingHistory>
-              </TableCell>
-            </TableRow>
+            <EmptyBillingHistory>
+              Please contact {page?.revenue_program.name}
+              {page?.revenue_program.contact_email ? (
+                <>
+                  {' '}
+                  at{' '}
+                  <Link href={`mailto:${page?.revenue_program.contact_email}`}>
+                    {page?.revenue_program.contact_email}
+                  </Link>
+                </>
+              ) : (
+                ''
+              )}{' '}
+              for billing history and prior receipts for this contribution.
+            </EmptyBillingHistory>
           )}
         </TableBody>
       </Table>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -66,6 +66,7 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
                   Please contact {page?.revenue_program.name}
                   {page?.revenue_program.contact_email ? (
                     <>
+                      {' '}
                       at{' '}
                       <Link href={`mailto:${page?.revenue_program.contact_email}`}>
                         {page?.revenue_program.contact_email}

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -1,4 +1,4 @@
-import { Table, TableBody } from 'components/base';
+import { Link, Table, TableBody } from 'components/base';
 import { PortalContributionPayment } from 'hooks/usePortalContribution';
 import PropTypes, { InferProps } from 'prop-types';
 import formatCurrencyAmount from 'utilities/formatCurrencyAmount';
@@ -63,8 +63,18 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
             <TableRow>
               <TableCell colSpan={3}>
                 <EmptyBillingHistory>
-                  Please contact {page?.revenue_program.name} for billing history and prior receipts for this
-                  contribution.
+                  Please contact {page?.revenue_program.name}
+                  {page?.revenue_program.contact_email ? (
+                    <>
+                      at{' '}
+                      <Link href={`mailto:${page?.revenue_program.contact_email}`}>
+                        {page?.revenue_program.contact_email}
+                      </Link>
+                    </>
+                  ) : (
+                    ''
+                  )}{' '}
+                  for billing history and prior receipts for this contribution.
                 </EmptyBillingHistory>
               </TableCell>
             </TableRow>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -6,6 +6,7 @@ import { DetailSection } from '../DetailSection';
 import { EmptyBillingHistory, TableCell, TableHead, TableRow } from './BillingHistory.styled';
 import { SectionControlButton } from '../common.styled';
 import usePortal from 'hooks/usePortal';
+import { Skeleton } from '@material-ui/lab';
 
 const BillingHistoryPropTypes = {
   disabled: PropTypes.bool,
@@ -30,13 +31,31 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
   const sendNreEmail = page?.revenue_program?.organization?.send_receipt_email_via_nre;
   const hasPayments = payments.length > 0;
 
+  const renderEmptyBillingHistory = () =>
+    page?.revenue_program.name ? (
+      <EmptyBillingHistory>
+        Please contact {page?.revenue_program.name}
+        {page?.revenue_program.contact_email ? (
+          <>
+            {' '}
+            at <Link href={`mailto:${page?.revenue_program.contact_email}`}>{page?.revenue_program.contact_email}</Link>
+          </>
+        ) : (
+          ''
+        )}{' '}
+        for billing history and prior receipts for this contribution.
+      </EmptyBillingHistory>
+    ) : (
+      <Skeleton variant="rect" height={20} />
+    );
+
   return (
     <DetailSection
       disabled={disabled}
       title="Billing History"
       controls={
         sendNreEmail && (
-          <SectionControlButton onClick={onSendEmailReceipt} disabled={!hasPayments}>
+          <SectionControlButton $cursorNotAllowed onClick={onSendEmailReceipt} disabled={!hasPayments}>
             Resend receipt
           </SectionControlButton>
         )
@@ -51,31 +70,15 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
           </TableRow>
         </TableHead>
         <TableBody>
-          {hasPayments ? (
-            payments.map((payment, index) => (
-              <TableRow key={index}>
-                <TableCell>{dateFormatter.format(new Date(payment.created))}</TableCell>
-                <TableCell>{formatCurrencyAmount(payment.gross_amount_paid)}</TableCell>
-                <TableCell>{PAYMENT_STATUS_NAMES[payment.status]}</TableCell>
-              </TableRow>
-            ))
-          ) : (
-            <EmptyBillingHistory>
-              Please contact {page?.revenue_program.name}
-              {page?.revenue_program.contact_email ? (
-                <>
-                  {' '}
-                  at{' '}
-                  <Link href={`mailto:${page?.revenue_program.contact_email}`}>
-                    {page?.revenue_program.contact_email}
-                  </Link>
-                </>
-              ) : (
-                ''
-              )}{' '}
-              for billing history and prior receipts for this contribution.
-            </EmptyBillingHistory>
-          )}
+          {hasPayments
+            ? payments.map((payment, index) => (
+                <TableRow key={index}>
+                  <TableCell>{dateFormatter.format(new Date(payment.created))}</TableCell>
+                  <TableCell>{formatCurrencyAmount(payment.gross_amount_paid)}</TableCell>
+                  <TableCell>{PAYMENT_STATUS_NAMES[payment.status]}</TableCell>
+                </TableRow>
+              ))
+            : renderEmptyBillingHistory()}
         </TableBody>
       </Table>
     </DetailSection>

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/common.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/common.styled.ts
@@ -17,7 +17,7 @@ export const Columns = styled.div`
 /**
  * Buttons that appear in the header of each section.
  */
-export const SectionControlButton = styled(Button)`
+export const SectionControlButton = styled(Button)<{ $cursorNotAllowed: boolean }>`
   && {
     background: none;
     box-shadow: none;
@@ -37,7 +37,7 @@ export const SectionControlButton = styled(Button)`
     background-color: unset;
 
     .NreButtonLabel {
-      cursor: not-allowed;
+      ${({ $cursorNotAllowed }) => $cursorNotAllowed && 'cursor: not-allowed;'}
       color: ${({ theme }) => theme.basePalette.greyscale.grey2};
     }
   }

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/common.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/common.styled.ts
@@ -32,6 +32,15 @@ export const SectionControlButton = styled(Button)`
       color: ${({ theme }) => theme.basePalette.primary.engineBlue};
     }
   }
+
+  &&.Mui-disabled {
+    background-color: unset;
+
+    .NreButtonLabel {
+      cursor: not-allowed;
+      color: ${({ theme }) => theme.basePalette.greyscale.grey2};
+    }
+  }
 `;
 
 export const SectionEditButton = styled(Button)`

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/common.styled.ts
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/common.styled.ts
@@ -17,7 +17,7 @@ export const Columns = styled.div`
 /**
  * Buttons that appear in the header of each section.
  */
-export const SectionControlButton = styled(Button)<{ $cursorNotAllowed: boolean }>`
+export const SectionControlButton = styled(Button)<{ $cursorNotAllowed?: boolean }>`
   && {
     background: none;
     box-shadow: none;


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
Handles when Billing History is empty in Portal
#### Why are we doing this? How does it help us?
Improves usability for donors that have active payments, but no payment history to understand what is going on
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
yes
#### Have automated unit tests been added? If not, why?
yes
#### How should this change be communicated to end users?
n/a
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
no
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-4868
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
no