### PR TITLE
DEV-6079 | Fix stripe webhook processing

### DIFF
--- a/apps/contributions/tasks.py
+++ b/apps/contributions/tasks.py
@@ -156,7 +156,22 @@ def on_process_stripe_webhook_task_failure(self, task: Task, exc: Exception, tra
 )
 def process_stripe_webhook_task(self, raw_event_data: dict) -> None:
     logger.info("Processing Stripe webhook event with ID %s", raw_event_data["id"])
-    processor = StripeWebhookProcessor(event=(event := StripeEventData(**raw_event_data)))
+    processor = StripeWebhookProcessor(
+        event=(
+            event := StripeEventData(
+                id=raw_event_data.get("id"),
+                object=raw_event_data.get("object"),
+                account=raw_event_data.get("account"),
+                api_version=raw_event_data.get("api_version"),
+                created=raw_event_data.get("created"),
+                data=raw_event_data.get("data"),
+                request=raw_event_data.get("request"),
+                livemode=raw_event_data.get("livemode"),
+                pending_webhooks=raw_event_data.get("pending_webhooks"),
+                type=raw_event_data.get("type"),
+            )
+        )
+    )
     try:
         processor.process()
     except Contribution.DoesNotExist:

--- a/apps/contributions/tests/test_tasks.py
+++ b/apps/contributions/tests/test_tasks.py
@@ -264,6 +264,12 @@ class TestProcessStripeWebhookTask:
                 "Could not find contribution. Here's the event data: %s", mocker.ANY, exc_info=True
             )
 
+    def test_extraneous_properties_on_event(self, payment_intent_succeeded, mocker):
+        mock_process = mocker.patch("apps.contributions.webhooks.StripeWebhookProcessor.process")
+        payment_intent_succeeded["unexpected_property"] = "value"
+        contribution_tasks.process_stripe_webhook_task(raw_event_data=payment_intent_succeeded)
+        mock_process.assert_called_once()
+
 
 def test_on_process_stripe_webhook_task_failure(mocker):
     mock_logger = mocker.patch("apps.contributions.tasks.logger.error")


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Updates process_stripe_webhook_task such that we only pass known kwargs to StripeEventData constructor.  This is because we encountered a bug where there is a new `context` property in the passed data, and the `StripeEventData` constructor doesn't know what to do with this argument.

#### Why are we doing this? How does it help us?

Solves for a bug that broke webhook processing for contributions related events.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

We'll need to do client-facing comms re: the outage.

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

No

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-6079](https://news-revenue-hub.atlassian.net/browse/DEV-6079)
- [ITS-3046](https://news-revenue-hub.atlassian.net/browse/ITS-3046)
- [DEV-6080](https://news-revenue-hub.atlassian.net/browse/DEV-6080)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

- [ITS-3046](https://news-revenue-hub.atlassian.net/browse/ITS-3046)
- [DEV-6080](https://news-revenue-hub.atlassian.net/browse/DEV-6080)

[DEV-6079]: https://news-revenue-hub.atlassian.net/browse/DEV-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ