### PR TITLE
DEV-5569 | Add token auth to SB-related endpoints that don't already have it

### DIFF
--- a/apps/contributions/views/switchboard.py
+++ b/apps/contributions/views/switchboard.py
@@ -58,7 +58,7 @@ class SwitchboardContributionsViewSet(
         "donation_page__revenue_program__organization", "_revenue_program__organization"
     )
     serializer_class = serializers.SwitchboardContributionSerializer
-    # TODO @BW: Remove JWTHttpOnlyCookieAuthentication after DEV-5549
+    # TODO @BW: Remove JWTHttpOnlyCookieAuthentication after DEV-5570
     # DEV-5571
     authentication_classes = [TokenAuthentication, JWTHttpOnlyCookieAuthentication]
     filter_backends = [DjangoFilterBackend]

--- a/apps/organizations/tests/views/test_revengine.py
+++ b/apps/organizations/tests/views/test_revengine.py
@@ -6,6 +6,7 @@ from django.template.loader import render_to_string
 import pytest
 import stripe
 from faker import Faker
+from knox.auth import TokenAuthentication
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.permissions import AND, OR, IsAuthenticated
@@ -15,6 +16,7 @@ from reversion.models import Version
 from stripe.error import SignatureVerificationError, StripeError
 from waffle import get_waffle_flag_model
 
+from apps.api.authentication import JWTHttpOnlyCookieAuthentication
 from apps.api.permissions import HasRoleAssignment, IsHubAdmin, IsOrgAdmin
 from apps.common.constants import MAILCHIMP_INTEGRATION_ACCESS_FLAG_NAME
 from apps.common.secret_manager import GoogleCloudSecretProvider
@@ -901,6 +903,10 @@ class TestRevenueProgramViewSet:
             RevenueProgramViewSet.mailchimp.kwargs.get("serializer_class", None)
             == MailchimpRevenueProgramForSwitchboard
         )
+        assert set(RevenueProgramViewSet.mailchimp.kwargs.get("authentication_classes", [])) == {
+            TokenAuthentication,
+            JWTHttpOnlyCookieAuthentication,
+        }
 
     def test_mailchimp_configure_detail_configured_correctly(self):
         assert RevenueProgramViewSet.mailchimp_configure.detail is True

--- a/apps/organizations/tests/views/test_switchboard.py
+++ b/apps/organizations/tests/views/test_switchboard.py
@@ -1,10 +1,13 @@
 from django.urls import reverse
 
 import pytest
+from knox.auth import TokenAuthentication
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from apps.api.authentication import JWTHttpOnlyCookieAuthentication
 from apps.organizations.models import Organization
+from apps.organizations.views.switchboard import get_revenue_program_activecampaign_detail
 from apps.users.models import User
 
 
@@ -42,6 +45,13 @@ def test_switchboard_rp_activecampaign_detail(request, user_fixture, permitted, 
             "activecampaign_integration_connected": is_connected,
             "activecampaign_server_url": revenue_program.activecampaign_server_url,
         }
+
+
+def test_get_revenue_program_activecampaign_detail_authentication_classes():
+    assert set(get_revenue_program_activecampaign_detail.cls.authentication_classes) == {
+        TokenAuthentication,
+        JWTHttpOnlyCookieAuthentication,
+    }
 
 
 @pytest.mark.django_db

--- a/apps/organizations/views/revengine.py
+++ b/apps/organizations/views/revengine.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 
 import reversion
 import stripe
+from knox.auth import TokenAuthentication
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.exceptions import APIException, PermissionDenied, ValidationError
@@ -17,6 +18,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from stripe.error import StripeError
 
+from apps.api.authentication import JWTHttpOnlyCookieAuthentication
 from apps.api.permissions import (
     HasFlaggedAccessToMailchimp,
     HasRoleAssignment,
@@ -256,9 +258,14 @@ class RevenueProgramViewSet(FilterForSuperUserOrRoleAssignmentUserMixin, viewset
     @action(
         methods=["GET"],
         detail=True,
+        # TODO @BW: Remove JWTHttpOnlyCookieAuthentication after DEV-5570
+        # DEV-5571
+        authentication_classes=[TokenAuthentication, JWTHttpOnlyCookieAuthentication],
         permission_classes=[IsAuthenticated, IsActiveSuperUser],
         serializer_class=serializers.MailchimpRevenueProgramForSwitchboard,
     )
+    # TODO @BW: Move mailchimp config endpoint to SB viewset
+    # DEV-6420
     def mailchimp(self, request, pk=None):
         """Return the mailchimp data for the revenue program with the given pk.
 

--- a/apps/organizations/views/switchboard.py
+++ b/apps/organizations/views/switchboard.py
@@ -3,9 +3,10 @@ from django.shortcuts import get_object_or_404
 
 from knox.auth import TokenAuthentication
 from rest_framework import mixins, viewsets
-from rest_framework.decorators import action, api_view, permission_classes
+from rest_framework.decorators import action, api_view, authentication_classes, permission_classes
 from rest_framework.response import Response
 
+from apps.api.authentication import JWTHttpOnlyCookieAuthentication
 from apps.api.permissions import IsSwitchboardAccount
 from apps.organizations import serializers
 from apps.organizations.models import Organization, RevenueProgram
@@ -42,6 +43,9 @@ class OrganizationViewSet(
 
 @api_view(["GET"])
 @permission_classes([IsSwitchboardAccount])
+# TODO @BW: Remove JWTHttpOnlyCookieAuthentication after DEV-5570
+# DEV-5571
+@authentication_classes([TokenAuthentication, JWTHttpOnlyCookieAuthentication])
 def get_revenue_program_activecampaign_detail(_: HttpRequest, pk: int) -> Response:
     """Return the ActiveCampaign data for the revenue program with the given ID."""
     revenue_program = get_object_or_404(RevenueProgram, pk=pk)


### PR DESCRIPTION
Please fill out each section even if it's just with "N/A"

#### Plan? (if this draft/incomplete indicate what you intend to do and how)

#### What's this PR do?

Adds token auth to the following endpoints (while preserving existing JWTHttpOnlyCookieAuthentication auth already allowed by those endpoints, so that SB won't break in interim before we update it to auth with token for same endpoints):

- `api/v1/revenue-programs/<pk>/mailchimp/`
- `api/v1/switchboard/revenue-programs/<pk>/activecampaign/`

All other endpoints used by SB already use token auth.


#### Why are we doing this? How does it help us?

So we can eventually consolidate to having all SB authentication to RE be via token auth

#### Are there detailed, specific, step-by-step testing instructions in the associated ticket?

Yes

#### Did this PR make changes to the user interface that may require changes to the user-facing docs?

No

#### Have automated unit tests been added? If not, why?

Yes

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### Has this been documented? If so, where?

N/A

#### What are the relevant tickets? Add a link to any relevant ones.

- [DEV-5569](https://news-revenue-hub.atlassian.net/browse/DEV-5569)
- [DEV-5570](https://news-revenue-hub.atlassian.net/browse/DEV-5570)
- [DEV-5571](https://news-revenue-hub.atlassian.net/browse/DEV-5571)

#### Do any changes need to be made before deployment to production (adding environment variables, for example)? If so, open a ticket and link it to the ticket for this PR and list it here:

No

#### Are there next steps? If so, what? Have tickets been opened for them? List next-step tickets here:

- [DEV-5570](https://news-revenue-hub.atlassian.net/browse/DEV-5570)
- [DEV-5571](https://news-revenue-hub.atlassian.net/browse/DEV-5571)


[DEV-5569]: https://news-revenue-hub.atlassian.net/browse/DEV-5569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ