### PR TITLE
DEV-5162: Sort contributions in list by first_payment_date

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -13,7 +13,7 @@ from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models import Q, Sum
+from django.db.models import Min, Q, Sum
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.safestring import SafeString, mark_safe
@@ -141,6 +141,10 @@ class ContributionQuerySet(models.QuerySet):
                 | Q(contribution_metadata__revenue_program__in=revenue_programs)
             )
         return self
+
+    def with_first_payment_date(self):
+        """Annotate the earliest Payment belonging to each contribution as "first_payment_date"."""
+        return self.annotate(first_payment_date=Min("payment__transaction_time"))
 
     def with_stripe_account(self):
         """Annotate stripe_account_id as "stripe_account".

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -848,19 +848,15 @@ class PortalContributionBaseSerializer(serializers.ModelSerializer):
     card_brand = serializers.CharField(read_only=True, allow_blank=True)
     card_expiration_date = serializers.CharField(read_only=True, allow_blank=True)
     card_last_4 = serializers.CharField(read_only=True, allow_blank=True)
+    first_payment_date = serializers.DateTimeField()
     last_payment_date = serializers.DateTimeField(source="_last_payment_date", read_only=True, allow_null=True)
     next_payment_date = serializers.DateTimeField(read_only=True, allow_null=True)
-    first_payment_date = serializers.SerializerMethodField()
     revenue_program = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Contribution
         fields = PORTAL_CONTRIBUTION_BASE_SERIALIZER_FIELDS
         read_only_fields = PORTAL_CONTRIBUTION_BASE_SERIALIZER_FIELDS
-
-    def get_first_payment_date(self, instance) -> datetime:
-        first_payment = instance.payment_set.order_by("transaction_time").first()
-        return first_payment.transaction_time if first_payment and first_payment.transaction_time else instance.created
 
     def create(self, validated_data):
         logger.info("create called but not supported. this will be a no-op")

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -2088,6 +2088,21 @@ class TestContributionQuerySetMethods:
             c.id for c in unmarked_abandoned_contributions
         }
 
+    def test_with_first_payment_date_when_payments_exist(self, monthly_contribution_multiple_payments):
+        contributions = Contribution.objects.with_first_payment_date()
+        first_payment = (
+            Payment.objects.filter(contribution_id=monthly_contribution_multiple_payments.id)
+            .order_by("transaction_time")
+            .first()
+        )
+        assert len(contributions) == 1
+        assert contributions[0].first_payment_date == first_payment.transaction_time
+
+    def test_with_first_payment_date_when_no_payments(self, one_time_contribution):
+        contributions = Contribution.objects.with_first_payment_date()
+        assert len(contributions) == 1
+        assert contributions[0].first_payment_date is None
+
     def test_with_stripe_account(self):
         contribution_1 = ContributionFactory(one_time=True)
         contribution_2 = ContributionFactory(

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -2090,18 +2090,16 @@ class TestContributionQuerySetMethods:
 
     def test_with_first_payment_date_when_payments_exist(self, monthly_contribution_multiple_payments):
         contributions = Contribution.objects.with_first_payment_date()
-        first_payment = (
-            Payment.objects.filter(contribution_id=monthly_contribution_multiple_payments.id)
-            .order_by("transaction_time")
-            .first()
-        )
-        assert len(contributions) == 1
-        assert contributions[0].first_payment_date == first_payment.transaction_time
+        assert contributions.count() == 1
+        assert (con := contributions.first()).first_payment_date == con.payment_set.exclude(
+            transaction_time__isnull=True
+        ).order_by("transaction_time").first().transaction_time
 
     def test_with_first_payment_date_when_no_payments(self, one_time_contribution):
         contributions = Contribution.objects.with_first_payment_date()
-        assert len(contributions) == 1
-        assert contributions[0].first_payment_date is None
+        assert contributions.count() == 1
+        assert Payment.objects.filter(contribution_id=contributions.first().id).count() == 0
+        assert contributions.first().first_payment_date is None
 
     def test_with_stripe_account(self):
         contribution_1 = ContributionFactory(one_time=True)

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -29,7 +29,7 @@ from apps.contributions.serializers import (
     PortalContributionBaseSerializer,
     PortalContributionDetailSerializer,
 )
-from apps.contributions.tests.factories import ContributionFactory, ContributorFactory, PaymentFactory
+from apps.contributions.tests.factories import ContributionFactory, ContributorFactory
 from apps.contributions.tests.test_models import MockSubscription
 from apps.contributions.types import StripeMetadataSchemaBase, StripePaymentMetadataSchemaV1_4
 from apps.contributions.utils import get_sha256_hash
@@ -1691,18 +1691,6 @@ class TestPortalContributionBaseSerializer:
     def test_unsupported_methods(self, method, kwargs):
         with pytest.raises(NotImplementedError):
             getattr(PortalContributionBaseSerializer(), method)(**kwargs)
-
-    @pytest.fixture(params=[True, False])
-    def contribution(self, request):
-        contribution = ContributionFactory()
-        if request.param:
-            PaymentFactory(contribution=contribution, transaction_time=timezone.now())
-            contribution.refresh_from_db()
-        return contribution
-
-    def test_get_first_payment_date(self, contribution):
-        first_payment_date = PortalContributionBaseSerializer().get_first_payment_date(instance=contribution)
-        assert isinstance(first_payment_date, datetime.datetime)
 
 
 @pytest.mark.django_db

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -564,8 +564,8 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
     """Furnish contributions data to the (new) contributor portal."""
 
     permission_classes = [IsAuthenticated, IsContributor, UserIsRequestedContributor]
-    DEFAULT_ORDERING_FIELDS = ["created"]
-    ALLOWED_ORDERING_FIELDS = ["created", "amount", "status"]
+    DEFAULT_ORDERING_FIELDS = ["created", "first_payment_date"]
+    ALLOWED_ORDERING_FIELDS = ["created", "amount", "first_payment_date", "status"]
     # NB: This view is about returning contributor.contributions and never returns contributors, but
     # we need to set a queryset to satisfy DRF's viewset expectations.
     queryset = Contributor.objects.all()
@@ -622,6 +622,7 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
             .exclude_hidden_statuses()
             .exclude_paymentless_canceled()
             .exclude_recurring_missing_provider_subscription_id()
+            .with_first_payment_date()
         )
 
     @action(

--- a/spa/src/components/portal/ContributionsList/ContributionsList.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.test.tsx
@@ -227,7 +227,7 @@ describe('ContributionsList', () => {
     it('should sort contributions by date by default', () => {
       tree();
       expect(usePortalContributionsListMock).toBeCalledWith(expect.anything(), expect.anything(), {
-        ordering: '-created'
+        ordering: '-first_payment_date'
       });
     });
 
@@ -246,7 +246,7 @@ describe('ContributionsList', () => {
 
       await waitFor(() => {
         expect(usePortalContributionsListMock).toBeCalledWith(expect.anything(), expect.anything(), {
-          ordering: `-${ordering},-created`
+          ordering: `-${ordering},-first_payment_date`
         });
       });
     });
@@ -256,7 +256,7 @@ describe('ContributionsList', () => {
     it('should show all contributions by default', () => {
       tree();
       expect(usePortalContributionsListMock).toBeCalledWith(expect.anything(), expect.anything(), {
-        ordering: '-created'
+        ordering: '-first_payment_date'
       });
     });
 
@@ -266,7 +266,7 @@ describe('ContributionsList', () => {
       userEvent.click(screen.getByRole('tab', { name: 'Recurring' }));
       await waitFor(() => {
         expect(usePortalContributionsListMock).toBeCalledWith(expect.anything(), expect.anything(), {
-          ordering: '-created',
+          ordering: '-first_payment_date',
           interval: 'recurring'
         });
       });
@@ -274,7 +274,7 @@ describe('ContributionsList', () => {
 
       await waitFor(() => {
         expect(usePortalContributionsListMock).toBeCalledWith(expect.anything(), expect.anything(), {
-          ordering: '-created'
+          ordering: '-first_payment_date'
         });
       });
     });
@@ -289,7 +289,7 @@ describe('ContributionsList', () => {
 
       await waitFor(() => {
         expect(usePortalContributionsListMock).toBeCalledWith(expect.anything(), expect.anything(), {
-          ordering: '-created',
+          ordering: '-first_payment_date',
           interval
         });
       });

--- a/spa/src/components/portal/ContributionsList/ContributionsList.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionsList.tsx
@@ -33,7 +33,7 @@ const CONTRIBUTION_SORT_OPTIONS = [
       </span>
     ),
     selectedLabel: 'Date',
-    value: 'created'
+    value: 'first_payment_date'
   },
   { label: 'Status', value: 'status' },
   {
@@ -59,7 +59,7 @@ export function ContributionsList() {
     contributor?.id,
     page?.revenue_program.id,
     {
-      ordering: ordering === 'created' ? `-${ordering}` : `-${ordering},-created`,
+      ordering: ordering === 'first_payment_date' ? `-${ordering}` : `-${ordering},-first_payment_date`,
       // If the tab is 'All', we don't need to pass an interval
       ...(tab !== 0 && { interval: CONTRIBUTIONS_TABS[tab].toLowerCase().replace('-', '_') })
     }


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Moves the `first_payment_date` serializer field to an annotation created by a new method on `ContributionQuerySet`.
- Changes the ordering of contributions to use `first_payment_date` instead of `created`.

#### Why are we doing this? How does it help us?

- We need `first_payment_date` to exist on the queryset instead of the serializer so that it can be sorted on.
- Sorts migrated contributions correctly.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Updated existing.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5162

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.