### PR TITLE
DEV-5060 | Exclude abandoned contributions from org dashboard

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -144,6 +144,7 @@ class ContributionQuerySet(models.QuerySet):
         """Exclude contributions with statuses that should not be seen by org users from the queryset."""
         return self.exclude(
             status__in=[
+                ContributionStatus.ABANDONED,
                 ContributionStatus.FLAGGED,
                 ContributionStatus.REJECTED,
                 ContributionStatus.PROCESSING,

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -1862,8 +1862,13 @@ class TestContributionQuerySetMethods:
         assert {pi_1.id} == {item.id for item in results}
         spy.assert_not_called()
 
+    @pytest.fixture()
+    def abandoned_contribution(self):
+        return ContributionFactory(abandoned=True)
+
     def test_having_org_viewable_status(
         self,
+        abandoned_contribution,
         flagged_contribution,
         rejected_contribution,
         canceled_contribution,
@@ -1872,6 +1877,17 @@ class TestContributionQuerySetMethods:
         processing_contribution,
     ):
         """Show that this method excludes the expected statuses and includes the right ones."""
+        assert (
+            Contribution.objects.filter(
+                id__in=[
+                    abandoned_contribution.id,
+                    flagged_contribution.id,
+                    rejected_contribution.id,
+                    processing_contribution.id,
+                ]
+            ).count()
+            == 4
+        )
         assert set(Contribution.objects.having_org_viewable_status().values_list("id", flat=True)) == {
             canceled_contribution.id,
             refunded_contribution.id,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Adds abandoned to set of excluded statuses in `having_org_viewable_status` method.

#### Why are we doing this? How does it help us?

Orgs should not see abandoned contributions, and we missed this when originally adding that status.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-5060](https://news-revenue-hub.atlassian.net/browse/DEV-5060)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No

[DEV-5060]: https://news-revenue-hub.atlassian.net/browse/DEV-5060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ