### PR TITLE
DEV-5896 | make contributor non-nullable at serializer level

### DIFF
--- a/apps/contributions/models.py
+++ b/apps/contributions/models.py
@@ -332,6 +332,8 @@ class Contribution(IndexedTimeStampedModel):
     # TODO @BW: Remove Contribution.last_payment_date in favor of derivation from payments
     # DEV-4333
     last_payment_date = models.DateTimeField(null=True)
+    # TODO @BW: Make Contribution.contributor non-nullable
+    # DEV-5953
     contributor = models.ForeignKey("contributions.Contributor", on_delete=models.SET_NULL, null=True)
 
     # Further down, we add a constraint that requires that either donation page or _revenue_program

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -883,8 +883,10 @@ class SwitchboardContributionSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
     )
-
     revenue_program_source = serializers.SerializerMethodField(read_only=True)
+    # TODO @BW: Remove this once Contribution.contributor is non-nullable
+    # DEV-5953
+    contributor = serializers.PrimaryKeyRelatedField(queryset=Contributor.objects.all())
 
     class Meta:
         model = Contribution

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -886,7 +886,7 @@ class SwitchboardContributionSerializer(serializers.ModelSerializer):
     revenue_program_source = serializers.SerializerMethodField(read_only=True)
     # TODO @BW: Remove this once Contribution.contributor is non-nullable
     # DEV-5953
-    contributor = serializers.PrimaryKeyRelatedField(queryset=Contributor.objects.all())
+    contributor = serializers.PrimaryKeyRelatedField(queryset=Contributor.objects.all(), allow_null=False)
 
     class Meta:
         model = Contribution

--- a/apps/contributions/serializers.py
+++ b/apps/contributions/serializers.py
@@ -950,6 +950,8 @@ class SwitchboardContributionSerializer(serializers.ModelSerializer):
             )
         return value
 
+    # TODO @BW: Add validation to ensure provider_customer_id is set if send_receipt is true in request context
+    # DEV-5961
     def validate(self, data):
         """Ensure that either a revenue program or a donation page is set on the contribution, but not both."""
         data = super().validate(data)

--- a/apps/contributions/views/switchboard.py
+++ b/apps/contributions/views/switchboard.py
@@ -55,6 +55,8 @@ class SwitchboardContributionsViewSet(
         callers have already created an appropriate Stripe object (e.g. payment
         intent or subscription).
         """
+        # TODO @BW: Make this transaction rollback if the email fails
+        # DEV-5961
         contribution: Contribution = serializer.save()
         if (qp := self.request.query_params.get(SEND_RECEIPT_QUERY_PARAM)) and booleanize_string(qp):
             # send_thank_you_email() handles conditionality around whether


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR adds validation to the contribution creation API endpoint used by Switchboard so that contributions cannot be created without a contributor, and cannot be updated such that contributor would be nullfieid.

#### Why are we doing this? How does it help us?

There is no use case for contributor-less contributions, but it's an affordance of the API as currently implemented.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No, but this is a short term fix and I've created a follow up ticket to make contribution.contributor non-nullable at DB level ([DEV-5953](https://news-revenue-hub.atlassian.net/browse/DEV-5953)).

Also noting that in devising QA for this ticket, I encountered a bug whereby it's possible to create a contribution via the endpoint, requesting receipt email to be sent, and for the contribution creation to succeed despite the server returning a 500 and the email failing to send. I created [DEV-5961](https://news-revenue-hub.atlassian.net/browse/DEV-5961) as a follow up to address this.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-5896](https://news-revenue-hub.atlassian.net/browse/DEV-5896)
- [DEV-5961](https://news-revenue-hub.atlassian.net/browse/DEV-5961)
- [DEV-5953](https://news-revenue-hub.atlassian.net/browse/DEV-5953)
- [DEV-5250](https://news-revenue-hub.atlassian.net/browse/DEV-5250)


#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

- [DEV-5961](https://news-revenue-hub.atlassian.net/browse/DEV-5961)
- [DEV-5953](https://news-revenue-hub.atlassian.net/browse/DEV-5953)



[DEV-5953]: https://news-revenue-hub.atlassian.net/browse/DEV-5953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ