### PR TITLE
DEV-5221: add rp detail endpoint

### DIFF
--- a/apps/organizations/serializers.py
+++ b/apps/organizations/serializers.py
@@ -399,3 +399,10 @@ class OrganizationSwitchboardSerializer(serializers.ModelSerializer):
         model = Organization
         fields = ["id", "name", "plan_name", "slug", "stripe_subscription_id"]
         read_only_fields = fields
+
+
+class RevenueProgramSwitchboardSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RevenueProgram
+        fields = ["id", "slug", "stripe_account_id"]
+        read_only_fields = fields

--- a/apps/organizations/urls.py
+++ b/apps/organizations/urls.py
@@ -37,5 +37,10 @@ urlpatterns = [
         switchboard_views.get_revenue_program_activecampaign_detail,
         name="switchboard-revenue-program-activecampaign-detail",
     ),
+    path(
+        "switchboard/revenue-programs/<int:pk>/",
+        switchboard_views.get_revenue_program_detail,
+        name="switchboard-revenue-program-detail",
+    ),
     path("switchboard/", include(switchboard_router.urls)),
 ]

--- a/apps/organizations/views/switchboard.py
+++ b/apps/organizations/views/switchboard.py
@@ -46,3 +46,11 @@ def get_revenue_program_activecampaign_detail(_: HttpRequest, pk: int) -> Respon
     """Return the ActiveCampaign data for the revenue program with the given ID."""
     revenue_program = get_object_or_404(RevenueProgram, pk=pk)
     return Response(serializers.ActiveCampaignRevenueProgramForSwitchboardSerializer(revenue_program).data)
+
+
+@api_view(["GET"])
+@permission_classes([IsSwitchboardAccount])
+def get_revenue_program_detail(_: HttpRequest, pk: int) -> Response:
+    """Return the revenue program detail for the given ID."""
+    revenue_program = get_object_or_404(RevenueProgram, pk=pk)
+    return Response(serializers.RevenueProgramSwitchboardSerializer(revenue_program).data)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

N/A

#### What's this PR do?

Add switchboard rp detail view

#### Why are we doing this? How does it help us?

This is one of a series of tickets that will ultimately allow devs to run a script in Switchboard that allows external migrations to Revengine via CSV import. The external migration script will have columns for revenue program ID, revenue program slug, and destination Stripe account ID.  

Here, we’ll expose an endpoint to Switchboard that allows it to determine if a given revenue program ID, slug and destination Stripe account match by fetching the RP from revengine.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

N/A

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

N/A

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-5221]

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

N/A

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

[DEV-5222]
