### PR TITLE
DEV-2683: Reduce Sentry sampling rate on backend to 30%

### DIFF
--- a/revengine/settings/deploy.py
+++ b/revengine/settings/deploy.py
@@ -132,10 +132,7 @@ if SENTRY_ENABLE_BACKEND and SENTRY_DSN_BACKEND:
         ],
         send_default_pii=SENTRY_ENABLE_PII,
         environment=ENVIRONMENT,
-        # TODO @njh: After testing will want to reduce this to less than 100% sampling rate.
-        # DEV-2683
-        # https://docs.sentry.io/platforms/python/configuration/sampling/#setting-a-uniform-sample-rate
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.3,
         profiles_sample_rate=SENTRY_PROFILING_SAMPLE_RATE,
     )
     ignore_logger("django.security.DisallowedHost")


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Reduces the Sentry transaction sampling rate to 30%. This matches [the rate we set on the frontend](https://github.com/newsrevenuehub/rev-engine/blob/38d73d8159890dbaa69c1882a5f022e1deaec769/spa/src/hooks/useSentry.ts#L30).

#### Why are we doing this? How does it help us?

Reduces performance overhead.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No, this is a config change only.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-2569

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.