### PR TITLE
DEV-5240: Make referer optional in metadata

### DIFF
--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -474,7 +474,7 @@ class BaseCreatePaymentSerializer(serializers.Serializer):
             honoree=self.validated_data["honoree"] or None,
             in_memory_of=self.validated_data["in_memory_of"] or None,
             reason_for_giving=self.validated_data["reason_for_giving"] or None,
-            referer=self._context["request"].META["HTTP_REFERER"],
+            referer=self._context["request"].META.get("HTTP_REFERER"),  # treat missing key as None
             revenue_program_id=self.validated_data["page"].revenue_program.id,
             revenue_program_slug=self.validated_data["page"].revenue_program.slug,
             sf_campaign_id=self.validated_data["sf_campaign_id"] or None,

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from django.utils import timezone
 
 import pydantic
-import pydantic_core
 import pytest
 import stripe
 from addict import Dict as AttrDict
@@ -983,13 +982,12 @@ class TestBaseCreatePaymentSerializer:
         assert settings.METADATA_SCHEMA_VERSION_1_4
         minimally_valid_contribution_form_data["swag_choices"] = valid_swag_choices_string
         contribution = ContributionFactory(donation_page_id=minimally_valid_contribution_form_data["page"])
-        request = APIRequestFactory(HTTP_REFERER=(referer := "https://www.google.com")).post("", {}, format="json")
+        request = APIRequestFactory().post("", {}, format="json")
         serializer = self.serializer_class(data=minimally_valid_contribution_form_data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         metadata = serializer.generate_stripe_metadata(contribution)
         assert isinstance(metadata, StripePaymentMetadataSchemaV1_4)
         assert metadata.agreed_to_pay_fees == minimally_valid_contribution_form_data["agreed_to_pay_fees"]
-        assert metadata.referer == pydantic_core.Url(referer)
         assert metadata.swag_choices == valid_swag_choices_string
         assert metadata.schema_version == "1.4"
         assert metadata.source == "rev-engine"
@@ -1006,6 +1004,7 @@ class TestBaseCreatePaymentSerializer:
             "honoree",
             "in_memory_of",
             "reason_for_giving",
+            "referer",
             "sf_campaign_id",
             "mc_campaign_id",
         )

--- a/apps/contributions/types.py
+++ b/apps/contributions/types.py
@@ -175,7 +175,7 @@ class StripePaymentMetadataSchemaV1_4(StripeMetadataSchemaBase):
 
     agreed_to_pay_fees: bool
     donor_selected_amount: float
-    referer: pydantic.HttpUrl
+    referer: pydantic.HttpUrl | None = None
     revenue_program_id: str
     revenue_program_slug: str
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Makes the referer field optional and populates an empty value if not set.

#### Why are we doing this? How does it help us?

Improves handling of requests where the browser sends no referer field at all, not even a blank string.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

Unsure about unit testing. In the existing tests, there are tests that optional fields don't require a value, but I don't think we test that they take a value if they should. QA tests cover this, though.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5240

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.