### PR TITLE
DEV-5939: Loosen criteria for Mailchimp ready, re-add recurring product field to model

### DIFF
--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -573,7 +573,7 @@ class RevenueProgram(IndexedTimeStampedModel):
         return self._get_mailchimp_product(MailchimpProductType.MONTHLY.as_mailchimp_product_id(self.id))
 
     @cached_property
-    def mailchimp_recurringly_contribution_product(self) -> MailchimpProduct | None:
+    def mailchimp_recurring_contribution_product(self) -> MailchimpProduct | None:
         return self._get_mailchimp_product(MailchimpProductType.RECURRING.as_mailchimp_product_id(self.id))
 
     @cached_property
@@ -703,7 +703,7 @@ class RevenueProgram(IndexedTimeStampedModel):
         """
         logger.info("Ensuring mailchimp entities for RP %s", self.id)
         self.ensure_mailchimp_store()
-        for product in MailchimpProductType:
+        for product in [x for x in MailchimpProductType if x != MailchimpProductType.RECURRING]:
             self.ensure_mailchimp_contribution_product(product)
         for segment in MailchimpSegmentName:
             self.ensure_mailchimp_contributor_segment(segment)

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -573,6 +573,10 @@ class RevenueProgram(IndexedTimeStampedModel):
         return self._get_mailchimp_product(MailchimpProductType.MONTHLY.as_mailchimp_product_id(self.id))
 
     @cached_property
+    def mailchimp_recurringly_contribution_product(self) -> MailchimpProduct | None:
+        return self._get_mailchimp_product(MailchimpProductType.RECURRING.as_mailchimp_product_id(self.id))
+
+    @cached_property
     def mailchimp_yearly_contribution_product(self) -> MailchimpProduct | None:
         return self._get_mailchimp_product(MailchimpProductType.YEARLY.as_mailchimp_product_id(self.id))
 
@@ -638,9 +642,7 @@ class RevenueProgram(IndexedTimeStampedModel):
             [
                 self.mailchimp_integration_connected,
                 self.mailchimp_store,
-                self.mailchimp_one_time_contribution_product,
-                self.mailchimp_monthly_contribution_product,
-                self.mailchimp_yearly_contribution_product,
+                # Skip contribution products for now.
             ]
         )
 

--- a/apps/organizations/serializers.py
+++ b/apps/organizations/serializers.py
@@ -196,10 +196,8 @@ class MailchimpRevenueProgramForSwitchboard(serializers.ModelSerializer):
     mailchimp_one_time_contribution_product = serializers.SerializerMethodField()
     mailchimp_monthly_contribution_product = serializers.SerializerMethodField()
     mailchimp_yearly_contribution_product = serializers.SerializerMethodField()
-    # NB: This is a vestigial field that we're keeping around in short term so SB won't break.
-    # TODO @BW: Remove this field
-    # DEV-5588
-    mailchimp_recurring_contribution_product = serializers.ReadOnlyField(default=None)
+    # Add todo here.
+    mailchimp_recurring_contribution_product = serializers.SerializerMethodField()
     stripe_account_id = serializers.ReadOnlyField(allow_null=True)
     id = serializers.ReadOnlyField()
     name = serializers.ReadOnlyField()
@@ -237,6 +235,9 @@ class MailchimpRevenueProgramForSwitchboard(serializers.ModelSerializer):
 
     def get_mailchimp_yearly_contribution_product(self, obj) -> dict | None:
         return self._get_mc_product(MailchimpProductType.YEARLY.as_rp_field(), obj)
+
+    def get_mailchimp_recurring_contribution_product(self, obj) -> dict | None:
+        return self._get_mc_product(MailchimpProductType.RECURRING.as_rp_field(), obj)
 
 
 class BaseActiveCampaignRevenueProgram(serializers.ModelSerializer):

--- a/apps/organizations/tests/test_models.py
+++ b/apps/organizations/tests/test_models.py
@@ -810,7 +810,10 @@ class TestRevenueProgram:
         assert revenue_program.ensure_mailchimp_store.called
         assert revenue_program.ensure_mailchimp_contribution_product.call_count == 3
         revenue_program.ensure_mailchimp_contribution_product.assert_has_calls(
-            [mocker.call(prod_type) for prod_type in MailchimpProductType],
+            [
+                mocker.call(prod_type)
+                for prod_type in [x for x in MailchimpProductType if x != MailchimpProductType.RECURRING]
+            ],
             any_order=True,
         )
         assert revenue_program.ensure_mailchimp_contributor_segment.call_count == 5

--- a/apps/organizations/tests/test_models.py
+++ b/apps/organizations/tests/test_models.py
@@ -731,16 +731,10 @@ class TestRevenueProgram:
         [True, False],
     )
     @pytest.mark.parametrize("mailchimp_store", ["truthy", None])
-    @pytest.mark.parametrize("one_time_product_value", ["truthy", None])
-    @pytest.mark.parametrize("monthly_product_value", ["truthy", None])
-    @pytest.mark.parametrize("yearly_product_value", ["truthy", None])
     def test_mailchimp_integration_ready_property(
         self,
         mailchimp_integration_connected: bool,
         mailchimp_store: str | None,
-        one_time_product_value: str | None,
-        monthly_product_value: str | None,
-        yearly_product_value: str | None,
         mocker: pytest_mock.MockerFixture,
     ):
         mocker.patch(
@@ -753,25 +747,12 @@ class TestRevenueProgram:
             new_callable=mocker.PropertyMock,
             return_value=mailchimp_store,
         )
-        for prop, val in [
-            (MailchimpProductType.ONE_TIME, one_time_product_value),
-            (MailchimpProductType.MONTHLY, monthly_product_value),
-            (MailchimpProductType.YEARLY, yearly_product_value),
-        ]:
-            mocker.patch(
-                f"apps.organizations.models.RevenueProgram.{prop.as_rp_field()}",
-                new_callable=mocker.PropertyMock,
-                return_value=val,
-            )
 
         rp = RevenueProgramFactory()
         assert rp.mailchimp_integration_ready == all(
             [
                 mailchimp_integration_connected,
                 mailchimp_store,
-                one_time_product_value,
-                monthly_product_value,
-                yearly_product_value,
             ]
         )
 

--- a/apps/organizations/tests/test_serializers.py
+++ b/apps/organizations/tests/test_serializers.py
@@ -247,12 +247,11 @@ class TestMailchimpRevenueProgramForSwitchboard:
         ):
             assert serialized[field] == getattr(mc_connected_rp, field)
         assert serialized["mailchimp_store"] == asdict(mailchimp_store)
-        # This field is kept around for legacy reasons to not break SB, but we just send back None.
-        assert serialized["mailchimp_recurring_contribution_product"] is None
         for product in (
             "mailchimp_monthly_contribution_product",
             "mailchimp_yearly_contribution_product",
             "mailchimp_one_time_contribution_product",
+            "mailchimp_recurring_contribution_product",
         ):
             assert serialized[product] == asdict(mailchimp_product)
 

--- a/apps/organizations/tests/test_typings.py
+++ b/apps/organizations/tests/test_typings.py
@@ -6,21 +6,25 @@ class TestMailchimpProductType:
         assert MailchimpProductType.ONE_TIME.as_mailchimp_product_name() == "one-time contribution"
         assert MailchimpProductType.YEARLY.as_mailchimp_product_name() == "yearly contribution"
         assert MailchimpProductType.MONTHLY.as_mailchimp_product_name() == "monthly contribution"
+        assert MailchimpProductType.RECURRING.as_mailchimp_product_name() == "recurring contribution"
 
     def test_as_rp_field(self):
         assert MailchimpProductType.ONE_TIME.as_rp_field() == "mailchimp_one_time_contribution_product"
         assert MailchimpProductType.YEARLY.as_rp_field() == "mailchimp_yearly_contribution_product"
         assert MailchimpProductType.MONTHLY.as_rp_field() == "mailchimp_monthly_contribution_product"
+        assert MailchimpProductType.RECURRING.as_rp_field() == "mailchimp_recurring_contribution_product"
 
     def test_as_mailchimp_product_id(self):
         assert MailchimpProductType.ONE_TIME.as_mailchimp_product_id(1) == "rp-1-one-time-contribution-product"
         assert MailchimpProductType.YEARLY.as_mailchimp_product_id(2) == "rp-2-yearly-contribution-product"
         assert MailchimpProductType.MONTHLY.as_mailchimp_product_id(3) == "rp-3-monthly-contribution-product"
+        assert MailchimpProductType.RECURRING.as_mailchimp_product_id(4) == "rp-4-recurring-contribution-product"
 
     def test_as_str(self):
         assert str(MailchimpProductType.ONE_TIME) == "one_time"
         assert str(MailchimpProductType.YEARLY) == "yearly"
         assert str(MailchimpProductType.MONTHLY) == "monthly"
+        assert str(MailchimpProductType.RECURRING) == "recurring"
 
 
 class TestMailchimpSegmentName:

--- a/apps/organizations/typings.py
+++ b/apps/organizations/typings.py
@@ -9,6 +9,7 @@ class MailchimpProductType(StrEnum):
     """
 
     ONE_TIME = "one_time"
+    RECURRING = "recurring"
     YEARLY = "yearly"
     MONTHLY = "monthly"
 


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Makes `mailchimp_connection_ready` looser
- Restores the `mailchimp_recurring_contribution_product` field on RevenueProgram

#### Why are we doing this? How does it help us?

Fixes issues for existing integrations.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

TBD

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5939

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

Backfill missing data.