### PR TITLE
DEV-5850: Remove footer from most contribution-related emails

### DIFF
--- a/apps/contributions/tests/test_models.py
+++ b/apps/contributions/tests/test_models.py
@@ -42,7 +42,7 @@ from apps.contributions.tests.factories import (
 from apps.contributions.typings import StripeEventData, cast_metadata_to_stripe_payment_metadata_schema
 from apps.emails.helpers import convert_to_timezone_formatted
 from apps.emails.tasks import generate_email_data, send_templated_email
-from apps.organizations.models import FiscalStatusChoices, FreePlan
+from apps.organizations.models import FreePlan
 from apps.organizations.tests.factories import OrganizationFactory, RevenueProgramFactory
 from apps.pages.tests.factories import DonationPageFactory, StyleFactory
 from apps.users.choices import Roles
@@ -1018,29 +1018,6 @@ class TestContributionModel:
         if email_method_name == "send_recurring_contribution_canceled_email":
             email_expectations.append(
                 f"Date Canceled: {now.strftime('%m/%d/%Y')}",
-            )
-
-        if revenue_program.non_profit and email_method_name != "send_recurring_contribution_canceled_email":
-            email_expectations.append("This receipt may be used for tax purposes.")
-
-            if revenue_program.fiscal_status == FiscalStatusChoices.FISCALLY_SPONSORED:
-                email_expectations.append(
-                    f"All contributions or gifts to { revenue_program.name } are tax deductible through our fiscal sponsor"
-                    f" {revenue_program.fiscal_sponsor_name}."
-                )
-                if tax_id:
-                    email_expectations.append(f"{revenue_program.fiscal_sponsor_name}'s tax ID is {tax_id}")
-
-            if revenue_program.fiscal_status == FiscalStatusChoices.NONPROFIT:
-                email_expectations.append(
-                    f"{annual_contribution.revenue_program.name} is a 501(c)(3) nonprofit organization"
-                )
-                if tax_id:
-                    email_expectations.append(f"with a Federal Tax ID #{tax_id}")
-
-        if not revenue_program.non_profit and email_method_name != "send_recurring_contribution_canceled_email":
-            email_expectations.append(
-                f"Contributions to {annual_contribution.revenue_program.name} are not deductible as charitable donations."
             )
 
         getattr(annual_contribution, email_method_name)()

--- a/apps/emails/templates/recurring-contribution-amount-updated.html
+++ b/apps/emails/templates/recurring-contribution-amount-updated.html
@@ -90,3 +90,5 @@
 {% block timestamp_label %}Date Changed{% endblock timestamp_label %}
 {% block amount_label_one_time %}New Amount{% endblock amount_label_one_time %}
 {% block amount_label_recurring %}New Amount{% endblock amount_label_recurring %}
+
+{% block contribution_footer %}{# omit the normal disclaimer #}{% endblock contribution_footer %}

--- a/apps/emails/templates/recurring-contribution-amount-updated.txt
+++ b/apps/emails/templates/recurring-contribution-amount-updated.txt
@@ -12,3 +12,4 @@ You've recently changed the contribution amount for your contribution to {{ rp_n
 {% block timestamp_label %}Date Changed{% endblock timestamp_label %}
 {% block amount_label_one_time %}New Amount{% endblock amount_label_one_time %}
 {% block amount_label_recurring %}New Amount{% endblock amount_label_recurring %}
+{% block contribution_footer %}{# omit the normal disclaimer #}{% endblock contribution_footer %}

--- a/apps/emails/templates/recurring-contribution-email-reminder.html
+++ b/apps/emails/templates/recurring-contribution-email-reminder.html
@@ -66,3 +66,4 @@
 {% endblock header %}
 
 {% block timestamp_label %}Scheduled{% endblock timestamp_label %}
+{% block contribution_footer %}{# omit the normal disclaimer #}{% endblock contribution_footer %}

--- a/apps/emails/templates/recurring-contribution-email-reminder.txt
+++ b/apps/emails/templates/recurring-contribution-email-reminder.txt
@@ -6,3 +6,4 @@ Scheduled Contribution
 {% endblock header %}
 
 {% block timestamp_label %}Scheduled{% endblock timestamp_label %}
+{% block contribution_footer %}{# omit the normal disclaimer #}{% endblock contribution_footer %}

--- a/apps/emails/templates/recurring-contribution-payment-updated.html
+++ b/apps/emails/templates/recurring-contribution-payment-updated.html
@@ -88,3 +88,5 @@
 {% block contribution_header %}
   Contribution Changed
 {% endblock contribution_header %}
+
+{% block contribution_footer %}{# omit the normal disclaimer #}{% endblock contribution_footer %}

--- a/apps/emails/templates/recurring-contribution-payment-updated.txt
+++ b/apps/emails/templates/recurring-contribution-payment-updated.txt
@@ -9,3 +9,5 @@ You've recently changed your payment method for a contribution to {{ rp_name }}.
 {% endblock header %}
 
 {% block timestamp_label %}Date Changed{% endblock timestamp_label %}
+
+{% block contribution_footer %}{# omit the normal disclaimer #}{% endblock contribution_footer %}


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Removes footer from all contribution-related emails except initial receipt.

#### Why are we doing this? How does it help us?

Fix for non-US nonprofits who are not 501c(3).

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Updated existing.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5850

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.