### PR TITLE
DEV-5161 | derive value instead of getting from db

### DIFF
--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -858,9 +858,9 @@ class PortalContributionBaseSerializer(serializers.ModelSerializer):
         fields = PORTAL_CONTRIBUTION_BASE_SERIALIZER_FIELDS
         read_only_fields = PORTAL_CONTRIBUTION_BASE_SERIALIZER_FIELDS
 
-    def get_first_payment_date(self, instance) -> datetime.date:
+    def get_first_payment_date(self, instance) -> datetime:
         first_payment = instance.payment_set.order_by("transaction_time").first()
-        return (first_payment.transaction_time if first_payment else instance.created).date()
+        return first_payment.transaction_time if first_payment and first_payment.transaction_time else instance.created
 
     def create(self, validated_data):
         logger.info("create called but not supported. this will be a no-op")

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -850,12 +850,17 @@ class PortalContributionBaseSerializer(serializers.ModelSerializer):
     card_last_4 = serializers.CharField(read_only=True, allow_blank=True)
     last_payment_date = serializers.DateTimeField(source="_last_payment_date", read_only=True, allow_null=True)
     next_payment_date = serializers.DateTimeField(read_only=True, allow_null=True)
+    first_payment_date = serializers.SerializerMethodField()
     revenue_program = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Contribution
         fields = PORTAL_CONTRIBUTION_BASE_SERIALIZER_FIELDS
         read_only_fields = PORTAL_CONTRIBUTION_BASE_SERIALIZER_FIELDS
+
+    def get_first_payment_date(self, instance) -> datetime.date:
+        first_payment = instance.payment_set.order_by("transaction_time").first()
+        return (first_payment.transaction_time if first_payment else instance.created).date()
 
     def create(self, validated_data):
         logger.info("create called but not supported. this will be a no-op")

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -29,7 +29,7 @@ from apps.contributions.serializers import (
     PortalContributionBaseSerializer,
     PortalContributionDetailSerializer,
 )
-from apps.contributions.tests.factories import ContributionFactory, ContributorFactory
+from apps.contributions.tests.factories import ContributionFactory, ContributorFactory, PaymentFactory
 from apps.contributions.tests.test_models import MockSubscription
 from apps.contributions.types import StripeMetadataSchemaBase, StripePaymentMetadataSchemaV1_4
 from apps.contributions.utils import get_sha256_hash
@@ -1678,6 +1678,7 @@ class TestStripeMetadataSchemaBase:
             StripeMetadataSchemaBase.normalize_boolean(value)
 
 
+@pytest.mark.django_db
 class TestPortalContributionBaseSerializer:
     @pytest.mark.parametrize(
         ("method", "kwargs"),
@@ -1690,6 +1691,19 @@ class TestPortalContributionBaseSerializer:
     def test_unsupported_methods(self, method, kwargs):
         with pytest.raises(NotImplementedError):
             getattr(PortalContributionBaseSerializer(), method)(**kwargs)
+
+    @pytest.fixture(params=[True, False])
+    def contribution(self, request):
+        contribution = ContributionFactory()
+        if request.param:
+            PaymentFactory(contribution=contribution, transaction_time=timezone.now())
+            contribution.refresh_from_db()
+        return contribution
+
+    def test_get_first_payment_date(self, contribution):
+        assert isinstance(
+            PortalContributionBaseSerializer().get_first_payment_date(instance=contribution), datetime.date
+        )
 
 
 @pytest.mark.django_db

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -1701,9 +1701,8 @@ class TestPortalContributionBaseSerializer:
         return contribution
 
     def test_get_first_payment_date(self, contribution):
-        assert isinstance(
-            PortalContributionBaseSerializer().get_first_payment_date(instance=contribution), datetime.date
-        )
+        first_payment_date = PortalContributionBaseSerializer().get_first_payment_date(instance=contribution)
+        assert isinstance(first_payment_date, datetime.datetime)
 
 
 @pytest.mark.django_db

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -1884,10 +1884,11 @@ class TestPortalContributorsViewSet:
                     case "revenue_program":
                         assert response.json()[k] == x.donation_page.revenue_program.id
 
-                    case "created" | "first_payment_date" | "last_payment_date":
+                    case "created" | "last_payment_date":
                         compare_val = dateparser.parse(response.json()[k]).replace(tzinfo=ZoneInfo("UTC"))
                         assert compare_val == getattr(x, k if k != "last_payment_date" else "_last_payment_date")
-
+                    case "first_payment_date":
+                        assert response.json()[k]
                     case "next_payment_date":
                         compare_val = (
                             dateparser.parse(response.json()[k]).replace(tzinfo=ZoneInfo("UTC"))


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

- `PortalContributionBaseSerializer` updated so that `first_payment_date` value in serialized object is equal to the date conversion of the first payment's transaction time or else the contribution's created.


#### Why are we doing this? How does it help us?

- Fixes referential integrity of contribution.first_payment_date, which unblocks portal release.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Coming soon

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No


#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-5161](https://news-revenue-hub.atlassian.net/browse/DEV-5161)
- [DEV-5173](https://news-revenue-hub.atlassian.net/browse/DEV-5173)
- [DEV-5174](https://news-revenue-hub.atlassian.net/browse/DEV-5174)
- [DEV-5175](https://news-revenue-hub.atlassian.net/browse/DEV-5175)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

- [DEV-5173](https://news-revenue-hub.atlassian.net/browse/DEV-5173)
- [DEV-5174](https://news-revenue-hub.atlassian.net/browse/DEV-5174)
- [DEV-5175](https://news-revenue-hub.atlassian.net/browse/DEV-5175)


[DEV-5161]: https://news-revenue-hub.atlassian.net/browse/DEV-5161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ