### PR TITLE
DEV-5972: allow filtering of contributions and payments

### DIFF
--- a/apps/contributions/tests/views/test_switchboard.py
+++ b/apps/contributions/tests/views/test_switchboard.py
@@ -637,16 +637,14 @@ class TestSwitchboardContributionsViewSet:
             headers={"Authorization": f"Token {switchboard_api_token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 0
+        assert len(response.json()["results"]) == 0
 
         response = api_client.get(
             reverse("switchboard-contribution-list"),
             headers={"Authorization": f"Token {switchboard_api_token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 3
+        assert len(response.json()["results"]) == 3
 
     def test_filter_by_provider_payment_id(self, api_client: APIClient, switchboard_api_token: str):
         payment_contribution = ContributionFactory(one_time=True)
@@ -813,8 +811,8 @@ class TestSwitchboardPaymentsViewSet:
             headers={"Authorization": f"Token {token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 1
+
+        assert len(results := response.json()["results"]) == 1
         assert results[0]["id"] == payment.id
 
         response = api_client.get(
@@ -823,13 +821,11 @@ class TestSwitchboardPaymentsViewSet:
             headers={"Authorization": f"Token {token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 0
+        assert len(response.json()["results"]) == 0
 
         response = api_client.get(
             reverse("switchboard-payment-list"),
             headers={"Authorization": f"Token {token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 3
+        assert len(response.json()["results"]) == 3

--- a/apps/contributions/tests/views/test_switchboard.py
+++ b/apps/contributions/tests/views/test_switchboard.py
@@ -8,6 +8,7 @@ import reversion
 from knox.models import AuthToken
 from rest_framework import status
 from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
 
 from apps.contributions.choices import ContributionInterval, ContributionStatus
 from apps.contributions.models import Contribution, Contributor, Payment
@@ -615,7 +616,7 @@ class TestSwitchboardContributionsViewSet:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert response.json() == {"detail": "Invalid token."}
 
-    def test_filter_by_provider_subscription_id(self, api_client, switchboard_api_token):
+    def test_filter_by_provider_subscription_id(self, api_client: APIClient, switchboard_api_token: str):
         subscription_contribution = ContributionFactory(monthly_subscription=True)
         ContributionFactory(monthly_subscription=True)
         ContributionFactory(monthly_subscription=True)
@@ -647,7 +648,7 @@ class TestSwitchboardContributionsViewSet:
         results = response.json()["results"]
         assert len(results) == 3
 
-    def test_filter_by_provider_payment_id(self, api_client, switchboard_api_token):
+    def test_filter_by_provider_payment_id(self, api_client: APIClient, switchboard_api_token: str):
         payment_contribution = ContributionFactory(one_time=True)
         ContributionFactory(one_time=True)
         ContributionFactory(one_time=True)
@@ -804,7 +805,7 @@ class TestSwitchboardPaymentsViewSet:
             "stripe_balance_transaction_id": ["payment with this stripe balance transaction id already exists."]
         }
 
-    def test_filter_by_stripe_balance_transaction_id(self, api_client, payment, token):
+    def test_filter_by_stripe_balance_transaction_id(self, api_client: APIClient, payment: Payment, token: str):
         # ensure there are multiple payments
         PaymentFactory()
         PaymentFactory()

--- a/apps/contributions/tests/views/test_switchboard.py
+++ b/apps/contributions/tests/views/test_switchboard.py
@@ -617,8 +617,8 @@ class TestSwitchboardContributionsViewSet:
 
     def test_filter_by_provider_subscription_id(self, api_client, switchboard_api_token):
         subscription_contribution = ContributionFactory(monthly_subscription=True)
-        ContributionFactory()
-        ContributionFactory()
+        ContributionFactory(monthly_subscription=True)
+        ContributionFactory(monthly_subscription=True)
 
         response = api_client.get(
             reverse("switchboard-contribution-list"),
@@ -649,8 +649,8 @@ class TestSwitchboardContributionsViewSet:
 
     def test_filter_by_provider_payment_id(self, api_client, switchboard_api_token):
         payment_contribution = ContributionFactory(one_time=True)
-        ContributionFactory()
-        ContributionFactory()
+        ContributionFactory(one_time=True)
+        ContributionFactory(one_time=True)
 
         response = api_client.get(
             reverse("switchboard-contribution-list"),

--- a/apps/contributions/tests/views/test_switchboard.py
+++ b/apps/contributions/tests/views/test_switchboard.py
@@ -627,8 +627,8 @@ class TestSwitchboardContributionsViewSet:
             headers={"Authorization": f"Token {switchboard_api_token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 1
+
+        assert len(results := response.json()["results"]) == 1
         assert results[0]["id"] == subscription_contribution.id
 
         response = api_client.get(
@@ -659,8 +659,7 @@ class TestSwitchboardContributionsViewSet:
             headers={"Authorization": f"Token {switchboard_api_token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 1
+        assert len(results := response.json()["results"]) == 1
         assert results[0]["id"] == payment_contribution.id
 
         response = api_client.get(
@@ -669,16 +668,14 @@ class TestSwitchboardContributionsViewSet:
             headers={"Authorization": f"Token {switchboard_api_token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 0
+        assert len(response.json()["results"]) == 0
 
         response = api_client.get(
             reverse("switchboard-contribution-list"),
             headers={"Authorization": f"Token {switchboard_api_token}"},
         )
         assert response.status_code == status.HTTP_200_OK
-        results = response.json()["results"]
-        assert len(results) == 3
+        assert len(response.json()["results"]) == 3
 
 
 @pytest.mark.django_db

--- a/apps/contributions/views/switchboard.py
+++ b/apps/contributions/views/switchboard.py
@@ -7,6 +7,7 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 
 import reversion
+from django_filters.rest_framework import DjangoFilterBackend
 from knox.auth import TokenAuthentication
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
@@ -34,6 +35,7 @@ class SwitchboardContributionsViewSet(
     viewsets.mixins.RetrieveModelMixin,
     UniquenessConstraintViolationViewSetMixin,
     viewsets.GenericViewSet,
+    mixins.ListModelMixin,
 ):
     """Viewset for switchboard to update contributions."""
 
@@ -44,6 +46,8 @@ class SwitchboardContributionsViewSet(
     # TODO @BW: Remove JWTHttpOnlyCookieAuthentication after DEV-5549
     # DEV-5571
     authentication_classes = [TokenAuthentication, JWTHttpOnlyCookieAuthentication]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["provider_subscription_id", "provider_payment_id"]
 
     def perform_create(self, serializer: serializers.SwitchboardContributionSerializer):
         """Send a receipt email if requested in a query param.
@@ -122,6 +126,7 @@ class SwitchboardPaymentsViewSet(
     RevisionMixin,
     mixins.RetrieveModelMixin,
     mixins.CreateModelMixin,
+    mixins.ListModelMixin,
     mixins.UpdateModelMixin,
     UniquenessConstraintViolationViewSetMixin,
     viewsets.GenericViewSet,
@@ -133,6 +138,8 @@ class SwitchboardPaymentsViewSet(
     queryset = Payment.objects.all()
     serializer_class = serializers.SwitchboardPaymentSerializer
     authentication_classes = [TokenAuthentication]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["stripe_balance_transaction_id"]
 
     def perform_create(self, serializer):
         with reversion.create_revision():

--- a/apps/contributions/views/switchboard.py
+++ b/apps/contributions/views/switchboard.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404
 import reversion
 from django_filters.rest_framework import DjangoFilterBackend
 from knox.auth import TokenAuthentication
-from rest_framework import mixins, status, viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
@@ -30,12 +30,12 @@ SEND_RECEIPT_QUERY_PARAM = "send_receipt"
 
 
 class SwitchboardContributionsViewSet(
-    viewsets.mixins.CreateModelMixin,
-    viewsets.mixins.UpdateModelMixin,
-    viewsets.mixins.RetrieveModelMixin,
     UniquenessConstraintViolationViewSetMixin,
     viewsets.GenericViewSet,
-    mixins.ListModelMixin,
+    viewsets.mixins.CreateModelMixin,
+    viewsets.mixins.ListModelMixin,
+    viewsets.mixins.RetrieveModelMixin,
+    viewsets.mixins.UpdateModelMixin,
 ):
     """Viewset for switchboard to update contributions."""
 
@@ -88,7 +88,11 @@ class SwitchboardContributionsViewSet(
         return super().handle_exception(exc)
 
 
-class SwitchboardContributorsViewSet(mixins.RetrieveModelMixin, mixins.CreateModelMixin, viewsets.GenericViewSet):
+class SwitchboardContributorsViewSet(
+    viewsets.GenericViewSet,
+    viewsets.mixins.CreateModelMixin,
+    viewsets.mixins.RetrieveModelMixin,
+):
     """Viewset for switchboard to create and retrieve contributors."""
 
     permission_classes = [IsSwitchboardAccount]
@@ -124,12 +128,12 @@ class SwitchboardContributorsViewSet(mixins.RetrieveModelMixin, mixins.CreateMod
 
 class SwitchboardPaymentsViewSet(
     RevisionMixin,
-    mixins.RetrieveModelMixin,
-    mixins.CreateModelMixin,
-    mixins.ListModelMixin,
-    mixins.UpdateModelMixin,
     UniquenessConstraintViolationViewSetMixin,
     viewsets.GenericViewSet,
+    viewsets.mixins.CreateModelMixin,
+    viewsets.mixins.ListModelMixin,
+    viewsets.mixins.RetrieveModelMixin,
+    viewsets.mixins.UpdateModelMixin,
 ):
     """ViewSet for switchboard to retrieve, create and update payments."""
 


### PR DESCRIPTION
#### Plan?

N/A

#### What's this PR do?

This PR adds filtering capabilities to the Switchboard API endpoints:

1. Adds filtering by `provider_subscription_id` and `provider_payment_id` to `SwitchboardContributionsViewSet`
2. Adds filtering by `stripe_balance_transaction_id` to `SwitchboardPaymentsViewSet` 

I opted for DjangoFilterBackend instead SearchFilter as it is more in line with other api filtering standards (including Stripe's, which I consider one of the best out there).

#### Why are we doing this? How does it help us?

This initial implementation was motivated by Switchboard's need to upsert payment or contribution records. Switchboard needs to be able to check if there is an existing contribution or payment to guarantee idempotency.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

API only change

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A - This is an internal API change that only affects Switchboard integration.

#### Are there any smells or added technical debt to note?

Nope

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets?

[DEV-5972]

#### Do any changes need to be made before deployment to production?

N/A

#### Are there next steps?

Continue work on [DEV-5721]


[DEV-5972]: https://news-revenue-hub.atlassian.net/browse/DEV-5972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ