### PR TITLE
DEV-6280: Show other fields on quarantined contributions

### DIFF
--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -288,6 +288,7 @@ class ContributionAdmin(RevEngineBaseAdmin):
                     "Quarantine",
                     {"fields": ("quarantine_actions",)},
                 ),
+                *self.fieldsets,
             )
         return self.fieldsets
 

--- a/apps/contributions/tests/test_admin.py
+++ b/apps/contributions/tests/test_admin.py
@@ -397,6 +397,14 @@ class TestContributionAdmin:
             {"fields": ("quarantine_actions",)},
         ) in admin.get_fieldsets(obj=contribution, request="unused")
 
+    def test_other_fields_shown_on_flagged_detail(self, admin):
+        contribution = ContributionFactory(
+            status=ContributionStatus.FLAGGED, quarantine_status=QuarantineStatus.FLAGGED_BY_BAD_ACTOR
+        )
+        fields = admin.get_fieldsets(obj=contribution, request="unused")
+        for fieldset in ContributionAdmin.fieldsets:
+            assert fieldset in fields
+
     @pytest.mark.parametrize(
         "status",
         [


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

n/a

#### What's this PR do?

Fixes admin view of contribution detail so that flagged contributions show all fields, not just quarantine actions.

#### Why are we doing this? How does it help us?

Fixes a bug.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes.

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No.

#### Have automated unit tests been added? If not, why?

Yes.

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

No.

#### Has this been documented? If so, where?

No.

#### What are the relevant tickets? Add a link to any relevant ones.

https://news-revenue-hub.atlassian.net/browse/DEV-6280

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No.

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No.