### PR TITLE
DEV-5119: Add support for “mc_campaign_id” to the 1.4 metadata schema in NRE - SPA

### DIFF
--- a/spa/src/appSettings.ts
+++ b/spa/src/appSettings.ts
@@ -16,6 +16,7 @@ export const SALESFORCE_CAMPAIGN_ID_QUERYPARAM = resolveConstantFromEnv(
   'SALESFORCE_CAMPAIGN_ID_QUERYPARAM',
   'campaign'
 );
+export const MAILCHIMP_CAMPAIGN_ID_QUERYPARAM = resolveConstantFromEnv('MAILCHIMP_CAMPAIGN_ID_QUERYPARAM', 'mc_cid');
 export const CAPTURE_PAGE_SCREENSHOT = resolveConstantFromEnv('CAPTURE_PAGE_SCREENSHOT');
 
 // Conditional contributor portal access. This is a list of slugs separated by a

--- a/spa/src/components/donationPage/DonationPage.jsx
+++ b/spa/src/components/donationPage/DonationPage.jsx
@@ -5,7 +5,8 @@ import {
   AMOUNT_QUERYPARAM,
   FREQUENCY_QUERYPARAM,
   GRECAPTCHA_SITE_KEY,
-  SALESFORCE_CAMPAIGN_ID_QUERYPARAM
+  SALESFORCE_CAMPAIGN_ID_QUERYPARAM,
+  MAILCHIMP_CAMPAIGN_ID_QUERYPARAM
 } from 'appSettings';
 import { frequencySort } from 'components/donationPage/pageContent/DFrequency';
 import * as getters from 'components/donationPage/pageGetters';
@@ -42,7 +43,7 @@ function DonationPage({ page, live = false }, ref) {
   const alert = useAlert();
   const formRef = useRef();
   const salesforceCampaignId = useQueryString(SALESFORCE_CAMPAIGN_ID_QUERYPARAM);
-  const mailchimpCampaignId = useQueryString('mc_cid');
+  const mailchimpCampaignId = useQueryString(MAILCHIMP_CAMPAIGN_ID_QUERYPARAM);
   const freqQs = useQueryString(FREQUENCY_QUERYPARAM);
   const amountQs = useQueryString(AMOUNT_QUERYPARAM);
   const [frequency, setFrequency] = useState();

--- a/spa/src/components/donationPage/DonationPage.jsx
+++ b/spa/src/components/donationPage/DonationPage.jsx
@@ -42,6 +42,7 @@ function DonationPage({ page, live = false }, ref) {
   const alert = useAlert();
   const formRef = useRef();
   const salesforceCampaignId = useQueryString(SALESFORCE_CAMPAIGN_ID_QUERYPARAM);
+  const mailchimpCampaignId = useQueryString('mc_cid');
   const freqQs = useQueryString(FREQUENCY_QUERYPARAM);
   const amountQs = useQueryString(AMOUNT_QUERYPARAM);
   const [frequency, setFrequency] = useState();
@@ -143,7 +144,8 @@ function DonationPage({ page, live = false }, ref) {
           pageId: page.id,
           payFee: userAgreesToPayFees,
           rpIsNonProfit: page.revenue_program_is_nonprofit,
-          salesforceCampaignId
+          salesforceCampaignId,
+          mailchimpCampaignId
         }),
         page
       );
@@ -221,7 +223,12 @@ function DonationPage({ page, live = false }, ref) {
                 {displayErrorFallback ? (
                   <LiveErrorFallback />
                 ) : (
-                  <DonationPageForm disabled={paymentIsLoading || payment} loading={paymentIsLoading} onSubmit={handleCheckoutSubmit} ref={formRef}>
+                  <DonationPageForm
+                    disabled={paymentIsLoading || payment}
+                    loading={paymentIsLoading}
+                    onSubmit={handleCheckoutSubmit}
+                    ref={formRef}
+                  >
                     <S.PageElements>
                       {(!live && !page?.elements) ||
                         (page?.elements?.length === 0 && (

--- a/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
@@ -280,6 +280,15 @@ describe('serializeData', () => {
       expect.objectContaining({ sf_campaign_id: 'test-id' })
     ));
 
+  it('sets mc_campaign_id based on the state provided', () => {
+    const result = serializeData(mockForm, { ...mockState, mailchimpCampaignId: 'test-id' });
+    expect(result).toEqual(expect.objectContaining({ mc_campaign_id: 'test-id' }));
+    expect(Object.keys(result)).toContain('mc_campaign_id');
+  });
+
+  it('does not set mc_campaign_id based on the state provided', () =>
+    expect(Object.keys(serializeData(mockForm, { ...mockState }))).not.toContain('mc_campaign_id'));
+
   it('throws an error if not given a form element', () => {
     expect(() => serializeData(document.createElement('div') as any, mockState)).toThrow();
     expect(() => serializeData(null as any, mockState)).toThrow();

--- a/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.test.ts
@@ -286,7 +286,7 @@ describe('serializeData', () => {
     expect(Object.keys(result)).toContain('mc_campaign_id');
   });
 
-  it('does not set mc_campaign_id based on the state provided', () =>
+  it('does not set mc_campaign_id if not present in state', () =>
     expect(Object.keys(serializeData(mockForm, { ...mockState }))).not.toContain('mc_campaign_id'));
 
   it('throws an error if not given a form element', () => {

--- a/spa/src/components/paymentProviders/stripe/stripeFns.ts
+++ b/spa/src/components/paymentProviders/stripe/stripeFns.ts
@@ -88,6 +88,7 @@ export interface ContributionFormExtraData {
   rpCountry: string;
   rpIsNonProfit: boolean;
   salesforceCampaignId?: string;
+  mailchimpCampaignId?: string;
 }
 
 export interface SerializedContributionForm extends ReturnType<typeof serializeForm> {
@@ -102,6 +103,7 @@ export interface SerializedContributionForm extends ReturnType<typeof serializeF
   revenue_program_country: string;
   revenue_program_slug: string;
   sf_campaign_id: string | null;
+  mc_campaign_id: string | null;
 }
 
 /**
@@ -126,6 +128,10 @@ export function serializeData(formRef: HTMLFormElement, state: ContributionFormE
 
   if (state.salesforceCampaignId) {
     serializedData.sf_campaign_id = state.salesforceCampaignId;
+  }
+
+  if (state.mailchimpCampaignId) {
+    serializedData.mc_campaign_id = state.mailchimpCampaignId;
   }
 
   // Cast is needed here because we're making the interface more strict.

--- a/spa/src/hooks/usePayment.test.ts
+++ b/spa/src/hooks/usePayment.test.ts
@@ -31,7 +31,8 @@ const mockFormData: PaymentData = {
   phone: 'mock-phone',
   revenue_program_country: 'mock-rp-country',
   revenue_program_slug: 'mock-rp-slug',
-  sf_campaign_id: 'mock-campaign-id'
+  sf_campaign_id: 'mock-campaign-id',
+  mc_campaign_id: 'mc-campaign-id'
 };
 
 const mockPage = {


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
This is stacked on top of PR https://github.com/newsrevenuehub/rev-engine/pull/1600
`main <- DEV-5105 <- DEV-5119`

#### What's this PR do?
Sends "mc_campaign_id" from URL query param to the BE 
#### Why are we doing this? How does it help us?
Add support for "mc_campaign_id" to stripe and contribution metadata
#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
yes
#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no
#### Have automated unit tests been added? If not, why?
yes
#### How should this change be communicated to end users?
Added support for “mc_campaign_id”
#### Are there any smells or added technical debt to note?
no
#### Has this been documented? If so, where?
no
#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-5119
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
https://news-revenue-hub.atlassian.net/browse/DEV-4357