### PR TITLE
DEV-5309: Allow Core org contributors to change contribution amount

### DIFF
--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
@@ -80,7 +80,7 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
             contribution={contribution}
             disabled={!!editableSection && editableSection !== 'billingDetails'}
             enableEditMode={
-              contribution.is_modifiable && page?.revenue_program?.organization?.plan?.name === PLAN_NAMES.PLUS
+              contribution.is_modifiable && page?.revenue_program?.organization?.plan?.name !== PLAN_NAMES.FREE
             }
             editable={editableSection === 'billingDetails' && contribution.is_modifiable}
             onEdit={() => setEditableSection('billingDetails')}


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Changes the criteria for who is allowed to change their contribution amount to all RPs on a paid plan.

#### Why are we doing this? How does it help us?

New portal rollout.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Maybe need to document availability?

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

Announcement re: rollout.

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5309

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.