### PR TITLE
DEV-5499: Disable exiting payment modal if payment is deleting

### DIFF
--- a/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.test.tsx
+++ b/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.test.tsx
@@ -39,13 +39,29 @@ describe('FinishPaymentModal', () => {
   });
 
   describe('When open', () => {
-    it('shows a back button which calls the onCancel prop when clicked', () => {
+    it('shows an enabled back button which calls the onCancel prop when clicked', () => {
       const onCancel = jest.fn();
 
       tree({ onCancel });
       expect(onCancel).not.toBeCalled();
-      fireEvent.click(screen.getByRole('button', { name: 'common.actions.back' }));
+
+      const cancelButton = screen.getByRole('button', { name: 'common.actions.back' });
+
+      expect(cancelButton).not.toBeDisabled();
+      fireEvent.click(cancelButton);
       expect(onCancel).toBeCalledTimes(1);
+    });
+
+    it('disables the back button if the cancelDisabled prop is true', () => {
+      const onCancel = jest.fn();
+
+      tree({ onCancel, cancelDisabled: true });
+      expect(onCancel).not.toBeCalled();
+      const cancelButton = screen.getByRole('button', { name: 'common.actions.back' });
+
+      expect(cancelButton).toBeDisabled();
+      fireEvent.click(cancelButton);
+      expect(onCancel).not.toBeCalled();
     });
 
     it('shows a Stripe payment wrapper configured with the onError prop passed and Stripe details in the payment prop', () => {

--- a/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.tsx
+++ b/spa/src/components/donationPage/FinishPaymentModal/FinishPaymentModal.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { StripeElementLocale } from '@stripe/stripe-js';
 
 const FinishPaymentModalPropTypes = {
+  cancelDisabled: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onError: PropTypes.func,
   open: PropTypes.bool.isRequired,
@@ -31,7 +32,14 @@ export interface FinishPaymentModalProps extends InferProps<typeof FinishPayment
  * appropriate thank you page.
  * @see https://stripe.com/docs/payments/payment-element
  */
-export function FinishPaymentModal({ onCancel, onError, open, payment, locale }: FinishPaymentModalProps) {
+export function FinishPaymentModal({
+  cancelDisabled,
+  onCancel,
+  onError,
+  open,
+  payment,
+  locale
+}: FinishPaymentModalProps) {
   const { t } = useTranslation();
 
   return (
@@ -44,7 +52,7 @@ export function FinishPaymentModal({ onCancel, onError, open, payment, locale }:
       <Modal open={open}>
         <AlertProvider template={Alert} {...alertOptions}>
           <Root>
-            <BackButton onClick={onCancel}>
+            <BackButton disabled={!!cancelDisabled} onClick={onCancel}>
               <ChevronLeft />
               {t('common.actions.back')}
             </BackButton>

--- a/spa/src/hooks/usePayment.test.ts
+++ b/spa/src/hooks/usePayment.test.ts
@@ -239,25 +239,25 @@ describe('usePayment', () => {
       expect(result.current.payment).toBeUndefined();
     });
 
-    it("doesn't return a deletePayment function", async () => {
+    it("doesn't return a deletePaymentMutation", async () => {
       const { result } = hook();
 
-      expect(result.current.deletePayment).toBeUndefined();
+      expect(result.current.deletePaymentMutation).toBeUndefined();
     });
   });
 
   describe('After creating a payment', () => {
-    describe('The deletePayment function it returns', () => {
+    describe('The deletePaymentMutation it returns', () => {
       it('DELETEs to /payments', async () => {
         const { result } = hook();
 
-        expect(result.current.deletePayment).toBeUndefined();
+        expect(result.current.deletePaymentMutation).toBeUndefined();
         await act(async () => {
           await result.current.createPayment!(mockFormData, mockPage);
         });
-        expect(result.current.deletePayment).not.toBeUndefined();
+        expect(result.current.deletePaymentMutation).not.toBeUndefined();
         await act(async () => {
-          await result.current.deletePayment!();
+          await result.current.deletePaymentMutation!.mutateAsync();
         });
         expect(axiosMock.history.delete.length).toBe(1);
         expect(axiosMock.history.delete[0].url).toBe('payments/mock-payment-uuid/');
@@ -270,7 +270,7 @@ describe('usePayment', () => {
           await result.current.createPayment!(mockFormData, mockPage);
         });
         await act(async () => {
-          await result.current.deletePayment!();
+          await result.current.deletePaymentMutation!.mutateAsync();
         });
         expect(axiosMock.history.delete?.[0]?.headers?.['X-CSRFTOKEN']).toBe('mock-csrf-token');
       });
@@ -289,7 +289,7 @@ describe('usePayment', () => {
         await act(async () => {
           await result.current.createPayment!(mockFormData, mockPage);
         });
-        await expect(result.current.deletePayment!()).rejects.toThrow();
+        await expect(result.current.deletePaymentMutation?.mutateAsync()).rejects.toThrow();
         errorSpy.mockReset();
       });
     });
@@ -348,7 +348,7 @@ describe('usePayment', () => {
       });
       expect(result.current.createPayment).toBeUndefined();
       await act(async () => {
-        await result.current.deletePayment!();
+        await result.current.deletePaymentMutation!.mutateAsync();
       });
       expect(result.current.createPayment).not.toBeUndefined();
     });
@@ -361,22 +361,22 @@ describe('usePayment', () => {
       });
       expect(result.current.payment).not.toBeUndefined();
       await act(async () => {
-        await result.current.deletePayment!();
+        await result.current.deletePaymentMutation!.mutateAsync();
       });
       expect(result.current.payment).toBeUndefined();
     });
 
-    it("doesn't return a deletePayment function", async () => {
+    it("doesn't return a deletePaymentMutation", async () => {
       const { result } = hook();
 
       await act(async () => {
         await result.current.createPayment!(mockFormData, mockPage);
       });
-      expect(result.current.deletePayment).not.toBeUndefined();
+      expect(result.current.deletePaymentMutation).not.toBeUndefined();
       await act(async () => {
-        await result.current.deletePayment!();
+        await result.current.deletePaymentMutation!.mutateAsync();
       });
-      expect(result.current.deletePayment).toBeUndefined();
+      expect(result.current.deletePaymentMutation).toBeUndefined();
     });
   });
 });

--- a/spa/src/hooks/usePayment.ts
+++ b/spa/src/hooks/usePayment.ts
@@ -186,21 +186,18 @@ export function usePayment() {
     },
     [createPaymentMutation]
   );
-  const deletePaymentMutation = useMutation(() =>
-    axios.delete(`${AUTHORIZE_STRIPE_PAYMENT_ROUTE}${payment?.uuid}/`, {
-      headers: { [CSRF_HEADER]: cookies.csrftoken }
-    })
-  );
-  const deletePayment = useCallback(
+  const deletePaymentMutation = useMutation(
     () =>
-      deletePaymentMutation.mutateAsync(undefined, {
-        onSuccess: () => setPayment(undefined)
+      axios.delete(`${AUTHORIZE_STRIPE_PAYMENT_ROUTE}${payment?.uuid}/`, {
+        headers: { [CSRF_HEADER]: cookies.csrftoken }
       }),
-    [deletePaymentMutation]
+    {
+      onSuccess: () => setPayment(undefined)
+    }
   );
 
   if (payment) {
-    return { payment, deletePayment };
+    return { payment, deletePaymentMutation };
   }
 
   return { createPayment, isLoading: createPaymentMutation.isLoading };


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Changes `usePayment` to expose the delete mutation instead of an async function.
- Disables the back button in the payment modal while the payment is being deleted.

#### Why are we doing this? How does it help us?

Prevents an error where clicking the button repeatedly causes network errors (the payment is attempted to be deleted multiple times) and gets the page into a stuck state.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

I created https://news-revenue-hub.atlassian.net/browse/DEV-5567 to track work on making the modal loading process more bulletproof/faster.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5499

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.