### PR TITLE
Dev 5429 set amount metadata correctly

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -1267,10 +1267,13 @@ class Contribution(IndexedTimeStampedModel):
     def update_subscription_amount(self, amount: int, donor_selected_amount: float) -> None:
         """Update the item amount and donor-selected amount (in metadata) of the Stripe subscription of this contribution.
 
-        **amount is in cents, but donor_selected_amount is in dollars.** This difference is because amount is tracked in Stripe
-        natively as cents, while donor_selected_amount is a metadata field we added that uses float dollars.
+        **amount is in cents, but donor_selected_amount is in dollars.** This
+        difference is because amount is tracked in Stripe natively as cents,
+        while donor_selected_amount is a metadata field we added that uses float
+        dollars. This field is persisted in Stripe as a string.
 
-        This doesn't prorate the change (e.g. paying difference of existing month next time).
+        This doesn't prorate the change (e.g. paying difference of existing
+        month next time).
         """
         # vs circular import
         from apps.contributions.serializers import REVENGINE_MIN_AMOUNT, STRIPE_MAX_AMOUNT

--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -1274,6 +1274,8 @@ class Contribution(IndexedTimeStampedModel):
 
         This doesn't prorate the change (e.g. paying difference of existing
         month next time).
+
+        TODO in DEV-5465: improved validation of donor_selected_amount in Pydantic
         """
         # vs circular import
         from apps.contributions.serializers import REVENGINE_MIN_AMOUNT, STRIPE_MAX_AMOUNT

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -991,6 +991,7 @@ class PortalContributionDetailSerializer(PortalContributionBaseSerializer):
                 instance.update_payment_method_for_subscription(
                     provider_payment_method_id=provider_payment_method_id,
                 )
+            # Need to pop donor_selected_amount so it doesn't get sent when saving changes.
             donor_selected_amount = validated_data.pop("donor_selected_amount", None)
             if amount := validated_data.get("amount", None):
                 # We can trust that donor_selected_amount is not None because of

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -993,9 +993,14 @@ class PortalContributionDetailSerializer(PortalContributionBaseSerializer):
                 )
             # Need to pop donor_selected_amount so it doesn't get sent when saving changes.
             donor_selected_amount = validated_data.pop("donor_selected_amount", None)
+
             if amount := validated_data.get("amount", None):
-                # We can trust that donor_selected_amount is not None because of
-                # the check in validate().
+                if not donor_selected_amount:
+                    # amount and donor_selected_amount should always be set in tandem in real life thanks to validate(),
+                    # but we want to be certain.
+                    raise serializers.ValidationError(
+                        "If amount is updated, donor_selected_amount must be set as well."
+                    )
                 instance.update_subscription_amount(amount=amount, donor_selected_amount=donor_selected_amount)
             for key, value in validated_data.items():
                 setattr(instance, key, value)

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -963,7 +963,8 @@ class PortalContributionDetailSerializer(PortalContributionBaseSerializer):
             "min_value": f"We can only accept contributions greater than or equal to {format_ambiguous_currency(REVENGINE_MIN_AMOUNT)}",
         },
     )
-    # Note that donor_selected_amount is float dollars, not int cents.
+    # Note that donor_selected_amount is float dollars, not int cents. This
+    # value is persisted in Stripe as a string.
     donor_selected_amount = serializers.FloatField(
         required=False,
         min_value=REVENGINE_MIN_AMOUNT / 100,

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -953,6 +953,7 @@ class PortalContributionDetailSerializer(PortalContributionBaseSerializer):
     card_owner_name = serializers.CharField(read_only=True, allow_blank=True)
     payments = PortalContributionPaymentSerializer(many=True, read_only=True, source="payment_set")
     provider_payment_method_id = serializers.CharField(write_only=True, required=False)
+    # Note that amount is int cents, not float dollars.
     amount = serializers.IntegerField(
         required=False,
         min_value=REVENGINE_MIN_AMOUNT,
@@ -962,10 +963,25 @@ class PortalContributionDetailSerializer(PortalContributionBaseSerializer):
             "min_value": f"We can only accept contributions greater than or equal to {format_ambiguous_currency(REVENGINE_MIN_AMOUNT)}",
         },
     )
+    # Note that donor_selected_amount is float dollars, not int cents.
+    donor_selected_amount = serializers.FloatField(
+        required=False,
+        min_value=REVENGINE_MIN_AMOUNT / 100,
+        max_value=STRIPE_MAX_AMOUNT / 100,
+        error_messages={
+            "max_value": f"We can only accept contributions less than or equal to {format_ambiguous_currency(STRIPE_MAX_AMOUNT)}",
+            "min_value": f"We can only accept contributions greater than or equal to {format_ambiguous_currency(REVENGINE_MIN_AMOUNT)}",
+        },
+        write_only=True,
+    )
 
     class Meta:
         model = Contribution
-        fields = [*PORTAL_CONTRIBUTION_DETAIL_SERIALIZER_DB_FIELDS, "provider_payment_method_id"]
+        fields = [
+            *PORTAL_CONTRIBUTION_DETAIL_SERIALIZER_DB_FIELDS,
+            "donor_selected_amount",
+            "provider_payment_method_id",
+        ]
         read_only_fields = PORTAL_CONTRIBUTION_DETAIL_SERIALIZER_DB_FIELDS
 
     def update(self, instance: Contribution, validated_data) -> Contribution:
@@ -974,16 +990,27 @@ class PortalContributionDetailSerializer(PortalContributionBaseSerializer):
                 instance.update_payment_method_for_subscription(
                     provider_payment_method_id=provider_payment_method_id,
                 )
-            if amount := validated_data.get("amount", None):
-                instance.update_subscription_amount(
-                    amount=amount,
-                )
+            donor_selected_amount = validated_data.pop("donor_selected_amount", None)
+            if donor_selected_amount and (amount := validated_data.get("amount", None)):
+                instance.update_subscription_amount(amount=amount, donor_selected_amount=donor_selected_amount)
             for key, value in validated_data.items():
                 setattr(instance, key, value)
             with reversion.create_revision():
                 instance.save(update_fields={*validated_data.keys(), "modified"})
                 reversion.set_comment("Updated by PortalContributionDetailSerializer.update")
         return instance
+
+    def validate(self, data):
+        data = super().validate(data)
+        if "amount" in data and "donor_selected_amount" not in data:
+            raise serializers.ValidationError(
+                {"amount": "If this field is updated, donor_selected_amount must be provided as well."}
+            )
+        if "donor_selected_amount" in data and "amount" not in data:
+            raise serializers.ValidationError(
+                {"donor_selected_amount": "If this field is updated, amount must be provided as well."}
+            )
+        return data
 
 
 class PortalContributionListSerializer(PortalContributionBaseSerializer):

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -1848,7 +1848,16 @@ class TestPortalContributionDetailSerializer:
         mocker.patch("stripe.Subscription.modify")
         serializer = PortalContributionDetailSerializer(instance=one_time_contribution)
         with pytest.raises(ValueError, match="Cannot update amount for one-time contribution"):
-            serializer.update(one_time_contribution, {"amount": 123})
+            serializer.update(one_time_contribution, {"amount": 123, "donor_selected_amount": 1.23})
+
+    def test_amount_donor_selected_amount_validation(self, monthly_contribution):
+        serializer = PortalContributionDetailSerializer(instance=monthly_contribution)
+        with pytest.raises(
+            ValidationError, match="If this field is updated, donor_selected_amount must be provided as well."
+        ):
+            serializer.validate({"amount": 123})
+        with pytest.raises(ValidationError, match="If this field is updated, amount must be provided as well."):
+            serializer.validate({"donor_selected_amount": 1.23})
 
 
 @pytest.mark.django_db

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -1822,42 +1822,32 @@ class TestPortalContributionDetailSerializer:
         )
         mocker.patch("stripe.Subscription.modify")
         serializer = PortalContributionDetailSerializer(instance=monthly_contribution)
-        updated_contribution = serializer.update(monthly_contribution, {"amount": 123})
-
-        assert updated_contribution.amount == 123
-
-    def test_update_amount_one_time_contribution(self, mocker, one_time_contribution):
-        one_time_contribution.stripe_subscription = MockSubscription("active")
-        mocker.patch(
-            "stripe.SubscriptionItem.list",
-            return_value={
-                "data": [
-                    {
-                        "id": "si_123",
-                        "price": {
-                            "currency": "usd",
-                            "product": "prod_123",
-                            "recurring": {
-                                "interval": "month",
-                            },
-                        },
-                    }
-                ]
-            },
+        updated_contribution = serializer.update(
+            monthly_contribution, {"amount": 12345, "donor_selected_amount": 123.45}
         )
-        mocker.patch("stripe.Subscription.modify")
+        assert updated_contribution.amount == 12345
+        assert updated_contribution.contribution_metadata["donor_selected_amount"] == 123.45
+
+    def test_update_amount_one_time_contribution(self, one_time_contribution):
+        one_time_contribution.stripe_subscription = MockSubscription("active")
         serializer = PortalContributionDetailSerializer(instance=one_time_contribution)
         with pytest.raises(ValueError, match="Cannot update amount for one-time contribution"):
-            serializer.update(one_time_contribution, {"amount": 123, "donor_selected_amount": 1.23})
+            serializer.update(one_time_contribution, {"amount": 12345, "donor_selected_amount": 123.45})
+
+    def test_update_raises_if_donor_selected_amount_omitted(self, mocker, monthly_contribution):
+        monthly_contribution.stripe_subscription = MockSubscription("active")
+        serializer = PortalContributionDetailSerializer(instance=monthly_contribution)
+        with pytest.raises(ValidationError, match="If amount is updated, donor_selected_amount must be set as well."):
+            serializer.update(monthly_contribution, {"amount": 12345})
 
     def test_amount_donor_selected_amount_validation(self, monthly_contribution):
         serializer = PortalContributionDetailSerializer(instance=monthly_contribution)
         with pytest.raises(
             ValidationError, match="If this field is updated, donor_selected_amount must be provided as well."
         ):
-            serializer.validate({"amount": 123})
+            serializer.validate({"amount": 12345})
         with pytest.raises(ValidationError, match="If this field is updated, amount must be provided as well."):
-            serializer.validate({"donor_selected_amount": 1.23})
+            serializer.validate({"donor_selected_amount": 123.45})
 
     def test_amount_donor_selected_amount_too_small(self):
         serializer = PortalContributionDetailSerializer(data={"amount": 0, "donor_selected_amount": 0})

--- a/apps/contributions/tests/test_serializers.py
+++ b/apps/contributions/tests/test_serializers.py
@@ -1859,6 +1859,16 @@ class TestPortalContributionDetailSerializer:
         with pytest.raises(ValidationError, match="If this field is updated, amount must be provided as well."):
             serializer.validate({"donor_selected_amount": 1.23})
 
+    def test_amount_donor_selected_amount_too_small(self):
+        serializer = PortalContributionDetailSerializer(data={"amount": 0, "donor_selected_amount": 0})
+        with pytest.raises(ValidationError, match="We can only accept contributions greater than or equal to 1.00"):
+            serializer.is_valid(raise_exception=True)
+
+    def test_amount_donor_selected_amount_too_big(self):
+        serializer = PortalContributionDetailSerializer(data={"amount": 100000000, "donor_selected_amount": 1000000})
+        with pytest.raises(ValidationError, match="We can only accept contributions less than or equal to 999,999.99"):
+            serializer.is_valid(raise_exception=True)
+
 
 @pytest.mark.django_db
 class TestPortalContributionPaymentSerializer:

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -2121,7 +2121,7 @@ class TestPortalContributorsViewSet:
             mock_pm_attach.assert_not_called()
             mock_update_sub.assert_not_called()
 
-    @pytest.mark.parametrize("request_data", [{}, {"amount": 100}])
+    @pytest.mark.parametrize("request_data", [{}, {"amount": 123, "donor_selected_amount": 1.23}])
     def test_contribution_detail_patch_amount(
         self,
         request_data,
@@ -2164,7 +2164,7 @@ class TestPortalContributorsViewSet:
         contribution.refresh_from_db()
         if amount := request_data.get("amount"):
             assert contribution.amount == amount
-            assert contribution.contribution_metadata["donor_selected_amount"] == amount
+            assert contribution.contribution_metadata["donor_selected_amount"] == request_data["donor_selected_amount"]
             mock_update_sub.assert_called()
         else:
             mock_sub_item_list.assert_not_called()

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingDetails/BillingDetails.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingDetails/BillingDetails.test.tsx
@@ -33,7 +33,7 @@ const defaultProps = {
   editable: false,
   onEdit: jest.fn(),
   onEditComplete: jest.fn(),
-  onUpdateBillingDetails: jest.fn()
+  onUpdateAmount: jest.fn()
 };
 
 function tree(props?: Partial<BillingDetailsProps>) {
@@ -197,14 +197,14 @@ describe('BillingDetails', () => {
       });
 
       describe('When clicked', () => {
-        it('calls onUpdateBillingDetails with the amount in cents', () => {
+        it('calls onUpdateAmount with the amount in cents, and user-entered amount in dollars', () => {
           tree({ editable: true, enableEditMode: true });
           const amountInput = screen.getByRole('textbox', { name: /amount/i });
 
           fireEvent.change(amountInput, { target: { value: '99.45' } });
           screen.getByRole('button', { name: 'Save' }).click();
 
-          expect(defaultProps.onUpdateBillingDetails).toHaveBeenCalledWith(9945);
+          expect(defaultProps.onUpdateAmount).toHaveBeenCalledWith(9945, 99.45);
         });
 
         it('calls onEditComplete', () => {

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/BillingDetails/__mocks__/BillingDetails.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/BillingDetails/__mocks__/BillingDetails.tsx
@@ -7,7 +7,7 @@ export const BillingDetails = ({
   editable,
   onEdit,
   onEditComplete,
-  onUpdateBillingDetails
+  onUpdateAmount
 }: BillingDetailsProps) => (
   <div
     data-testid="mock-billing-details"
@@ -18,7 +18,7 @@ export const BillingDetails = ({
   >
     <button onClick={onEdit}>onEditBillingDetails</button>
     <button onClick={onEditComplete}>onEditCompleteBillingDetails</button>
-    <button onClick={() => onUpdateBillingDetails(999)}>onUpdateBillingDetails</button>
+    <button onClick={() => onUpdateAmount(12345, 123.45)}>onUpdateAmount</button>
   </div>
 );
 export default BillingDetails;

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.test.tsx
@@ -421,12 +421,14 @@ describe('ContributionDetail', () => {
           } as any);
         });
 
-        it('calls updateContribution with the amount value and appropriate change type', () => {
+        it('calls updateContribution with the amount and donor-selected amount values and appropriate change type', () => {
           tree();
           fireEvent.click(screen.getByRole('button', { name: 'onEditBillingDetails' }));
           expect(updateContribution).not.toBeCalled();
-          fireEvent.click(screen.getByRole('button', { name: 'onUpdateBillingDetails' }));
-          expect(updateContribution.mock.calls).toEqual([[{ amount: 999 }, 'billingDetails']]);
+          fireEvent.click(screen.getByRole('button', { name: 'onUpdateAmount' }));
+          expect(updateContribution.mock.calls).toEqual([
+            [{ amount: 12345, donor_selected_amount: 123.45 }, 'billingDetails']
+          ]);
         });
       });
 

--- a/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
+++ b/spa/src/components/portal/ContributionsList/ContributionDetail/ContributionDetail.tsx
@@ -44,8 +44,8 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
     updateContribution({ provider_payment_method_id: method.id }, 'paymentMethod');
   }
 
-  function handleBillingDetailsUpdate(amount: number) {
-    updateContribution({ amount }, 'billingDetails');
+  function handleAmountUpdate(amount: number, donorSelectedAmount: number) {
+    updateContribution({ amount, donor_selected_amount: donorSelectedAmount }, 'billingDetails');
   }
 
   if (isError) {
@@ -85,7 +85,7 @@ export function ContributionDetail({ domAnchor, contributionId, contributorId }:
             editable={editableSection === 'billingDetails' && contribution.is_modifiable}
             onEdit={() => setEditableSection('billingDetails')}
             onEditComplete={() => setEditableSection(undefined)}
-            onUpdateBillingDetails={handleBillingDetailsUpdate}
+            onUpdateAmount={handleAmountUpdate}
           />
           <PaymentMethod
             contribution={contribution}

--- a/spa/src/hooks/usePortalContribution.tsx
+++ b/spa/src/hooks/usePortalContribution.tsx
@@ -67,7 +67,16 @@ export interface PortalContributionDetail extends PortalContribution {
  */
 export interface PortalContributionUpdate {
   provider_payment_method_id?: string;
+  /**
+   * Amount in integer cents, not dollars. Integers are used here because that's
+   * how Stripe stores amounts.
+   */
   amount?: number;
+  /**
+   * Donor-selected amount in dollars, not integer cents. Dollars are used here
+   * because this is a metadata field we've defined that is in Stripe.
+   */
+  donor_selected_amount?: number;
 }
 
 /**


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Adds a `donor_selected_amount` that is only available when PATCHing an individual contribution. Sending a value here updates the contribution metadata.
- Changes the SPA to send both `amount` and `donor_selected_amount`.

#### Why are we doing this? How does it help us?

Corrects a problem where donor_selected_amount is getting to set to an amount in cents rather than dollars.

I went with this approach to minimize the amount of math we are doing to amounts, to avoid possible problem sources re: rounding.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5429

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.