### PR TITLE
DEV-5617: Band-aid fix for error validation

### DIFF
--- a/spa/src/components/donationPage/pageContent/DReason.jsx
+++ b/spa/src/components/donationPage/pageContent/DReason.jsx
@@ -86,11 +86,12 @@ function DReason({ element, ...props }) {
                   <motion.div {...S.inputAnimations}>
                     <S.ReasonOtherInput
                       placeholder={t('donationPage.dReason.tellUsWhy')}
+                      required={element?.requiredFields?.includes('reason_for_giving')}
                       value={reasonOther}
                       name="reason_other"
                       onChange={(e) => setReasonOther(e.target.value)}
                       maxLength={REASON_OPTION_MAX_LENGTH}
-                      errors={errors.reason_other}
+                      errors={errors.reason_for_giving}
                     />
                   </motion.div>
                 )}

--- a/spa/src/components/donationPage/pageContent/DReason.jsx
+++ b/spa/src/components/donationPage/pageContent/DReason.jsx
@@ -91,7 +91,7 @@ function DReason({ element, ...props }) {
                       name="reason_other"
                       onChange={(e) => setReasonOther(e.target.value)}
                       maxLength={REASON_OPTION_MAX_LENGTH}
-                      errors={errors.reason_for_giving}
+                      errors={errors.reason_other}
                     />
                   </motion.div>
                 )}


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Corrects the field that the text input for reason for giving looks at to display a validation error.

#### Why are we doing this? How does it help us?

Shows the user an error message they should see.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

I added Cypress tests because it seemed like the fastest route forward.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

I created https://news-revenue-hub.atlassian.net/browse/DEV-5640 to overhaul this component.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5617

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

https://news-revenue-hub.atlassian.net/browse/DEV-5640