### PR TITLE
DEV-5037 | Short term fix for excluding duplicated recurring contributions

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -194,6 +194,17 @@ class ContributionQuerySet(models.QuerySet):
     def exclude_hidden_statuses(self) -> models.QuerySet[Contribution]:
         return self.exclude(status__in=self.CONTRIBUTOR_HIDDEN_STATUSES)
 
+    def exclude_recurring_missing_provider_subscription_id(self) -> models.QuerySet[Contribution]:
+        """Exclude contributions that are recurring and that don't have a provider subscription ID.
+
+        See this comment in JIRA for explanation of why this is necessary:
+        https://news-revenue-hub.atlassian.net/browse/DEV-5037?focusedCommentId=120074
+        """
+        return self.exclude(
+            models.Q(provider_subscription_id="") | models.Q(provider_subscription_id__isnull=True),
+            interval__in=[ContributionInterval.MONTHLY, ContributionInterval.YEARLY],
+        )
+
     def exclude_paymentless_canceled(self) -> models.QuerySet[Contribution]:
         return self.annotate(num_payments=models.Count("payment")).exclude(
             num_payments=0, status=ContributionStatus.CANCELED

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -1791,6 +1791,14 @@ class TestContributionModel:
             contribution.provider_customer_id, stripe_account=contribution.stripe_account_id
         )
 
+    def test_exclude_recurring_missing_provider_subscription_id(self, mocker):
+        ContributionFactory(provider_subscription_id=None, monthly_subscription=True, status=ContributionStatus.PAID)
+        expected = ContributionFactory(
+            provider_subscription_id="something", monthly_subscription=True, status=ContributionStatus.PAID
+        )
+        assert (returned := Contribution.objects.exclude_recurring_missing_provider_subscription_id()).count() == 1
+        assert returned.first() == expected
+
     @pytest.mark.parametrize("status", ContributionQuerySet.CONTRIBUTOR_HIDDEN_STATUSES)
     def test_exclude_hidden_statuses(self, status):
         ContributionFactory(status=status)

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -2306,9 +2306,13 @@ class TestPortalContributorsViewSet:
     def test_get_contributor_queryset(self, mocker):
         exclude_hidden_spy = mocker.spy(ContributionQuerySet, "exclude_hidden_statuses")
         exclude_paymentless_spy = mocker.spy(ContributionQuerySet, "exclude_paymentless_canceled")
+        exclude_missing_stripe_sub_id = mocker.spy(
+            ContributionQuerySet, "exclude_recurring_missing_provider_subscription_id"
+        )
         contributions_views.PortalContributorsViewSet().get_contributor_queryset(contributor=ContributorFactory())
         exclude_hidden_spy.assert_called_once()
         exclude_paymentless_spy.assert_called_once()
+        exclude_missing_stripe_sub_id.assert_called_once()
 
 
 @pytest.mark.django_db()

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -617,7 +617,12 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         return Response(impact, status=status.HTTP_200_OK)
 
     def get_contributor_queryset(self, contributor):
-        return contributor.contribution_set.all().exclude_hidden_statuses().exclude_paymentless_canceled()
+        return (
+            contributor.contribution_set.all()
+            .exclude_hidden_statuses()
+            .exclude_paymentless_canceled()
+            .exclude_recurring_missing_provider_subscription_id()
+        )
 
     @action(
         methods=["get"],


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR makes a small code change to exclude contributions from portal where both of following are true:

- recurring
- missing provider_subscription_id

For a lengthy explanation of reasoning behind this, [please see this comment in JIRA](https://news-revenue-hub.atlassian.net/browse/DEV-5037?focusedCommentId=120074)

#### Why are we doing this? How does it help us?

Unblocks portal release and removes potentially confusing data from portal.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

N/A

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No


#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-5037](https://news-revenue-hub.atlassian.net/browse/DEV-5037)
- [DEV-5059](https://news-revenue-hub.atlassian.net/browse/DEV-5059)
- [DEV-5062](https://news-revenue-hub.atlassian.net/browse/DEV-5062)


#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

- [DEV-5059](https://news-revenue-hub.atlassian.net/browse/DEV-5059)
- [DEV-5062](https://news-revenue-hub.atlassian.net/browse/DEV-5062)


[DEV-5037]: https://news-revenue-hub.atlassian.net/browse/DEV-5037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ