### PR TITLE
DEV-5246 | Exclude contributions that don't have provider payment method ID from quarantine queue

### DIFF
--- a/apps/contributions/admin.py
+++ b/apps/contributions/admin.py
@@ -513,6 +513,7 @@ class QuarantineQueue(admin.ModelAdmin):
             super()
             .get_queryset(request)
             .filter(quarantine_status=QuarantineStatus.FLAGGED_BY_BAD_ACTOR, status=ContributionStatus.FLAGGED)
+            .exclude(provider_payment_method_id__isnull=True)
         )
 
     def complete_flagged_contribution(self, request: HttpRequest, contribution_id: str, quarantine_status: str):


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Excludes contributions that don't have a provider_payment_method_id value from querset of quarantine queue because such contributions cannot be successfully completed (whether rejecting or approving).

#### Why are we doing this? How does it help us?

Gets rid of unactionable itmes from quarantine queue.

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

no

#### Have automated unit tests been added? If not, why?

yes

#### How should this change be communicated to end users?

n/a

#### Are there any smells or added technical debt to note?

no

#### Has this been documented? If so, where?

no

#### What are the relevant tickets? Add a link to any relevant ones.

[DEV-5246](https://news-revenue-hub.atlassian.net/browse/DEV-5246)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

No
