### PR TITLE
DEV-6227: Add quarantine actions in Django admin detail

### DIFF
--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -9,6 +9,7 @@ from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import re_path, reverse
 from django.urls.resolvers import URLPattern
 from django.utils.html import format_html
+from django.utils.safestring import SafeText
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
@@ -21,7 +22,7 @@ from apps.contributions.payment_managers import PaymentProviderError
 logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 
-def flagged_contribution_actions_html(obj: Contribution):
+def flagged_contribution_actions_html(obj: Contribution) -> SafeText:
     """Return HTML to take quick actions on a flagged contribution.
 
     This is shared across the quarantine queue and contribution admins.
@@ -281,7 +282,7 @@ class ContributionAdmin(RevEngineBaseAdmin):
 
     def get_fieldsets(self, request: HttpRequest, obj: Contribution):
         # Add quarantine options to flagged contributions.
-        if obj.status == ContributionStatus.FLAGGED:
+        if obj.quarantine_status == QuarantineStatus.FLAGGED_BY_BAD_ACTOR:
             return (
                 (
                     "Quarantine",

--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -21,6 +21,49 @@ from apps.contributions.payment_managers import PaymentProviderError
 logger = logging.getLogger(f"{settings.DEFAULT_LOGGER}.{__name__}")
 
 
+def flagged_contribution_actions_html(obj: Contribution):
+    """Return HTML to take quick actions on a flagged contribution.
+
+    This is shared across the quarantine queue and contribution admins.
+    """
+    mapping = [
+        {
+            "label": "✅ appr",
+            "url": reverse("admin:approve_quarantined_contribution", args=[obj.id]),
+            "class": "approve",
+        },
+        {
+            "label": "❌ dupe",
+            "url": reverse(
+                "admin:reject_quarantined_contribution",
+                args=[obj.id, QuarantineStatus.REJECTED_BY_HUMAN_DUPE.value],
+            ),
+            "class": "reject",
+        },
+        {
+            "label": "❌ fraud",
+            "url": reverse(
+                "admin:reject_quarantined_contribution",
+                args=[obj.id, QuarantineStatus.REJECTED_BY_HUMAN_FRAUD.value],
+            ),
+            "class": "reject",
+        },
+        {
+            "label": "❌ other",
+            "url": reverse(
+                "admin:reject_quarantined_contribution",
+                args=[obj.id, QuarantineStatus.REJECTED_BY_HUMAN_OTHER.value],
+            ),
+            "class": "reject",
+        },
+    ]
+
+    actions = [f"""<a class="button {x["class"]}" href="{x["url"]}">{x["label"]}</a>""" for x in mapping]
+    return format_html(
+        f"""<div class="quarantine-item-button-group">{"".join(actions)}</div>""",
+    )
+
+
 @admin.register(Contributor)
 class ContributorAdmin(RevEngineBaseAdmin):
     list_display = ("email",)
@@ -227,6 +270,26 @@ class ContributionAdmin(RevEngineBaseAdmin):
 
     inlines = [PaymentInline]
 
+    class Media:
+        css = {"all": ("admin/css/quarantine-admin.css",)}
+
+    def quarantine_actions(self, obj: Contribution):
+        return flagged_contribution_actions_html(obj)
+
+    quarantine_actions.short_description = "Resolve"
+    quarantine_actions.allow_tags = True
+
+    def get_fieldsets(self, request: HttpRequest, obj: Contribution):
+        # Add quarantine options to flagged contributions.
+        if obj.status == ContributionStatus.FLAGGED:
+            return (
+                (
+                    "Quarantine",
+                    {"fields": ("quarantine_actions",)},
+                ),
+            )
+        return self.fieldsets
+
     def get_queryset(self, request: HttpRequest) -> QuerySet[Contribution]:
         # Annotate the queryset with the first_payment_date
         queryset = super().get_queryset(request)
@@ -402,42 +465,7 @@ class QuarantineQueue(admin.ModelAdmin):
         return custom_urls + urls
 
     def resolve_field(self, obj: Contribution):
-        mapping = [
-            {
-                "label": "✅ appr",
-                "url": reverse("admin:approve_quarantined_contribution", args=[obj.id]),
-                "class": "approve",
-            },
-            {
-                "label": "❌ dupe",
-                "url": reverse(
-                    "admin:reject_quarantined_contribution",
-                    args=[obj.id, QuarantineStatus.REJECTED_BY_HUMAN_DUPE.value],
-                ),
-                "class": "reject",
-            },
-            {
-                "label": "❌ fraud",
-                "url": reverse(
-                    "admin:reject_quarantined_contribution",
-                    args=[obj.id, QuarantineStatus.REJECTED_BY_HUMAN_FRAUD.value],
-                ),
-                "class": "reject",
-            },
-            {
-                "label": "❌ other",
-                "url": reverse(
-                    "admin:reject_quarantined_contribution",
-                    args=[obj.id, QuarantineStatus.REJECTED_BY_HUMAN_OTHER.value],
-                ),
-                "class": "reject",
-            },
-        ]
-
-        actions = [f"""<a class="button {x['class']}" href="{x['url']}">{x['label']}</a>""" for x in mapping]
-        return format_html(
-            f"""<div class="quarantine-item-button-group">{"".join(actions)}</div>""",
-        )
+        return flagged_contribution_actions_html(obj)
 
     resolve_field.short_description = "Resolve"
     resolve_field.allow_tags = True

--- a/apps/contributions/static/admin/css/quarantine-admin.css
+++ b/apps/contributions/static/admin/css/quarantine-admin.css
@@ -1,31 +1,21 @@
-.field-resolve_field {
-    display: flex;
-    flex-direction: column;
-}
-
-.field-resolve_field .approve {
-    background-color: #094609;
-}
-
-.field-resolve_field .reject {
-    background-color: rgb(108, 31, 31);
-}
-
-.field-resolve_field .button {
-    transition: filter 0.3s;
-}
-
-
-.field-resolve_field .button:hover {
-    filter: brightness(150%);
-}
-
-
 .quarantine-item-button-group {
     display: flex;
     gap: 0.5rem;
-}
 
-.quarantine-item-button-group .button {
-    text-align: center;
+    & .button {
+        text-align: center;
+        transition: filter 0.3s;
+
+        &:hover {
+            filter: brightness(150%);
+        }
+
+        &.approve {
+            background-color: #094609;
+        }
+
+        &.reject {
+            background-color: rgb(108, 31, 31);
+        }
+    }
 }

--- a/apps/contributions/tests/test_admin.py
+++ b/apps/contributions/tests/test_admin.py
@@ -390,7 +390,9 @@ class TestContributionAdmin:
         assert isinstance(admin, CompareVersionAdmin)
 
     def test_quarantine_actions_shown_on_flagged_detail(self, admin):
-        contribution = ContributionFactory(status=ContributionStatus.FLAGGED)
+        contribution = ContributionFactory(
+            status=ContributionStatus.FLAGGED, quarantine_status=QuarantineStatus.FLAGGED_BY_BAD_ACTOR
+        )
         assert (
             "Quarantine",
             {"fields": ("quarantine_actions",)},
@@ -410,6 +412,25 @@ class TestContributionAdmin:
     )
     def test_quarantine_actions_hidden_on_unflagged_detail(self, admin, status):
         contribution = ContributionFactory(status=status)
+        assert (
+            "Quarantine",
+            {"fields": ("quarantine_actions",)},
+        ) not in admin.get_fieldsets(obj=contribution, request="unused")
+
+    @pytest.mark.parametrize(
+        "quarantine_status",
+        [
+            QuarantineStatus.REJECTED_BY_HUMAN_FRAUD,
+            QuarantineStatus.REJECTED_BY_HUMAN_DUPE,
+            QuarantineStatus.REJECTED_BY_HUMAN_OTHER,
+            QuarantineStatus.REJECTED_BY_MACHINE_FOR_BAD_ACTOR,
+            QuarantineStatus.APPROVED_BY_MACHINE_AFTER_WAIT,
+            QuarantineStatus.APPROVED_BY_HUMAN,
+            QuarantineStatus.REJECTED_BY_STRIPE_FOR_FRAUD,
+        ],
+    )
+    def test_quarantine_actions_hidden_on_other_flagged_statuses(self, admin, quarantine_status):
+        contribution = ContributionFactory(status=ContributionStatus.FLAGGED, quarantine_status=quarantine_status)
         assert (
             "Quarantine",
             {"fields": ("quarantine_actions",)},

--- a/apps/contributions/tests/test_admin.py
+++ b/apps/contributions/tests/test_admin.py
@@ -28,7 +28,6 @@ from apps.users.models import User
 
 @pytest.mark.django_db
 class TestQuarantineAdmin:
-
     @pytest.fixture
     def flagged_one_time_contribution(self):
         return ContributionFactory(
@@ -435,3 +434,47 @@ class TestContributionAdmin:
             "Quarantine",
             {"fields": ("quarantine_actions",)},
         ) not in admin.get_fieldsets(obj=contribution, request="unused")
+
+    def test_quarantine_actions_contain_correct_content(self, admin):
+        contribution = ContributionFactory()
+        soup = bs4(admin.quarantine_actions(contribution), "html.parser")
+        assert (
+            soup.find("a", {"href": reverse("admin:approve_quarantined_contribution", args=[contribution.id])})
+            is not None
+        )
+        assert (
+            soup.find(
+                "a",
+                {
+                    "href": reverse(
+                        "admin:reject_quarantined_contribution",
+                        args=[contribution.id, QuarantineStatus.REJECTED_BY_HUMAN_DUPE.value],
+                    )
+                },
+            )
+            is not None
+        )
+        assert (
+            soup.find(
+                "a",
+                {
+                    "href": reverse(
+                        "admin:reject_quarantined_contribution",
+                        args=[contribution.id, QuarantineStatus.REJECTED_BY_HUMAN_FRAUD.value],
+                    )
+                },
+            )
+            is not None
+        )
+        assert (
+            soup.find(
+                "a",
+                {
+                    "href": reverse(
+                        "admin:reject_quarantined_contribution",
+                        args=[contribution.id, QuarantineStatus.REJECTED_BY_HUMAN_OTHER.value],
+                    )
+                },
+            )
+            is not None
+        )

--- a/apps/contributions/tests/test_admin.py
+++ b/apps/contributions/tests/test_admin.py
@@ -388,3 +388,29 @@ class TestContributionAdmin:
         CompareVersionAdmin to do the right thing.
         """
         assert isinstance(admin, CompareVersionAdmin)
+
+    def test_quarantine_actions_shown_on_flagged_detail(self, admin):
+        contribution = ContributionFactory(status=ContributionStatus.FLAGGED)
+        assert (
+            "Quarantine",
+            {"fields": ("quarantine_actions",)},
+        ) in admin.get_fieldsets(obj=contribution, request="unused")
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            ContributionStatus.ABANDONED,
+            ContributionStatus.CANCELED,
+            ContributionStatus.FAILED,
+            ContributionStatus.PAID,
+            ContributionStatus.PROCESSING,
+            ContributionStatus.REFUNDED,
+            ContributionStatus.REJECTED,
+        ],
+    )
+    def test_quarantine_actions_hidden_on_unflagged_detail(self, admin, status):
+        contribution = ContributionFactory(status=status)
+        assert (
+            "Quarantine",
+            {"fields": ("quarantine_actions",)},
+        ) not in admin.get_fieldsets(obj=contribution, request="unused")


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

- Refactors HTML for admin quarantine actions into a shared function.
- Display admin quarantine actions on flagged contribution detail pages in Django admin.
- Streamlines custom CSS.

#### Why are we doing this? How does it help us?

Allows admins to process quarantined contributions faster.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

Not sure if we're documenting admin UI.

#### Have automated unit tests been added? If not, why?

Yes but I'm unsure they're complete.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-6227

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.