### PR TITLE
DEV-5599: Revert Contributions section part of DEV-5502

### DIFF
--- a/spa/cypress/e2e/04-donations.cy.js
+++ b/spa/cypress/e2e/04-donations.cy.js
@@ -91,8 +91,8 @@ describe('Donations list', () => {
     it('should display the right columns and row values', () => {
       const columnExpectations = [
         {
-          renderedName: 'Date received',
-          rawName: 'first_payment_date',
+          renderedName: 'Date',
+          rawName: 'created',
           transform: (rawVal) => (rawVal ? formatDatetimeForDisplay(rawVal) : NO_VALUE)
         },
         {
@@ -106,7 +106,7 @@ describe('Donations list', () => {
           transform: (rawVal) => (rawVal ? getFrequencyAdjective(rawVal) : NO_VALUE)
         },
         {
-          renderedName: 'Recent payment',
+          renderedName: 'Payment received',
           rawName: 'last_payment_date',
           transform: (rawVal) => (rawVal ? formatDatetimeForDisplay(rawVal) : NO_VALUE)
         },
@@ -432,7 +432,7 @@ describe('Table sorting for revenue program name', () => {
     cy.interceptPaginatedDonations(donationsDataOneRp);
     cy.visit(DONATIONS_SLUG);
     cy.wait('@getDonations');
-    ['Date received', 'Amount', 'Frequency', 'Recent payment', 'Contributor', 'Payment status'].forEach((name) => {
+    ['Date', 'Amount', 'Frequency', 'Payment received', 'Contributor', 'Payment status'].forEach((name) => {
       cy.findByRole('columnheader', { name: `Sort by ${name}` }).should('be.visible');
     });
     cy.findByRole('columnheader', { name: 'Sort by revenue program' }).should('not.exist');
@@ -445,17 +445,11 @@ describe('Table sorting for revenue program name', () => {
     cy.interceptPaginatedDonations(donationsDataTwoRps);
     cy.visit(DONATIONS_SLUG);
     cy.wait('@getDonations');
-    [
-      'Date received',
-      'Amount',
-      'Frequency',
-      'Recent payment',
-      'Revenue program',
-      'Contributor',
-      'Payment status'
-    ].forEach((name) => {
-      cy.findByRole('columnheader', { name: `Sort by ${name}` }).should('be.visible');
-    });
+    ['Date', 'Amount', 'Frequency', 'Payment received', 'Revenue program', 'Contributor', 'Payment status'].forEach(
+      (name) => {
+        cy.findByRole('columnheader', { name: `Sort by ${name}` }).should('be.visible');
+      }
+    );
     // it's sortable
     cy.findByRole('columnheader', { name: 'Sort by Revenue program' }).click();
     cy.wait('@getDonations');

--- a/spa/src/components/donations/Donations.jsx
+++ b/spa/src/components/donations/Donations.jsx
@@ -111,8 +111,8 @@ const Donations = () => {
   const columns = useMemo(() => {
     const defaultColumns = [
       {
-        Header: 'Date received',
-        accessor: 'first_payment_date',
+        Header: 'Date',
+        accessor: 'created',
         Cell: (props) => (props.value ? <DateAndTimeCell dateTime={props.value} /> : NO_VALUE)
       },
       {
@@ -126,7 +126,7 @@ const Donations = () => {
         Cell: (props) => (props.value ? getFrequencyAdjective(props.value) : NO_VALUE)
       },
       {
-        Header: 'Recent payment',
+        Header: 'Payment received',
         accessor: 'last_payment_date',
         Cell: (props) => (props.value ? <DateAndTimeCell dateTime={props.value} /> : NO_VALUE)
       },

--- a/spa/src/components/donations/DonationsTable.jsx
+++ b/spa/src/components/donations/DonationsTable.jsx
@@ -9,7 +9,7 @@ import PaginatedTable from 'elements/table/PaginatedTable';
 import GenericErrorBoundary from 'components/errors/GenericErrorBoundary';
 
 export const DEFAULT_RESULTS_ORDERING = [
-  { id: 'first_payment_date', desc: true },
+  { id: 'created', desc: true },
   { id: 'contributor_email', desc: false }
 ];
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Reverts admin-facing part of https://github.com/newsrevenuehub/rev-engine/pull/1674/

#### Why are we doing this? How does it help us?

We are in fact seeing null first payment dates and it's causing problems in the UI.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

TBD

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

This is a reversion of a change to previous behavior.

#### Have automated unit tests been added? If not, why?

Updated Cypress.

#### How should this change be communicated to end users?

n/a?

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

- https://news-revenue-hub.atlassian.net/browse/DEV-5599
- https://news-revenue-hub.atlassian.net/browse/DEV-5502

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

More comprehensive fix.