### PR TITLE
DEV-5538: Past due maps to FAILED

### DIFF
--- a/apps/contributions/stripe_import.py
+++ b/apps/contributions/stripe_import.py
@@ -387,12 +387,11 @@ class StripeTransactionsImporter:
         match subscription_status:
             # TODO @BW: Look into inconsistencies between Stripe subscription statuses and Revengine contribution statuses
             # DEV-4506
-            # In revengine terms, we conflate active and past due because we don't have an internal status
-            # for past due, and paid is closest given current statuses
-            case "active" | "past_due":
+            case "active":
                 return ContributionStatus.PAID
             # happens after time period for incomplete, when expired no longer can be charged
-            case "incomplete_expired":
+            # past_due should map to FAILED, check DEV-5538 for context
+            case "incomplete_expired" | "past_due":
                 return ContributionStatus.FAILED
             case "canceled":
                 return ContributionStatus.CANCELED

--- a/apps/contributions/tests/test_stripe_import.py
+++ b/apps/contributions/tests/test_stripe_import.py
@@ -488,7 +488,7 @@ class TestStripeTransactionsImporter:
         ("status", "expected"),
         [
             ("active", ContributionStatus.PAID),
-            ("past_due", ContributionStatus.PAID),
+            ("past_due", ContributionStatus.FAILED),
             ("incomplete_expired", ContributionStatus.FAILED),
             ("canceled", ContributionStatus.CANCELED),
             ("anything_else_that_arrives", ContributionStatus.PROCESSING),


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)
n/a

#### What's this PR do?

Map "past_due" to FAILED.  The initial impetus for this was to respond to an issue we found with `audit_recurring_contributions` management command on first run. There were a number of contributions it flagged as having an unexpected status.  See [this comment in JIRA](https://news-revenue-hub.atlassian.net/browse/DEV-5511?focusedCommentId=132870) for more context.

The method in question (`StripeTransactionsImporter.get_status_for_subscription`) is used in 3 places:

- audit_recurring_contributions 
- when accepting a flagged contribution in Django admin
- in Stripe transaction import when upserting a recurring contribution


In each case, we want subscriptions with "past_due" status to map to "failed" in our system.

#### Why are we doing this? How does it help us?

This will allow us to correctly identify contributions with a status other than failed when they are past due. It also will make our system upsert contributions as failed when past due in transaction import or when accepting a flagged contribution (though this last path is unlikely to be affected by the code change).


#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?
Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?
no

#### Have automated unit tests been added? If not, why?
yes

#### How should this change be communicated to end users?
n/a

#### Are there any smells or added technical debt to note?
no

#### Has this been documented? If so, where?
no

#### What are the relevant tickets? Add a link to any relevant ones.
https://news-revenue-hub.atlassian.net/browse/DEV-5538
#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:
no
#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:
Yes, additional tickets listed in spike: https://news-revenue-hub.atlassian.net/browse/DEV-5511