### PR TITLE
DEV-5080 | Account for case variation in org name

### DIFF
--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -119,7 +119,7 @@ def extract_ticket_id_from_branch_name(branch_name: str) -> str | None:
 
 
 def normalize_slug(name="", slug="", max_length=50) -> str:
-    """Return a string of length less than or equal to the max_length.
+    """Return a lowercase string of length less than or equal to the max_length.
 
     :param name: str:  a character string that can be slugified.
     :param slug: str:  a slug value.

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -255,7 +255,6 @@ class Organization(IndexedTimeStampedModel):
         slug = normalize_slug(name=name, max_length=ORG_SLUG_MAX_LENGTH)
         # note that we in practice we expect slugs to be lowercase, but since there's no guarantee (casing is not enforced at db level),
         # we do do a case insensitive filter
-        # we filter on iexact
         if Organization.objects.filter(slug__iexact=slug).exists():
             logger.warning("Slug `%s` already exists for org name %s", slug, name)
             raise ValidationError("Slug already exists for org name %s", name)

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -253,7 +253,8 @@ class Organization(IndexedTimeStampedModel):
     @staticmethod
     def generate_slug_from_name(name: str) -> str:
         slug = normalize_slug(name=name, max_length=ORG_SLUG_MAX_LENGTH)
-        # note that we expect slug to be lowercase, since there's no guarantee that all extant slugs are lowercase,
+        # note that we in practice we expect slugs to be lowercase, but since there's no guarantee (casing is not enforced at db level),
+        # we do do a case insensitive filter
         # we filter on iexact
         if Organization.objects.filter(slug__iexact=slug).exists():
             logger.warning("Slug `%s` already exists for org name %s", slug, name)

--- a/apps/organizations/tests/test_models.py
+++ b/apps/organizations/tests/test_models.py
@@ -232,6 +232,12 @@ class TestOrganization:
         Organization.generate_slug_from_name(name := "test")
         mock_normalize_slug.assert_called_once_with(name=name, max_length=ORG_SLUG_MAX_LENGTH)
 
+    def test_generate_slug_from_name_when_slug_exists(self, mocker):
+        slug = Organization.generate_slug_from_name(name := "test")
+        OrganizationFactory(slug=slug, name=name)
+        with pytest.raises(ValidationError):
+            Organization.generate_slug_from_name(name)
+
     def test_downgrade_to_free_plan_happy_path(self, organization_on_core_plan_with_mailchimp_set_up, mocker):
         rp_count = 1
         assert organization_on_core_plan_with_mailchimp_set_up.plan_name == Plans.CORE.name


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR fixes a bug that allowed an uncaught integrity error around a uniquness constraint on slug to bubble up to org user as a generic error with no further information.   For more detail on the bug, please see the [JIRA ticket](https://news-revenue-hub.atlassian.net/browse/DEV-5080).

- Refactors `Organization.generate_unique_name` to make case insensitive queries (which I believe would have prevented the bug we're seeing in the first place had we been doing this before)
- Refactors `Organization.generate_slug_from_name` to make case insensitive query and raise Validation error if generated slug already exists. 

#### Why are we doing this? How does it help us?

Better signup experience for orgs


#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-5080](https://news-revenue-hub.atlassian.net/browse/DEV-5080)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No


[DEV-5080]: https://news-revenue-hub.atlassian.net/browse/DEV-5080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ