### PR TITLE
DEV-4704: Send failed email if payment intent failed

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -149,8 +149,9 @@ class RequestContributorTokenEmailView(APIView):
     throttle_classes = [ContributorRateThrottle]
 
     @staticmethod
-    def get_magic_link(domain, token, email):
-        return f"https://{domain}/{settings.CONTRIBUTOR_VERIFY_URL}?token={token}&email={quote_plus(email)}"
+    def get_magic_link(domain, token, email, next_url=None):
+        redirect = f"&redirect={quote_plus(next_url)}" if next_url else ""
+        return f"https://{domain}/{settings.CONTRIBUTOR_VERIFY_URL}?token={token}&email={quote_plus(email)}{redirect}"
 
     def post(self, request, *args, **kwargs):
         logger.info("[RequestContributorTokenEmailView][post] Request received for magic link %s", request.data)

--- a/apps/emails/templates/nrh-default-contribution-base-template.html
+++ b/apps/emails/templates/nrh-default-contribution-base-template.html
@@ -194,12 +194,14 @@
               </tr>
               <tr>
                 <td style="padding-right: 0px;padding-left: 0px;" align="left">
+                  {% block update_contribution %}
                   <p class="text inner-center">
                     Need to make changes to your contribution?
                     <a class="link" href="{{ magic_link }}" target="_blank" rel="noopener noreferrer">
                       Manage contributions here
                     </a>
                   </p>
+                  {% endblock update_contribution %}
                 </td>
               </tr>
             </table>

--- a/apps/emails/templates/nrh-default-contribution-base-template.txt
+++ b/apps/emails/templates/nrh-default-contribution-base-template.txt
@@ -3,7 +3,7 @@
 {% endblock header %}
 
 ------------------------
-Contribution Details:
+{% block contribution_header %}Contribution Details:{% endblock contribution_header %}
 
 {% block timestamp_label %}{% endblock timestamp_label %}: {{ timestamp }}
 Email: {{ contributor_email }}
@@ -26,4 +26,6 @@ All contributions or gifts to {{ rp_name }} are tax deductible through our fisca
 Contributions to {{ rp_name }} are not deductible as charitable donations.
 {% endif %}{% endblock contribution_footer %}
 
+{% block update_contribution %}
 Need to make changes to your contribution? {% autoescape off %}{{ magic_link }}{% endautoescape %}
+{% endblock update_contribution %}

--- a/apps/emails/templates/nrh-default-contribution-failed-email.html
+++ b/apps/emails/templates/nrh-default-contribution-failed-email.html
@@ -1,0 +1,177 @@
+{% extends "nrh-default-contribution-base-template.html" %}
+
+{% block custom_style %}
+<style type="text/css">
+  .header-background {
+    width: 600px;
+    height: 80px;
+    text-align: center;
+    vertical-align: middle;
+    background: #ffffff;
+    {% if style.header_color %}
+    background: {{ style.header_color }} !important;
+    {% endif %}
+  }
+
+  .header-background.default {
+    background: none !important;
+    text-align: left;
+  }
+
+  .header-logo {
+    height: 56px;
+    margin-top: 17px;
+    margin-bottom: 17px;
+    max-width: 100%;
+    width: auto;
+  }
+
+  .header-logo.default {
+    height: 50px;
+    width: auto;
+  }
+
+  .thank-you-title {
+    font-family: Roboto, sans-serif;
+    color: #25192B;
+    font-size: 30px;
+    margin-top: 37px;
+    margin-bottom: 25px;
+  }
+
+  .user-info {
+    font-family: Roboto, sans-serif;
+    color: #282828;
+    font-size: 16px;
+  }
+
+  .user-info-second-line {
+    margin-top: 28px;
+    margin-bottom: 25px;
+  }
+
+  .outer-center {
+    margin-left: 34px;
+    margin-right: 34px;
+  }
+
+  .billing-history-header {
+    font-family: Roboto, sans-serif;
+    font-size: 18px;
+    color: #282828;
+    margin-bottom: 20px;
+  }
+
+  .billing-history-label {
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    color: #282828;
+    margin-bottom: 6px;
+  }
+
+  .billing-history-value {
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    color: #282828;
+    margin-bottom: 12px;
+  }
+
+  .button-wrapper {
+      padding-top: 40px;
+      padding-bottom: 35px;
+    }
+
+  .button {
+    margin-left: 160px;
+    margin-right: 160px;
+    text-transform: uppercase;
+    background: #523A5E;
+    color: #ffffff !important;
+    border-radius: 6px;
+    font-family: 'Roboto';
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 16px;
+    text-decoration: none;
+    text-transform: uppercase;
+    padding: 15px 50px;
+    width: 270px;
+    {% if style.button_color %}
+    background: {{ style.button_color }} !important;
+    color: #ffffff !important;
+    {% endif %}
+  }
+</style>
+{% endblock custom_style %}
+
+{% block header %}
+{% if style.is_default_logo == True and style.logo_url %}
+<tr>
+  <td class="header-background default">
+    <img class="header-logo inner-center default" src="{{ style.logo_url }}" alt="{{ style.logo_alt_text }}" />
+  </td>
+</tr>
+{% elif style.logo_url %}
+<tr>
+  <td class="header-background">
+    <img class="header-logo" src="{{ style.logo_url }}" alt="{{ style.logo_alt_text }}" />
+  </td>
+</tr>
+{% endif %}
+<tr>
+  <td style="padding-right: 0px;padding-left: 0px;" align="left">
+    <h1 class="thank-you-title inner-center">Failed Contribution</h1>
+  </td>
+</tr>
+<tr>
+  <td style="padding-right: 0px;padding-left: 0px;" align="left">
+    <p class="user-info inner-center">
+      Dear {{ contributor_name }},
+    </p>
+    <p class="user-info user-info-second-line inner-center">
+      A recurring contribution to {{ rp_name }} failed to process on {{ timestamp }}. Please update the payment method on the Contributor Portal or reach out to {{ rp_name }} for assistance.
+    </p>
+  </td>
+</tr>
+{% endblock header %}
+
+{% block contribution_header %}Failed Contribution{% endblock contribution_header %}
+{% block timestamp_label %}Failed{% endblock timestamp_label %}
+
+{% block contribution_footer %}
+<tr>
+  <td>
+    <p class="inner-center user-info" style="font-weight: bold;">
+      Your contribution has a direct impact on the work that we do.
+    </p>
+  </td>
+</tr>
+<tr>
+  <td class="button-wrapper">
+    <a data-testid="magic-link" href="{{ magic_link }}" target="_blank" class="button">
+      Manage Contributions
+    </a>
+  </td>
+</tr>
+{% if rp_email %}
+<tr>
+  <td>
+    <p class="inner-center user-info" style="text-align: center;">
+      Or <span style="font-weight: bold;">email {{ rp_email }}</span>.
+    </p>
+  </td>
+</tr>
+{% endif %}
+<tr>
+  <td>
+    <p class="inner-center user-info" style="margin-top: 40px; margin-bottom: 60px;">
+      Already fixed this contribution? Please ignore this email.
+    </p>
+  </td>
+</tr>
+{% endblock contribution_footer %}
+
+{% block update_contribution %}
+{% endblock update_contribution %}

--- a/apps/emails/templates/nrh-default-contribution-failed-email.txt
+++ b/apps/emails/templates/nrh-default-contribution-failed-email.txt
@@ -1,0 +1,27 @@
+{% extends "nrh-default-contribution-base-template.txt" %}
+
+{% block header %}
+Failed Contribution
+
+Dear {{ contributor_name }},
+A recurring contribution to {{ rp_name }} failed to process on {{ timestamp }}. Please update the payment method on the Contributor Portal or reach out to {{ rp_name }} for assistance.
+{% endblock header %}
+
+{% block contribution_header %}Failed Contribution:{% endblock contribution_header %}
+
+{% block timestamp_label %}
+Failed
+{% endblock timestamp_label %}
+
+{% block contribution_footer %}
+Your contribution has a direct impact on the work that we do.
+Manage Contributions here: {{ magic_link }} {% if rp_email %} or email {{ rp_email }}{% endif %}.
+
+Already fixed this contribution? Please ignore this email.
+{% endblock contribution_footer %}
+
+{% block footer %}
+{% endblock footer %}
+
+{% block update_contribution %}
+{% endblock update_contribution %}

--- a/apps/emails/views.py
+++ b/apps/emails/views.py
@@ -17,6 +17,7 @@ PERMITTED_TEMPLATES = tuple(
             "recurring-contribution-canceled",
             "recurring-contribution-payment-updated",
             "nrh-default-contribution-confirmation-email",
+            "nrh-default-contribution-failed-email",
         ]
         for ext in ["html", "txt"]
     ]
@@ -43,11 +44,12 @@ def preview_contribution_email_template(request, template_name: str):
         "contribution_interval_display_value": "year",
         "timestamp": datetime.datetime.now(datetime.timezone.utc),
         "contribution_amount": "$123.45",
-        "contributor_name": "Contributor Name",
+        "contributor_name": "John Doe",
         "copyright_year": datetime.datetime.now(datetime.timezone.utc).year,
         "contributor_email": "nobody@fundjournalism.org",
         "magic_link": "https://magic-link",
         "rp_name": rp.name,
+        "rp_email": rp.contact_email,
         "style": rp_style,
         "default_contribution_page_url": rp.default_donation_page.page_url if rp.default_donation_page else None,
         "show_billing_history": True,

--- a/apps/organizations/tests/test_views.py
+++ b/apps/organizations/tests/test_views.py
@@ -1358,7 +1358,7 @@ class TestSendTestEmail:
     ):
         rp = hub_admin_user_with_rps_in_ra.roleassignment.revenue_programs.first()
         api_client.force_authenticate(hub_admin_user_with_rps_in_ra)
-        mocker.patch("apps.emails.tasks.get_test_magic_link", return_value="fake_magic_link")
+        mocker.patch("apps.emails.tasks.generate_magic_link", return_value="fake_magic_link")
         send_email_spy = mocker.spy(send_templated_email, "delay")
 
         api_client.post(
@@ -1408,7 +1408,7 @@ class TestSendTestEmail:
             else revenue_program
         )
 
-        mocker.patch("apps.emails.tasks.get_test_magic_link", return_value="fake_magic_link")
+        mocker.patch("apps.emails.tasks.generate_magic_link", return_value="fake_magic_link")
         send_thank_you_email_spy = mocker.spy(send_thank_you_email, "delay")
         expected_data = make_send_test_contribution_email_data(test_email_user, rp)
 
@@ -1428,7 +1428,7 @@ class TestSendTestEmail:
         )
 
         send_email_spy = mocker.spy(send_templated_email, "delay")
-        mocker.patch("apps.emails.tasks.get_test_magic_link", return_value="fake_magic_link")
+        mocker.patch("apps.emails.tasks.generate_magic_link", return_value="fake_magic_link")
         expected_data = make_send_test_contribution_email_data(test_email_user, rp)
 
         api_client.post(
@@ -1452,7 +1452,7 @@ class TestSendTestEmail:
         )
 
         send_email_spy = mocker.spy(send_templated_email, "delay")
-        mocker.patch("apps.emails.tasks.get_test_magic_link", return_value="fake_magic_link")
+        mocker.patch("apps.emails.tasks.generate_magic_link", return_value="fake_magic_link")
         expected_data = make_send_test_magic_link_email_data(test_email_user, rp)
         expected_data["style"]["logo_url"] = f"{settings.SITE_URL}/static/nre-logo-white.png"
         api_client.post(

--- a/spa/src/components/portal/TokenVerification/TokenVerification.test.tsx
+++ b/spa/src/components/portal/TokenVerification/TokenVerification.test.tsx
@@ -31,6 +31,12 @@ describe('TokenVerification', () => {
     expect(screen.getByTestId('mock-redirect').dataset.to).toBe('/portal/my-contributions/');
   });
 
+  it('redirects to the custom URL if redirect is a query param', () => {
+    useLocationMock.mockReturnValue({ search: '?email=mock-email&token=mock-token&redirect=/mock-redirect/' });
+    tree({ contributor: { mockContributor: true } as any });
+    expect(screen.getByTestId('mock-redirect').dataset.to).toBe('/mock-redirect/');
+  });
+
   describe("When the user isn't authenticated", () => {
     it.each([
       ['email', '?token=mock-token'],

--- a/spa/src/components/portal/TokenVerification/TokenVerification.tsx
+++ b/spa/src/components/portal/TokenVerification/TokenVerification.tsx
@@ -7,10 +7,10 @@ import TokenError from './TokenError';
 
 export function TokenVerification() {
   const { search } = useLocation();
-  const { email, token } = useMemo(() => {
+  const { email, token, redirect } = useMemo(() => {
     const params = new URLSearchParams(search);
 
-    return { email: params.get('email'), token: params.get('token') };
+    return { email: params.get('email'), token: params.get('token'), redirect: params.get('redirect') };
   }, [search]);
   const [error, setError] = useState<Error | undefined>(
     !email || !token ? new Error('Missing querystring params') : undefined
@@ -32,7 +32,7 @@ export function TokenVerification() {
   }, [email, token, verifyToken]);
 
   if (contributor) {
-    return <Redirect to={PORTAL.CONTRIBUTIONS} />;
+    return <Redirect to={redirect ?? PORTAL.CONTRIBUTIONS} />;
   }
 
   if (error) {


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a
#### What's this PR do?
- Sends "Failed Contribution" email if stripe triggers event "payment_intent.failed"
- Update "generate_magic_link" to include redirect query param when passed in as prop
- Create email template for "Failed Contribution"
- Handle "redirect" in FE after validating token
#### Why are we doing this? How does it help us?
- Warn user of a failed payment and send a magic link to redirect them directly to where they can update payment.
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
- not yet, not sure how to trigger failed payment
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
- yes, email template
#### Have automated unit tests been added? If not, why?
- yes
#### How should this change be communicated to end users?
- Failed payment email is sent to donors with a link to fix the issue
#### Are there any smells or added technical debt to note?
- no
#### Has this been documented? If so, where?
- no
#### What are the relevant tickets? Add a link to any relevant ones.
- https://news-revenue-hub.atlassian.net/browse/DEV-4704
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
- no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
- no