### PR TITLE
DEV-5281 | Fix bug with canceled_at on one-time contributions

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -402,6 +402,8 @@ class Contribution(IndexedTimeStampedModel):
 
     @property
     def canceled_at(self) -> datetime.datetime | None:
+        if self.interval == ContributionInterval.ONE_TIME:
+            return None
         if not self.stripe_subscription:
             logger.warning("Expected a retrievable stripe subscription on contribution %s but none was found", self.id)
             return None

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -1651,7 +1651,7 @@ class TestContributionModel:
         "canceled_at",
         [None, datetime.datetime.now(datetime.timezone.utc).timestamp()],
     )
-    def test_cancelled_at_date_when_subscription(self, canceled_at, contribution, subscription_factory, mocker):
+    def test_canceled_at_date_when_subscription(self, canceled_at, contribution, subscription_factory, mocker):
         contribution.provider_subscription_id = "something"
         contribution.status = ContributionStatus.CANCELED
         contribution.save()
@@ -1667,6 +1667,9 @@ class TestContributionModel:
             datetime.datetime.fromtimestamp(sub.canceled_at, tz=ZoneInfo("UTC")) if canceled_at else None
         )
         assert contribution.canceled_at == canceled_at_result
+
+    def test_canceled_at_when_one_time(self, one_time_contribution):
+        assert one_time_contribution.canceled_at is None
 
     def test_card_owner_name_when_no_provider_payment_method_details(self, mocker):
         contribution = ContributionFactory(provider_payment_method_details=None)

--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -1652,6 +1652,7 @@ class TestContributionModel:
         [None, datetime.datetime.now(datetime.timezone.utc).timestamp()],
     )
     def test_canceled_at_date_when_subscription(self, canceled_at, contribution, subscription_factory, mocker):
+        contribution.interval = ContributionInterval.MONTHLY
         contribution.provider_subscription_id = "something"
         contribution.status = ContributionStatus.CANCELED
         contribution.save()


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Fixes a bug whereby we were logging a warning, thereby creating Sentry noise when the `Contribution.canceled_at` property was referenced on one-time contributions.

#### Why are we doing this? How does it help us?

Reduce Sentry noise.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV5281](https://news-revenue-hub.atlassian.net/browse/DEV-5281)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

N/A