### PR TITLE
DEV-4654: Be more careful about presence of Google Maps API

### DIFF
--- a/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.test.tsx
@@ -290,6 +290,14 @@ describe('DDonorAddress', () => {
       // TODO: country field in DEV-2691
     });
 
+    it("doesn't error if the google.maps namespace isn't defined even if loading is reported to work", () => {
+      delete (google as any).maps;
+      expect(tree).not.toThrow();
+
+      // Recreate the mock we just deleted.
+      initialize();
+    });
+
     it("defaults fields that don't appear in the API response to empty strings", async () => {
       tree();
       mockPlaceAutocomplete([

--- a/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
+++ b/spa/src/components/donationPage/pageContent/DDonorAddress.tsx
@@ -81,7 +81,10 @@ function DDonorAddress({ element }: DDonorAddressProps) {
   const addressInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (!googleMapsLoading && !googleMapsError && addressInputRef.current) {
+    // Need this defensive coding because in some instances, there won't be an
+    // error reported, but `google.maps.places` won't be defined, either.
+
+    if (!googleMapsLoading && !googleMapsError && google.maps?.places?.Autocomplete && addressInputRef.current) {
       // https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete
 
       const autocomplete = new google.maps.places.Autocomplete(addressInputRef.current, { types: ['address'] });


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Adds a check for the `google.maps` object to address autocomplete on a contribution page.

#### Why are we doing this? How does it help us?

In some instances, we see that although an error isn't reported by useGoogleMaps, the API nevertheless isn't present or available in the global environment. This probably is caused by browser ad blockers or other privacy-related software. This handles this scenario more gracefully.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-4654

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.