### PR TITLE
DEV-5035: Show transaction date, not payment creation date, in billing history

### DIFF
--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.test.tsx
@@ -14,7 +14,8 @@ const mockPayments: PortalContributionPayment[] = [
     created: new Date('1/1/2001').toISOString(),
     gross_amount_paid: 12345,
     net_amount_paid: 12345,
-    status: 'paid'
+    status: 'paid',
+    transaction_time: new Date('1/1/3001').toISOString()
   },
   {
     amount_refunded: 678,
@@ -22,6 +23,7 @@ const mockPayments: PortalContributionPayment[] = [
     gross_amount_paid: 678,
     net_amount_paid: 678,
     status: 'refunded'
+    // transaction_time omitted intentionally to test fallback.
   }
 ];
 
@@ -66,12 +68,14 @@ describe('BillingHistory', () => {
     expect(screen.getAllByRole('row').length).toBe(mockPayments.length + 1);
   });
 
-  it('shows formatted dates in the first column', () => {
+  it('shows formatted transaction dates in the first column, falling back to creation time if not present', () => {
     tree();
 
     const rows = screen.getAllByRole('row');
 
-    expect(within(rows[1]).getAllByRole('cell')[0]).toHaveTextContent('1/1/2001');
+    // Our second mock payment has no transaction_time.
+
+    expect(within(rows[1]).getAllByRole('cell')[0]).toHaveTextContent('1/1/3001');
     expect(within(rows[2]).getAllByRole('cell')[0]).toHaveTextContent('1/2/2001');
   });
 

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingHistory/BillingHistory.tsx
@@ -48,7 +48,7 @@ export function BillingHistory({ disabled, payments, onSendEmailReceipt }: Billi
         <TableBody>
           {payments.map((payment, index) => (
             <TableRow key={index}>
-              <TableCell>{dateFormatter.format(new Date(payment.created))}</TableCell>
+              <TableCell>{dateFormatter.format(new Date(payment.transaction_time ?? payment.created))}</TableCell>
               <TableCell>{formatCurrencyAmount(payment.gross_amount_paid)}</TableCell>
               <TableCell>{PAYMENT_STATUS_NAMES[payment.status]}</TableCell>
             </TableRow>

--- a/spa/src/hooks/usePortalContribution.test.tsx
+++ b/spa/src/hooks/usePortalContribution.test.tsx
@@ -34,7 +34,8 @@ const mockContributionResponse = {
   next_payment_date: '',
   payment_type: 'mock-payment-type-1',
   revenue_program: 1,
-  status: 'paid'
+  status: 'paid',
+  transaction_time: 'mock-transaction-time-1'
 };
 
 function hook(contributorId: number, contributionId: number) {

--- a/spa/src/hooks/usePortalContribution.tsx
+++ b/spa/src/hooks/usePortalContribution.tsx
@@ -13,7 +13,8 @@ export interface PortalContributionPayment {
    */
   amount_refunded: number;
   /**
-   * Timestamp when the payment occurred.
+   * Timestamp when the payment was created. This may *not* be the same as when
+   * the payment actually occurred.
    */
   created: string;
   /**
@@ -28,6 +29,11 @@ export interface PortalContributionPayment {
    * Type of payment.
    */
   status: 'paid' | 'refunded';
+  /**
+   * Timestamp of when the transaction occurred. If omitted, this data isn't
+   * available and we should fall back to `created`.
+   */
+  transaction_time?: string;
 }
 
 export interface PortalContributionDetail extends PortalContribution {


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Changes the billing history section to show transaction time instead of creation time where available. **If transaction time is unset, this falls back to showing the creation time.**

#### Why are we doing this? How does it help us?

Shows correct dates in portal.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5035

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.