### PR TITLE
DEV-6018  | switchboard api endpoints for creating and updating contributions should create revisions

### DIFF
--- a/apps/contributions/tests/views/test_switchboard.py
+++ b/apps/contributions/tests/views/test_switchboard.py
@@ -280,6 +280,10 @@ class TestSwitchboardContributionsViewSet:
                     assert retrieved._revenue_program == RevenueProgram.objects.get(pk=data["revenue_program"])
                 case _:
                     assert getattr(retrieved, k) == v
+        # Verify reversion comment was recorded
+        versions = reversion.models.Version.objects.get_for_object(retrieved)
+        assert versions.count() == 1
+        assert versions[0].revision.comment == "Contribution created by Switchboard"
 
     @pytest.mark.parametrize(
         "data_fixture",
@@ -459,6 +463,10 @@ class TestSwitchboardContributionsViewSet:
                     assert contribution._revenue_program == RevenueProgram.objects.get(pk=data["revenue_program"])
                 case _:
                     assert getattr(contribution, k) == v
+        # Verify reversion comment was recorded
+        versions = reversion.models.Version.objects.get_for_object(contribution)
+        assert versions.count() == 1
+        assert versions[0].revision.comment == "Contribution updated by Switchboard"
 
     @pytest.fixture
     def invalid_update_data_both_rp_and_page(self, update_data_recurring_with_page):


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

This PR updates the view functions for updating and creating contributions (in SwitchboardContributionsViewSet) such that they create revisions.

#### Why are we doing this? How does it help us?

Enable better auditing of changes to contributions — especially given that they can be affected by webhooks from Stripe directly and by Switchboard initiated requests (and Switchboard itself responds to some webhook events also listened to by RevEngine).

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Existing ones have been updated.

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV=6018](https://news-revenue-hub.atlassian.net/browse/DEV-6018)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No