### PR TITLE
DEV-5897: Remove SVG as supported image type

### DIFF
--- a/spa/src/components/base/ImageUpload/ImageUpload.tsx
+++ b/spa/src/components/base/ImageUpload/ImageUpload.tsx
@@ -47,7 +47,7 @@ export interface ImageUploadProps extends InferProps<typeof ImageUploadPropTypes
  */
 export function ImageUpload(props: ImageUploadProps) {
   const {
-    accept = 'image/gif,image/jpeg,image/png,image/svg+xml,image/webp',
+    accept = 'image/gif,image/jpeg,image/png,image/webp',
     className,
     id,
     label,


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Removes SVG as a possible image format to upload.

#### Why are we doing this? How does it help us?

Django's ImageField doesn't support this.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

No, changing a config string only.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-5897

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.