### PR TITLE
DEV-5339 | allow superusers to access contributions list endpoint (via API)

### DIFF
--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -40,12 +40,8 @@ class IsHubAdmin(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        return all(
-            [
-                role_assignment := getattr(request.user, "roleassignment", False),
-                role_assignment.role_type == Roles.HUB_ADMIN,
-            ]
-        )
+        role_assignment = getattr(request.user, "roleassignment", None)
+        return role_assignment and role_assignment.role_type == Roles.HUB_ADMIN
 
 
 class IsOrgAdmin(permissions.BasePermission):

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -1598,11 +1598,11 @@ class TestPortalContributorsViewSet:
         """Test the happy path for the contributions list endpoint.
 
         Note that our tests show that this endpoint can be accessed both by a contributor (implicitly, when it's their own)
-        or by a superuser
+        or by a hub_admin
         """
         user = (
             request.getfixturevalue(user_fixture)
-            if user_fixture == "superuser"
+            if user_fixture == "hub_admin"
             else portal_contributor_with_multiple_contributions[0]
         )
         api_client.force_authenticate(user)
@@ -1802,7 +1802,7 @@ class TestPortalContributorsViewSet:
     def non_contributor_user(self, request):
         return request.getfixturevalue(request.param)
 
-    @pytest.fixture(params=["hub_admin_user", "org_user_free_plan", "rp_user"])
+    @pytest.fixture(params=["superuser", "org_user_free_plan", "rp_user"])
     def unpermitted_user_for_contributions_list(self, request):
         return request.getfixturevalue(request.param)
 

--- a/apps/contributions/tests/test_views.py
+++ b/apps/contributions/tests/test_views.py
@@ -1802,11 +1802,15 @@ class TestPortalContributorsViewSet:
     def non_contributor_user(self, request):
         return request.getfixturevalue(request.param)
 
+    @pytest.fixture(params=["hub_admin_user", "org_user_free_plan", "rp_user"])
+    def unpermitted_user_for_contributions_list(self, request):
+        return request.getfixturevalue(request.param)
+
     def test_contributions_list_when_im_not_contributor_user_type(
-        self, api_client, non_contributor_user, portal_contributor_with_multiple_contributions
+        self, api_client, unpermitted_user_for_contributions_list, portal_contributor_with_multiple_contributions
     ):
         contributor = portal_contributor_with_multiple_contributions[0]
-        api_client.force_authenticate(non_contributor_user)
+        api_client.force_authenticate(unpermitted_user_for_contributions_list)
         response = api_client.get(reverse("portal-contributor-contributions-list", args=(contributor.id,)))
         assert response.status_code == status.HTTP_403_FORBIDDEN
 

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -563,7 +563,7 @@ class SwitchboardContributionsViewSet(mixins.UpdateModelMixin, viewsets.GenericV
 class PortalContributorsViewSet(viewsets.GenericViewSet):
     """Furnish contributions data to the (new) contributor portal."""
 
-    permission_classes = [(IsAuthenticated & IsContributor & UserIsRequestedContributor) | IsActiveSuperUser]
+    permission_classes = [IsAuthenticated, IsContributor, UserIsRequestedContributor]
     DEFAULT_ORDERING_FIELDS = ["created", "first_payment_date"]
     ALLOWED_ORDERING_FIELDS = ["created", "amount", "first_payment_date", "status"]
     # NB: This view is about returning contributor.contributions and never returns contributors, but
@@ -632,6 +632,7 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         url_name="contributions-list",
         detail=True,
         serializer_class=serializers.PortalContributionListSerializer,
+        permission_classes=[(IsContributor & UserIsRequestedContributor) | IsActiveSuperUser],
     )
     def contributions_list(self, request, pk=None):
         """Endpoint to get all contributions for a given contributor."""

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -27,6 +27,7 @@ from apps.api.permissions import (
     HasRoleAssignment,
     IsContributor,
     IsContributorOwningContribution,
+    IsHubAdmin,
     IsSwitchboardAccount,
     UserIsRequestedContributor,
 )
@@ -632,7 +633,7 @@ class PortalContributorsViewSet(viewsets.GenericViewSet):
         url_name="contributions-list",
         detail=True,
         serializer_class=serializers.PortalContributionListSerializer,
-        permission_classes=[(IsContributor & UserIsRequestedContributor) | IsActiveSuperUser],
+        permission_classes=[(IsContributor & UserIsRequestedContributor) | IsHubAdmin],
     )
     def contributions_list(self, request, pk=None):
         """Endpoint to get all contributions for a given contributor."""

--- a/apps/contributions/views.py
+++ b/apps/contributions/views.py
@@ -563,7 +563,7 @@ class SwitchboardContributionsViewSet(mixins.UpdateModelMixin, viewsets.GenericV
 class PortalContributorsViewSet(viewsets.GenericViewSet):
     """Furnish contributions data to the (new) contributor portal."""
 
-    permission_classes = [IsAuthenticated, IsContributor, UserIsRequestedContributor]
+    permission_classes = [(IsAuthenticated & IsContributor & UserIsRequestedContributor) | IsActiveSuperUser]
     DEFAULT_ORDERING_FIELDS = ["created", "first_payment_date"]
     ALLOWED_ORDERING_FIELDS = ["created", "amount", "first_payment_date", "status"]
     # NB: This view is about returning contributor.contributions and never returns contributors, but


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Changes permissions on portal contributions list view such that superuser's can access the endpoint in order to help debug contributor issues.

#### Why are we doing this? How does it help us?

Better respond to bug reports about portal

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes: existing updated

#### How should this change be communicated to end users?

We should create a confluence that explains how to do this (for less technical folks)

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No, but see above about how to communicate.

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-5449](https://news-revenue-hub.atlassian.net/browse/DEV-5339)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No


[DEV-5339]: https://news-revenue-hub.atlassian.net/browse/DEV-5339

[DEV-5449]: https://news-revenue-hub.atlassian.net/browse/DEV-5449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ